### PR TITLE
built-in typescript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "ISC",
   "homepage": "https://github.com/merencia/node-cron",
   "main": "src/node-cron.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "test": "nyc --reporter=html --reporter=text mocha --recursive",
     "lint": "./node_modules/.bin/eslint ./src ./test",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,37 @@
+// Definitions by: morsic <https://github.com/maximelkin>,
+//                 burtek <https://github.com/burtek>,
+//                 Richard Honor <https://github.com/RMHonor>
+//                 Ata Berk YILMAZ <https://github.com/ataberkylmz>
+//                 Alex Seidmann <https://github.com/aseidma>
+
+import EventEmitter from 'events';
+
+export function schedule(cronExpression: string, func: (now: Date) => void, options?: ScheduleOptions): ScheduledTask;
+
+export function validate(cronExpression: string): boolean;
+
+export function getTasks(): Map<string, ScheduledTask>;
+
+export interface ScheduledTask extends EventEmitter {
+    start: () => this;
+    stop: () => this;
+}
+
+export interface ScheduleOptions {
+    /**
+     * A boolean to set if the created task is scheduled.
+     *
+     * Defaults to `true`
+     */
+    scheduled?: boolean | undefined;
+    /**
+     * The timezone that is used for job scheduling
+     */
+    timezone?: string;
+    /**
+     * Specifies whether to recover missed executions instead of skipping them.
+     *
+     * Defaults to `false`
+     */
+    recoverMissedExecutions?: boolean;
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,15 +1,26 @@
-// Definitions by: morsic <https://github.com/maximelkin>,
-//                 burtek <https://github.com/burtek>,
-//                 Richard Honor <https://github.com/RMHonor>
-//                 Ata Berk YILMAZ <https://github.com/ataberkylmz>
-//                 Alex Seidmann <https://github.com/aseidma>
-//                 Pedro Américo <https://github.com/ghostebony>
-import { EventEmitter } from 'events';
+import { EventEmitter } from "events";
 
-export function schedule(cronExpression: string, func: ((now: Date | "manual" | "init") => void) | string, options?: ScheduleOptions): ScheduledTask;
+/**
+ * Creates a new task to execute the given function when the cron expression ticks.
+ * @param cronExpression
+ * @param func
+ * @param options
+ */
+export function schedule(
+    cronExpression: string,
+    func: ((now: Date | "manual" | "init") => void) | string,
+    options?: ScheduleOptions,
+): ScheduledTask;
 
+/**
+ * To validate whether the expression is a cron expression or not
+ * @param cronExpression
+ */
 export function validate(cronExpression: string): boolean;
 
+/**
+ * Get the list of tasks created using the `schedule` function
+ */
 export function getTasks(): Map<string, ScheduledTask>;
 
 export interface ScheduledTask extends EventEmitter {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,6 +3,7 @@
 //                 Richard Honor <https://github.com/RMHonor>
 //                 Ata Berk YILMAZ <https://github.com/ataberkylmz>
 //                 Alex Seidmann <https://github.com/aseidma>
+//                 Pedro Américo <https://github.com/ghostebony>
 import { EventEmitter } from 'events';
 
 export function schedule(cronExpression: string, func: ((now: Date | "manual" | "init") => void) | string, options?: ScheduleOptions): ScheduledTask;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,18 +3,18 @@
 //                 Richard Honor <https://github.com/RMHonor>
 //                 Ata Berk YILMAZ <https://github.com/ataberkylmz>
 //                 Alex Seidmann <https://github.com/aseidma>
+import { EventEmitter } from 'events';
 
-import EventEmitter from 'events';
-
-export function schedule(cronExpression: string, func: (now: Date) => void, options?: ScheduleOptions): ScheduledTask;
+export function schedule(cronExpression: string, func: ((now: Date | "manual" | "init") => void) | string, options?: ScheduleOptions): ScheduledTask;
 
 export function validate(cronExpression: string): boolean;
 
 export function getTasks(): Map<string, ScheduledTask>;
 
 export interface ScheduledTask extends EventEmitter {
-    start: () => this;
-    stop: () => this;
+    now: (now?: Date) => void;
+    start: () => void;
+    stop: () => void;
 }
 
 export interface ScheduleOptions {
@@ -34,4 +34,12 @@ export interface ScheduleOptions {
      * Defaults to `false`
      */
     recoverMissedExecutions?: boolean;
+    /**
+     * The schedule name
+     */
+    name?: string;
+    /**
+     * Execute task immediately after creation
+     */
+    runOnInit?: boolean;
 }


### PR DESCRIPTION
Currently, TypeScript users have to install a separate package (`@types/node-cron`) to get type definitions. This PR adds built-in types copied from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node-cron/index.d.ts.

I believe this is a good idea for two reasons:
- Breaking changes are easier to reflect in the types, since they're all in the same repo
- TypeScript users no longer have to install a separate package. Great!