### PR TITLE
docs: add link to list of available timezones

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Arguments:
     timezone: "America/Sao_Paulo"
   });
  ```
+ 
+ [Full list of timezones can be found here](https://raw.githubusercontent.com/node-cron/tz-offset/master/generated/offsets.json)
 
 ## ScheduledTask methods
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Arguments:
   });
  ```
  
- [Full list of timezones can be found here](https://raw.githubusercontent.com/node-cron/tz-offset/master/generated/offsets.json)
+ [Full list of timezones can be found here (part of the tz-offset@0.0.1 package)](https://raw.githubusercontent.com/node-cron/tz-offset/a67968ab5b0efa6dee296dac32d3205b41f158e0/generated/offsets.json)
 
 ## ScheduledTask methods
 


### PR DESCRIPTION
according to this [post](https://github.com/node-cron/node-cron/issues/124#issuecomment-572837798), the list of timezones can be found here:
https://raw.githubusercontent.com/node-cron/tz-offset/a67968ab5b0efa6dee296dac32d3205b41f158e0/generated/offsets.json