### PR TITLE
Allow removing tasks from current schedule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cron",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/node-cron.js
+++ b/src/node-cron.js
@@ -29,6 +29,22 @@ function schedule(expression, func, options) {
     return task;
 }
 
+/**
+ * Removes the passed task from current schedule
+ *
+ * @param {ScheduledTask} task The scheduled task to be removed.
+ * @returns {boolean} Whether the operation was successful or not.
+ */
+function removeTask(task) {
+    try {
+        storage.remove(task);
+
+        return true;
+    } catch (_) {
+        return false;
+    }
+}
+
 function createTask(expression, func, options) {
     if (typeof func === 'string')
         return new BackgroundScheduledTask(expression, func, options);
@@ -61,4 +77,5 @@ function getTasks() {
     return storage.getTasks();
 }
 
-module.exports = { schedule, validate, getTasks };
+
+module.exports = { schedule, validate, getTasks, removeTask };

--- a/src/storage.js
+++ b/src/storage.js
@@ -14,6 +14,14 @@ module.exports = (() => {
         },
         getTasks: () => {
             return global.scheduledTasks;
+        },
+        remove: (task) => {
+            if(!task.options){
+                const uuid = require('uuid');
+                task.options = {};
+                task.options.name = uuid.v4();
+            }
+            global.scheduledTasks.delete(task.options.name, task);
         }
     };
 })();

--- a/test/node-cron-test.js
+++ b/test/node-cron-test.js
@@ -12,6 +12,16 @@ describe('node-cron', () => {
     });
     
     describe('schedule', () => {
+        it('should schedule a task and then remove it', () => {
+            let task = cron.schedule('* * * * * *', './test/assets/dummy-task.js');
+            assert.isNotNull(task);
+            assert.isDefined(task);
+            assert.isTrue(task.isRunning());
+            assert.equal(1, cron.getTasks().size);
+            cron.removeTask(task);
+            assert.equal(0, cron.getTasks().size);
+        })
+        
         it('should schedule a task', () => {
             let executed = 0;
             cron.schedule('* * * * * *', () => {
@@ -70,7 +80,7 @@ describe('node-cron', () => {
             assert.equal(0, executed);
         });
         
-        it('should start a stoped task', () => {
+        it('should start a stopped task', () => {
             let executed = 0;
             let scheduledTask = cron.schedule('* * * * * *', () => {
                 executed += 1;

--- a/test/node-cron-test.js
+++ b/test/node-cron-test.js
@@ -20,7 +20,7 @@ describe('node-cron', () => {
             assert.equal(1, cron.getTasks().size);
             cron.removeTask(task);
             assert.equal(0, cron.getTasks().size);
-        })
+        });
         
         it('should schedule a task', () => {
             let executed = 0;


### PR DESCRIPTION
Neither task.destroy() nor task.stop() were effective in removing tasks from the schedule. node-cron.remove(task) will remove the passed task from the schedule.