### PR TITLE
added background scheduled task

### DIFF
--- a/src/background-scheduled-task/daemon.js
+++ b/src/background-scheduled-task/daemon.js
@@ -12,8 +12,8 @@ function register(message){
 }
 
 process.on('message', (message) => {
-   switch(message.type){
-        case 'register':
-            return register(message);
-   }
+    switch(message.type){
+    case 'register':
+        return register(message);
+    }
 });

--- a/src/background-scheduled-task/daemon.js
+++ b/src/background-scheduled-task/daemon.js
@@ -1,0 +1,19 @@
+const ScheduledTask = require('../scheduled-task');
+
+let scheduledTask;
+
+function register(message){
+    const script = require(message.path);
+    scheduledTask = new ScheduledTask(message.cron, script.task, message.options);
+    scheduledTask.on('task-done', (result) => {
+        process.send({ type: 'task-done', result});
+    });
+    process.send({ type: 'registred' });
+}
+
+process.on('message', (message) => {
+   switch(message.type){
+        case 'register':
+            return register(message);
+   }
+});

--- a/src/background-scheduled-task/index.js
+++ b/src/background-scheduled-task/index.js
@@ -1,0 +1,65 @@
+const EventEmitter = require('events');
+const path = require('path');
+const { fork } = require('child_process');
+
+const daemonPath = `${__dirname}/daemon.js`;
+
+class BackgroundScheduledTask extends EventEmitter {
+    constructor(cronExpression, taskPath, options){
+        super();
+        if(!options){
+            options = {
+                scheduled: true,
+                recoverMissedExecutions: false
+            };
+        }
+        this.cronExpression = cronExpression;
+        this.taskPath = taskPath;
+        this.options = options;
+
+        if(options.scheduled){
+            this.start();
+        }
+    }
+
+    start() {
+        this.stop();
+        this.forkProcess = fork(daemonPath);
+
+        this.forkProcess.on('message', (message) => {
+            switch(message.type){
+                case 'task-done':
+                    this.emit('task-done', message.result);
+                    break;
+            }
+        });
+
+        let options = this.options;
+        options.scheduled = true;
+        
+        this.forkProcess.send({
+            type: 'register',
+            path: path.resolve(this.taskPath),
+            cron: this.cronExpression,
+            options: options
+        });
+    }
+    
+    stop(){
+        if(this.forkProcess){
+            this.forkProcess.kill();
+        }
+    }
+
+    pid() {
+        if(this.forkProcess){
+            return this.forkProcess.pid;
+        }
+    }
+
+    isRunning(){
+        return !this.forkProcess.killed;
+    }
+}
+
+module.exports = BackgroundScheduledTask;

