### PR TITLE
fix broken test

### DIFF
--- a/test/scheduled-task-test.js
+++ b/test/scheduled-task-test.js
@@ -11,13 +11,14 @@ describe('ScheduledTask', () => {
         this.clock.restore();
     });
 
-    it('should start a task by default', () => {
+    it('should start a task by default', (done) => {
         let executed = 0;
         let scheduledTask = new ScheduledTask('* * * * * *', () => {
             executed += 1;
+            assert.equal(3, executed);
+            done();
         });
         this.clock.tick(3000);
-        assert.equal(3, executed);
         scheduledTask.stop();
     });
 


### PR DESCRIPTION
adjusted to do the assert inside the callback function, this way we can guarantee that the `executed` count will be assigned.