### PR TITLE
Fixes #240. Edge case when dealing with multiple ranges for one parameter of the cron input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -508,8 +508,7 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "optional": true
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "commondir": {
       "version": "1.0.1",

--- a/src/convert-expression/range-conversion.js
+++ b/src/convert-expression/range-conversion.js
@@ -15,7 +15,7 @@ module.exports = ( () => {
             numbers.push(i);
         }
 
-        return expression.replace(new RegExp(text, 'gi'), numbers.join());
+        return expression.replace(new RegExp(text, 'i'), numbers.join());
     }
 
     function convertRange(expression){

--- a/test/convert-expression/range-conversion-test.js
+++ b/test/convert-expression/range-conversion-test.js
@@ -15,4 +15,10 @@ describe('range-conversion.js', () => {
         var expression = conversion(expressions).join(' ');
         expect(expression).to.equal('0,1,2,3 0,1,2,3 8,9,10 1,2,3 1,2 0,1,2,3');
     });
+
+    it('should convert comma delimited ranges to numbers', () => {
+        var expressions = '0-2,10-23'.split(' ');
+        var expression = conversion(expressions).join(' ');
+        expect(expression).to.equal('0,1,2,10,11,12,13,14,15,16,17,18,19,20,21,22,23');
+    })
 });

--- a/test/convert-expression/range-conversion-test.js
+++ b/test/convert-expression/range-conversion-test.js
@@ -20,5 +20,5 @@ describe('range-conversion.js', () => {
         var expressions = '0-2,10-23'.split(' ');
         var expression = conversion(expressions).join(' ');
         expect(expression).to.equal('0,1,2,10,11,12,13,14,15,16,17,18,19,20,21,22,23');
-    })
+    });
 });


### PR DESCRIPTION
I discussed the issue in #240 

Essentially, if the `g` flag is removed from the replace function, we make sure to only replace the first instance of the expression to be replaced. This is okay since the while loop will run again if there's other ranges to be converted. 

Since the original regex finds the first instance of the range, this replace will only replace the first instance. 

Hence, fixes the edge case of replacing an incorrect sub-string, and also will not change the functionality.