### PR TITLE
add option recoverMissedExecutions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Arguments:
 #### Options
 
  - **scheduled**: A `boolean` to set if the created task is scheduled. Default `true`;
+ - **recoverMissedExecutions**: A `boolean` to set if the created task should be able to recover missed executions. Default `true`;
  - **timezone**: The timezone that is used for job scheduling. See [IANA time zone database](https://www.iana.org/time-zones) for valid values, such as `Asia/Shanghai`, `Asia/Kolkata`, `America/Sao_Paulo`.
 
  **Example**:

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Arguments:
 #### Options
 
  - **scheduled**: A `boolean` to set if the created task is scheduled. Default `true`;
- - **recoverMissedExecutions**: A `boolean` to set if the created task should be able to recover missed executions. Default `true`;
+ - **recoverMissedExecutions**: A `boolean` to set if the created task should be able to recover missed executions. Default `false`;
  - **timezone**: The timezone that is used for job scheduling. See [IANA time zone database](https://www.iana.org/time-zones) for valid values, such as `Asia/Shanghai`, `Asia/Kolkata`, `America/Sao_Paulo`.
 
  **Example**:


### PR DESCRIPTION
I added the option recoverMissedExecutions, which was missing in the readme file