### PR TITLE
Removing open collective dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ var invalid = cron.validate('60 * * * *');
 
 Feel free to submit issues and enhancement requests [here](https://github.com/merencia/node-cron/issues).
 
-## Contributors
+## Contributing
 
 In general, we follow the "fork-and-pull" Git workflow.
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "scripts": {
     "test": "nyc --reporter=html --reporter=text mocha --recursive",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "check": "npm test && npm run coverage",
-    "postinstall": "opencollective-postinstall"
+    "check": "npm test && npm run coverage"
   },
   "engines": {
     "node": ">=6.0.0"
@@ -37,15 +36,7 @@
     "nyc": "^13.0.1",
     "sinon": "^4.1.2"
   },
-  "collective": {
-    "type": "opencollective",
-    "url": "https://opencollective.com/node-cron",
-    "mocha": "^5.2.0",
-    "nyc": "^13.0.1",
-    "sinon": "^6.2.0"
-  },
   "dependencies": {
-    "opencollective-postinstall": "^2.0.0",
     "tz-offset": "0.0.1"
   }
 }


### PR DESCRIPTION
As open-collective is a unnecessary dependency. I should be removed from node-cron.