### PR TITLE
Fix double execution in same second

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-tactile

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/merencia/node-cron",
   "main": "src/node-cron.js",
   "scripts": {
-    "test": "nyc --reporter=html --reporter=text --reporter=text-lcov mocha --recursive",
+    "test": "nyc --reporter=html --reporter=text mocha --recursive",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "check": "npm test && npm run coverage",
     "postinstall": "opencollective-postinstall"

--- a/src/scheduled-task.js
+++ b/src/scheduled-task.js
@@ -19,7 +19,7 @@ function ScheduledTask(task, options) {
   this.start = () => {
     this.status = 'scheduled';
     if (this.task && !this.tick) {
-      this.tick = setTimeout(this.task, 1000);
+      this.tick = setTimeout(this.task, 1000 - new Date().getMilliseconds() + 1);
     }
     
     return this;
@@ -82,7 +82,7 @@ function ScheduledTask(task, options) {
     if(timezone){
       date = tzOffset.timeAt(date, timezone);
     }
-    this.tick = setTimeout(this.task, 1000 - date.getMilliseconds());
+    this.tick = setTimeout(this.task, 1000 - date.getMilliseconds() + 1);
     task.update(date);
   };
   

--- a/test/defer-start-test.js
+++ b/test/defer-start-test.js
@@ -21,7 +21,7 @@ describe('defer a task', () => {
 
     this.clock.tick(1000 * 60);
     task.start();
-    this.clock.tick(1000 * 60);
+    this.clock.tick(1001 * 60);
     expect(executed).to.equal(1);
   });
 });

--- a/test/destroy-task-test.js
+++ b/test/destroy-task-test.js
@@ -19,11 +19,11 @@ describe('destroying a task', () => {
         executed++;
       });
 
-    this.clock.tick(1000 * 60);
+    this.clock.tick(1000 * 60 + 1);
     task.destroy();
-    this.clock.tick(1000 * 60);
+    this.clock.tick(1000 * 60 + 1);
     task.start();
-    this.clock.tick(1000 * 60);
+    this.clock.tick(1000 * 60 + 1);
 
     expect(executed).to.equal(1);
   });

--- a/test/range-values-test.js
+++ b/test/range-values-test.js
@@ -20,7 +20,7 @@ describe('scheduling with range values', () =>{
     cron.schedule('2-4 * * * *', () =>{
       executed += 1;
     });
-    this.clock.tick(7000 * 60);
+    this.clock.tick(7001 * 60);
     expect(executed).to.equal(3);
   });
 
@@ -31,7 +31,7 @@ describe('scheduling with range values', () =>{
     cron.schedule('0 2-4 * * *', () =>{
       executed += 1;
     });
-    this.clock.tick(7000 * 60 * 60);
+    this.clock.tick(7001 * 60 * 60);
     expect(executed).to.equal(3);
   });
 });

--- a/test/restart-task-test.js
+++ b/test/restart-task-test.js
@@ -19,11 +19,11 @@ describe('restarting a task', () => {
         executed++;
       });
 
-    this.clock.tick(1000 * 60);
+    this.clock.tick(1000 * 60 + 1);
     task.stop();
-    this.clock.tick(1000 * 60);
+    this.clock.tick(1000 * 60 + 1);
     task.start();
-    this.clock.tick(1000 * 60);
+    this.clock.tick(1000 * 60 + 1);
 
     expect(executed).to.equal(2);
   });

--- a/test/scheduling-test.js
+++ b/test/scheduling-test.js
@@ -18,7 +18,7 @@ describe('scheduling on minutes', () => {
     cron.schedule('* * * * *', () => {
       executed += 1;
     });
-    this.clock.tick(3000 * 60);
+    this.clock.tick(3000 * 60 + 1);
     expect(executed).to.equal(3);
   });
 
@@ -102,7 +102,7 @@ describe('scheduling on minutes', () => {
     cron.schedule('*/02 * * * * *', () => {
       executed += 1;
     });
-    this.clock.tick(6000);
+    this.clock.tick(6001);
     expect(executed).to.equal(3);
   });
   
@@ -114,7 +114,7 @@ describe('scheduling on minutes', () => {
         resolve();
       });
     });
-    this.clock.tick(1000);
+    this.clock.tick(1001);
     expect(executed).to.equal(1);
   });
 });

--- a/test/stop-task-test.js
+++ b/test/stop-task-test.js
@@ -19,9 +19,9 @@ describe('stopping a task', () => {
         executed++;
       });
 
-    this.clock.tick(1000 * 60);
+    this.clock.tick(1000 * 60 + 1);
     task.stop();
-    this.clock.tick(1000 * 60);
+    this.clock.tick(1000 * 60 + 1);
     expect(executed).to.equal(1);
   });
 });

--- a/test/task/task-fail-test.js
+++ b/test/task/task-fail-test.js
@@ -19,7 +19,7 @@ describe('scheduling a task with exception', () =>{
       executed += 1;
       throw 'exception!';
     });
-    this.clock.tick(3000 * 60);
+    this.clock.tick(3000 * 60 + 1);
     expect(executed).to.equal(3);
   });
 });

--- a/test/timezone-test.js
+++ b/test/timezone-test.js
@@ -31,7 +31,7 @@ describe('scheduling with timezone', () => {
             timezone: 'Etc/UTC'
         });
         
-        this.clock.tick(1000 * 60 * 60 * 24);
+        this.clock.tick(1000 * 60 * 60 * 24 + 1);
         expect(executedAt.getHours()).to.equal(21);
     });
 });


### PR DESCRIPTION
The calc to find the next interval timeout is missing 1 milisecond.
The current calc is: `1000 - new Date().getMiliseconds()` but getMilliseconds may return a value between 0 to 999.

https://www.w3schools.com/jsref/jsref_getmilliseconds.asp
> The getMilliseconds() method returns the milliseconds (from 0 to 999) of the specified date and time.

When `setInterval` is called on node-cron, the maximum delay may be 1000, as the first valid millisecond is `0` when it is used to calculate the next tick, one milisecond must be added, because the elapsed time is used rather than the current milisecond.