--- a/src/background-scheduled-task/index.js
+++ b/src/background-scheduled-task/index.js
@@ -28,9 +28,9 @@ class BackgroundScheduledTask extends EventEmitter {
 
         this.forkProcess.on('message', (message) => {
             switch(message.type){
-                case 'task-done':
-                    this.emit('task-done', message.result);
-                    break;
+            case 'task-done':
+                this.emit('task-done', message.result);
+                break;
             }
         });
 

--- a/src/node-cron.js
+++ b/src/node-cron.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var ScheduledTask = require('./scheduled-task'),
+    BackgroundScheduledTask = require('./background-scheduled-task'),
     validation = require('./pattern-validation');
 
 module.exports = (() => {
@@ -25,7 +26,11 @@ module.exports = (() => {
    * @returns {ScheduledTask} update function.
    */
     function createTask(expression, func, options) {
-        return new ScheduledTask(expression, func, options);
+        if(typeof func === 'string'){
+            return new BackgroundScheduledTask(expression, func, options);
+        } else {
+            return new ScheduledTask(expression, func, options);
+        }
     }
 
     function validate(expression) {

--- a/src/scheduled-task.js
+++ b/src/scheduled-task.js
@@ -1,10 +1,12 @@
 'use strict';
 
+const EventEmitter = require('events');
 const Task = require('./task');
 const Scheduler = require('./scheduler');
 
-class ScheduledTask {
+class ScheduledTask extends EventEmitter {
     constructor(cronExpression, func, options) {
+        super();
         if(!options){
             options = {
                 scheduled: true,
@@ -15,7 +17,8 @@ class ScheduledTask {
         let scheduler = new Scheduler(cronExpression, options.timezone, options.recoverMissedExecutions);
 
         scheduler.on('scheduled-time-matched', (now) => {
-            task.execute(now);
+            let result = task.execute(now);
+            this.emit('task-done', result);
         });
 
         if(options.scheduled !== false){

--- a/src/task.js
+++ b/src/task.js
@@ -16,7 +16,7 @@ class Task{
             // check if execution returns a promise
             // emit events on start and on finished
             // force execution return a promise
-            execution(now);
+            return execution(now);
         };
     }
 }

--- a/test/assets/dummy-task.js
+++ b/test/assets/dummy-task.js
@@ -1,0 +1,3 @@
+exports.task = () => {
+    return 'dummy task';
+}

--- a/test/assets/dummy-task.js
+++ b/test/assets/dummy-task.js
@@ -1,3 +1,3 @@
 exports.task = () => {
     return 'dummy task';
-}
+};

--- a/test/background-scheduled-task-test.js
+++ b/test/background-scheduled-task-test.js
@@ -15,7 +15,7 @@ describe('BackgroundScheduledTask', () => {
             scheduled: false
         });
 
-        assert.isUndefined(task.pid())
+        assert.isUndefined(task.pid());
     });
 
     it('should start a task', (done) => {
@@ -39,9 +39,9 @@ describe('BackgroundScheduledTask', () => {
         let task = new BackgroundScheduledTask('* * * * * *', './test/assets/dummy-task.js', {
             scheduled: true
         });
-        assert.isNotNull(task.pid())
-        assert.isTrue(task.isRunning())
+        assert.isNotNull(task.pid());
+        assert.isTrue(task.isRunning());
         task.stop();
-        assert.isFalse(task.isRunning())
+        assert.isFalse(task.isRunning());
     });
 });

--- a/test/background-scheduled-task-test.js
+++ b/test/background-scheduled-task-test.js
@@ -1,0 +1,47 @@
+const { assert } = require('chai');
+const BackgroundScheduledTask = require('../src/background-scheduled-task');
+
+describe('BackgroundScheduledTask', () => {
+    it('should start a task by default', (done) => {
+        let task = new BackgroundScheduledTask('* * * * * *', './test/assets/dummy-task.js');
+        task.on('task-done', (result) => {
+            assert.equal('dummy task', result);
+            task.stop();
+            done();
+        });
+    });
+    it('should create a task stoped', () => {
+        let task = new BackgroundScheduledTask('* * * * * *', './test/assets/dummy-task.js', {
+            scheduled: false
+        });
+
+        assert.isUndefined(task.pid())
+    });
+
+    it('should start a task', (done) => {
+        let task = new BackgroundScheduledTask('* * * * * *', './test/assets/dummy-task.js', {
+            scheduled: false
+        });
+
+        assert.isUndefined(task.pid());
+
+        task.on('task-done', (result) => {
+            assert.equal('dummy task', result);
+            task.stop();
+            done();
+        });
+
+        task.start();
+        assert.isNotNull(task.pid());
+    });
+    
+    it('should stop a task', () => {
+        let task = new BackgroundScheduledTask('* * * * * *', './test/assets/dummy-task.js', {
+            scheduled: true
+        });
+        assert.isNotNull(task.pid())
+        assert.isTrue(task.isRunning())
+        task.stop();
+        assert.isFalse(task.isRunning())
+    });
+});

--- a/test/node-cron-test.js
+++ b/test/node-cron-test.js
@@ -105,6 +105,14 @@ describe('node-cron', () => {
                 done();
             }, 1000);
         }).timeout(4000);
+
+        it('should schedule a background task', () => {
+            let task = cron.schedule('* * * * * *', './test/assets/dummy-task.js');
+            assert.isNotNull(task);
+            assert.isDefined(task);
+            assert.isTrue(task.isRunning());
+            task.stop();
+        });
     });
     
     describe('validate', () => {


### PR DESCRIPTION
Added suport to pass a external script to `node-cron` that will be executed in a `child process`.

usage: 
```js
/* my-task.js */
exports.task = () => {
   console.log("this is my task");
}
```

```js
let cron = require('node-cron');

cron.schedule('* * * * * *', './path/to/my-task.js');

```