### PR TITLE
Allowing Copy Function from Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The node-cron module is tiny task scheduler in pure JavaScript for node.js based
 Install node-cron using npm:
 
 ```console
-$ npm install --save node-cron
+npm install --save node-cron
 ```
 
 Import node-cron and schedule a task:


### PR DESCRIPTION
Since github allow us the command to copy the doller sign doesn't fit there anymore, even if it looks better.