### PR TITLE
fixes #358: creates single instance of date formatter

### DIFF
--- a/src/time-matcher.js
+++ b/src/time-matcher.js
@@ -15,6 +15,18 @@ class TimeMatcher{
         this.pattern = convertExpression(pattern);
         this.timezone = timezone;
         this.expressions = this.pattern.split(' ');
+        this.dtf = this.timezone
+            ? new Intl.DateTimeFormat('en-US', {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit',
+                hourCycle: 'h23',
+                fractionalSecondDigits: 3,
+                timeZone: this.timezone
+            }) : null;
     }
 
     match(date){
@@ -31,22 +43,10 @@ class TimeMatcher{
     }
 
     apply(date){
-        if(this.timezone){
-            const dtf = new Intl.DateTimeFormat('en-US', {
-                year: 'numeric',
-                month: '2-digit',
-                day: '2-digit',
-                hour: '2-digit',
-                minute: '2-digit',
-                second: '2-digit',
-                hourCycle: 'h23',
-                fractionalSecondDigits: 3,
-                timeZone: this.timezone
-            });
-            
-            return new Date(dtf.format(date));
+        if(this.dtf){
+            return new Date(this.dtf.format(date));
         }
-        
+
         return date;
     }
 }


### PR DESCRIPTION
Potential fix for: https://github.com/node-cron/node-cron/issues/358

The current implementation creates multiple instances of the `Intl.DateTimeFormat` causing excessive memory usage. 

I've tested the current implementation and can confirm that RAM usage has now stabilized.

Related issues:
- https://bugs.chromium.org/p/v8/issues/detail?id=6528
- https://github.com/nodejs/node/issues/31914