### PR TITLE
fix: replace missing uuid dependency with crypto.randomUUID

### DIFF
--- a/src/background-scheduled-task/index.js
+++ b/src/background-scheduled-task/index.js
@@ -1,7 +1,7 @@
 const EventEmitter = require('events');
 const path = require('path');
 const { fork } = require('child_process');
-const uuid = require('uuid');
+const crypto = require('crypto');
 
 const daemonPath = `${__dirname}/daemon.js`;
 
@@ -17,7 +17,7 @@ class BackgroundScheduledTask extends EventEmitter {
         this.cronExpression = cronExpression;
         this.taskPath = taskPath;
         this.options = options;
-        this.options.name = this.options.name || uuid.v4();
+        this.options.name = this.options.name || crypto.randomUUID();
 
         if(options.scheduled){
             this.start();

--- a/src/scheduled-task.js
+++ b/src/scheduled-task.js
@@ -3,7 +3,7 @@
 const EventEmitter = require('events');
 const Task = require('./task');
 const Scheduler = require('./scheduler');
-const uuid = require('uuid');
+const crypto = require('crypto');
 
 class ScheduledTask extends EventEmitter {
     constructor(cronExpression, func, options) {
@@ -16,7 +16,7 @@ class ScheduledTask extends EventEmitter {
         }
       
         this.options = options;
-        this.options.name = this.options.name || uuid.v4();
+        this.options.name = this.options.name || crypto.randomUUID();
 
         this._task = new Task(func);
         this._scheduler = new Scheduler(cronExpression, options.timezone, options.recoverMissedExecutions);

--- a/src/storage.js
+++ b/src/storage.js
@@ -6,9 +6,9 @@ module.exports = (() => {
     return {
         save: (task) => {
             if(!task.options){
-                const uuid = require('uuid');
+                const crypto = require('crypto');
                 task.options = {};
-                task.options.name = uuid.v4();
+                task.options.name = crypto.randomUUID();
             }
             global.scheduledTasks.set(task.options.name, task);
         },


### PR DESCRIPTION
as per this suggestion, [this](https://github.com/node-cron/node-cron/issues/355#issuecomment-1172932441) replaces the uuid dependency with crypto.randomUUID which [`Generates a random RFC 4122 version 4 UUID`](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions).