### PR TITLE
feat: support `L` (last day of month)

### DIFF
--- a/src/pattern/convertion/index.ts
+++ b/src/pattern/convertion/index.ts
@@ -21,7 +21,15 @@ export default (() => {
         for (let i=0; i < expressions.length; i++){
             const numbers = expressions[i].split(',');
             for (let j=0; j<numbers.length; j++){
-                numbers[j] = parseInt(numbers[j]);
+                // Keep the `L` (last day of month) token as a literal; it has no
+                // fixed numeric value. It is only meaningful in the day-of-month
+                // field, where validation accepts it; elsewhere it stays a token
+                // that no value matches and that validation rejects.
+                if (/^l$/i.test(String(numbers[j]).trim())) {
+                    numbers[j] = 'L';
+                } else {
+                    numbers[j] = parseInt(numbers[j]);
+                }
             }
             expressions[i] = numbers;
         }

--- a/src/pattern/validation/pattern-validation.ts
+++ b/src/pattern/validation/pattern-validation.ts
@@ -54,7 +54,10 @@ function isInvalidHour(expression) {
  * @returns {boolean}
  */
 function isInvalidDayOfMonth(expression) {
-    return !isValidExpression(expression, 1, 31);
+    // 'L' (last day of the month) is a valid token in this field only; the
+    // remaining values must still be valid day numbers.
+    const days = expression.filter((value) => value !== 'L');
+    return !isValidExpression(days, 1, 31);
 }
 
 /**

--- a/src/pattern/validation/validate-day.test.ts
+++ b/src/pattern/validation/validate-day.test.ts
@@ -27,5 +27,35 @@ describe('pattern-validation', function() {
                 validate('* * */2 * *');
             }).to.not.throw();
         });
+
+        it('should not fail with L (last day of month)', function() {
+            expect(() => {
+                validate('0 0 12 L * *');
+            }).to.not.throw();
+        });
+
+        it('should not fail with lowercase l', function() {
+            expect(() => {
+                validate('0 0 12 l * *');
+            }).to.not.throw();
+        });
+
+        it('should not fail with L combined with explicit days', function() {
+            expect(() => {
+                validate('0 0 12 15,L * *');
+            }).to.not.throw();
+        });
+
+        it('should fail with L outside the day-of-month field', function() {
+            expect(() => {
+                validate('0 L * * * *');
+            }).to.throw('L is a invalid expression for minute');
+        });
+
+        it('should fail with an unsupported L variant (LW)', function() {
+            expect(() => {
+                validate('0 0 12 LW * *');
+            }).to.throw('LW is a invalid expression for day of month');
+        });
     });
 });

--- a/src/time/day-of-month.test.ts
+++ b/src/time/day-of-month.test.ts
@@ -1,0 +1,45 @@
+import { assert } from 'chai';
+import { lastDayOfMonth, matchesDayOfMonth } from './day-of-month';
+
+describe('day-of-month', function () {
+  describe('lastDayOfMonth', function () {
+    it('returns 31 for January', function () {
+      assert.equal(lastDayOfMonth(2025, 1), 31);
+    });
+    it('returns 30 for April', function () {
+      assert.equal(lastDayOfMonth(2025, 4), 30);
+    });
+    it('returns 28 for a common-year February', function () {
+      assert.equal(lastDayOfMonth(2025, 2), 28);
+    });
+    it('returns 29 for a leap-year February', function () {
+      assert.equal(lastDayOfMonth(2024, 2), 29);
+    });
+  });
+
+  describe('matchesDayOfMonth', function () {
+    it('matches an explicit numeric day', function () {
+      assert.isTrue(matchesDayOfMonth([15], 2025, 1, 15));
+      assert.isFalse(matchesDayOfMonth([15], 2025, 1, 16));
+    });
+
+    it("matches the last day of the month for the 'L' token", function () {
+      assert.isTrue(matchesDayOfMonth(['L'], 2025, 1, 31));   // Jan -> 31
+      assert.isTrue(matchesDayOfMonth(['L'], 2025, 2, 28));   // Feb common year
+      assert.isTrue(matchesDayOfMonth(['L'], 2024, 2, 29));   // Feb leap year
+      assert.isTrue(matchesDayOfMonth(['L'], 2025, 4, 30));   // Apr -> 30
+    });
+
+    it("does not match a non-last day for 'L'", function () {
+      assert.isFalse(matchesDayOfMonth(['L'], 2025, 1, 30));
+      assert.isFalse(matchesDayOfMonth(['L'], 2025, 2, 27));
+      assert.isFalse(matchesDayOfMonth(['L'], 2024, 2, 28)); // 28 is not last in a leap Feb
+    });
+
+    it("supports 'L' combined with explicit days", function () {
+      assert.isTrue(matchesDayOfMonth([15, 'L'], 2025, 1, 15));
+      assert.isTrue(matchesDayOfMonth([15, 'L'], 2025, 1, 31));
+      assert.isFalse(matchesDayOfMonth([15, 'L'], 2025, 1, 20));
+    });
+  });
+});

--- a/src/time/day-of-month.ts
+++ b/src/time/day-of-month.ts
@@ -1,0 +1,30 @@
+/**
+ * The `L` token in the day-of-month field means "the last day of the month",
+ * which is 28, 29, 30 or 31 depending on the month and year. It is kept as a
+ * literal token (rather than a fixed number) through the pattern pipeline and
+ * resolved against the actual date here.
+ */
+export const LAST_DAY_TOKEN = 'L';
+
+export type DayOfMonthField = (number | string)[];
+
+/** The last calendar day (28-31) of the given 1-based month. */
+export function lastDayOfMonth(year: number, month: number): number {
+  // Day 0 of the next month is the last day of this one.
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+/**
+ * Whether the day-of-month field matches the given date, honouring the `L`
+ * (last day of month) token alongside any explicit numeric days.
+ */
+export function matchesDayOfMonth(
+  field: DayOfMonthField,
+  year: number,
+  month: number,
+  day: number,
+): boolean {
+  if (field.includes(day)) return true;
+  if (field.includes(LAST_DAY_TOKEN) && day === lastDayOfMonth(year, month)) return true;
+  return false;
+}

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -1,6 +1,7 @@
 import convertExpression from '../pattern/convertion';
 import { LocalizedTime, localTimeToTimestamp } from './localized-time';
 import { TimeMatcher } from './time-matcher';
+import { matchesDayOfMonth, DayOfMonthField } from './day-of-month';
 
 // Upper bound on the calendar search before giving up. A century is far beyond
 // any real recurrence (the calendar repeats within 28 years) and the loop is
@@ -18,7 +19,7 @@ export class MatcherWalker {
   private readonly seconds: number[];
   private readonly minutes: number[];
   private readonly hours: number[];
-  private readonly days: number[];
+  private readonly days: DayOfMonthField;
   private readonly months: number[];
 
   constructor(cronExpression: string, baseDate: Date, timezone?: string) {
@@ -61,7 +62,7 @@ export class MatcherWalker {
     let { year, month, day } = baseParts;
 
     for (let i = 0; i < MAX_DAYS; i++) {
-      if (months.includes(month) && days.includes(day)) {
+      if (months.includes(month) && matchesDayOfMonth(days, year, month, day)) {
         // On the base day the result must be strictly after the base instant;
         // on later days any matching time of day qualifies.
         const lowerBound = i === 0 ? baseParts : null;

--- a/src/time/time-matcher.test.ts
+++ b/src/time/time-matcher.test.ts
@@ -339,4 +339,48 @@ describe('TimeMatcher', function() {
         assert.equal(next.toISOString(), '2026-11-01T05:30:00.000Z');
       })
     })
+
+    describe('last day of month (L)', function() {
+      it('matches the last day of each month', function() {
+        const matcher = new TimeMatcher('0 0 12 L * *');
+        assert.isTrue(matcher.match(new Date(2025, 0, 31, 12, 0, 0)));  // Jan 31
+        assert.isTrue(matcher.match(new Date(2025, 1, 28, 12, 0, 0)));  // Feb 28 (common year)
+        assert.isTrue(matcher.match(new Date(2024, 1, 29, 12, 0, 0)));  // Feb 29 (leap year)
+        assert.isTrue(matcher.match(new Date(2025, 3, 30, 12, 0, 0)));  // Apr 30
+      });
+
+      it('does not match a non-last day', function() {
+        const matcher = new TimeMatcher('0 0 12 L * *');
+        assert.isFalse(matcher.match(new Date(2025, 0, 30, 12, 0, 0)));  // Jan 30
+        assert.isFalse(matcher.match(new Date(2025, 1, 27, 12, 0, 0)));  // Feb 27
+        assert.isFalse(matcher.match(new Date(2024, 1, 28, 12, 0, 0)));  // Feb 28 in a leap year
+      });
+
+      it('accepts a lowercase l', function() {
+        const matcher = new TimeMatcher('0 0 12 l * *');
+        assert.isTrue(matcher.match(new Date(2025, 0, 31, 12, 0, 0)));
+      });
+
+      it('supports L combined with explicit days', function() {
+        const matcher = new TimeMatcher('0 0 12 15,L * *');
+        assert.isTrue(matcher.match(new Date(2025, 0, 15, 12, 0, 0)));
+        assert.isTrue(matcher.match(new Date(2025, 0, 31, 12, 0, 0)));
+        assert.isFalse(matcher.match(new Date(2025, 0, 20, 12, 0, 0)));
+      });
+
+      it('getNextMatch finds the last day of the current month', function() {
+        const next = new TimeMatcher('0 0 12 L * *', 'Etc/UTC').getNextMatch(new Date('2025-01-10T00:00:00Z'));
+        assert.equal(next.toISOString(), '2025-01-31T12:00:00.000Z');
+      });
+
+      it('getNextMatch rolls over to the next month-end', function() {
+        const next = new TimeMatcher('0 0 12 L * *', 'Etc/UTC').getNextMatch(new Date('2025-02-01T00:00:00Z'));
+        assert.equal(next.toISOString(), '2025-02-28T12:00:00.000Z');
+      });
+
+      it('getNextMatch resolves Feb 29 on a leap year', function() {
+        const next = new TimeMatcher('0 0 12 L * *', 'Etc/UTC').getNextMatch(new Date('2024-02-01T00:00:00Z'));
+        assert.equal(next.toISOString(), '2024-02-29T12:00:00.000Z');
+      });
+    })
 });

--- a/src/time/time-matcher.ts
+++ b/src/time/time-matcher.ts
@@ -3,6 +3,7 @@ import convertExpression from '../pattern/convertion/index';
 import weekDayNamesConversion from '../pattern/convertion/week-day-names-conversion';
 import { LocalizedTime } from './localized-time';
 import { MatcherWalker } from './matcher-walker';
+import { matchesDayOfMonth } from './day-of-month';
 
 function matchValue(allowedValues: number[], value: number){
   return allowedValues.indexOf(value) !== -1;
@@ -25,7 +26,7 @@ export class TimeMatcher{
         const runOnSecond = matchValue(this.expressions[0], parts.second);
         const runOnMinute = matchValue(this.expressions[1], parts.minute);
         const runOnHour = matchValue(this.expressions[2], parts.hour);
-        const runOnDay = matchValue(this.expressions[3], parts.day);
+        const runOnDay = matchesDayOfMonth(this.expressions[3], parts.year, parts.month, parts.day);
         const runOnMonth = matchValue(this.expressions[4], parts.month);
         const runOnWeekDay = matchValue(this.expressions[5], parseInt(weekDayNamesConversion(parts.weekday)));
 


### PR DESCRIPTION
Closes #147

Adds support for `L` (last day of the month) in the day-of-month field, the feature originally proposed here by @antonidasyang. The original commits targeted the v3 JavaScript codebase, which has since been rewritten in TypeScript; this branch reimplements the same feature cleanly on the current code (full credit to @antonidasyang for the proposal and the original PR).

## Behavior

- `0 0 12 L * *` runs at 12:00 on the **last calendar day** of every month (28/29/30/31, leap-year aware).
- Lowercase `l` is accepted too.
- Combinable with explicit days: `0 0 12 15,L * *` runs on the 15th **and** the last day.
- `L` is valid **only** in the day-of-month field; variants like `LW` and `L` in other fields are rejected by validation.

## Implementation

- The pattern pipeline keeps `L` as a literal token instead of coercing it to `NaN`.
- A small `day-of-month` helper resolves the last day and the match, shared by both `TimeMatcher.match` and the `MatcherWalker` (so `getNextMatch` lands on the right day).
- Validation accepts `L` in the day-of-month field only.

## Tests

- `day-of-month` unit tests (last-day resolution + matching, including leap years and `15,L`).
- `TimeMatcher` match + `getNextMatch` cases (Jan 31, Feb 28, leap Feb 29, roll-over).
- Validation cases (valid `L`/`l`/`15,L`, rejected `LW` and `L` outside day-of-month).

Full suite green (280 tests), build and lint pass.