### PR TITLE
Fix: prevent job running twice when `recoverMissedExecutions` enabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-cron",
-  "version": "3.0.4",
+  "version": "3.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-cron",
-      "version": "3.0.4",
+      "version": "3.0.3",
       "license": "ISC",
       "dependencies": {
         "uuid": "8.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-cron",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-cron",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "ISC",
       "dependencies": {
         "uuid": "8.3.2"
@@ -15,6 +15,7 @@
         "chai": "^4.2.0",
         "eslint": "^5.7.0",
         "istanbul": "^0.4.2",
+        "luxon": "^3.5.0",
         "mocha": "^6.1.4",
         "moment-timezone": "^0.5.33",
         "nyc": "^14.0.0",
@@ -1803,6 +1804,15 @@
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -4736,6 +4746,12 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "dev": true
     },
     "make-dir": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-cron",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-cron",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "ISC",
       "dependencies": {
         "uuid": "8.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cron",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "A simple cron-like task scheduler for Node.js",
   "author": "Lucas Merencia",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "chai": "^4.2.0",
     "eslint": "^5.7.0",
     "istanbul": "^0.4.2",
+    "luxon": "^3.5.0",
     "mocha": "^6.1.4",
     "moment-timezone": "^0.5.33",
     "nyc": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cron",
-  "version": "3.0.4",
+  "version": "3.0.3",
   "description": "A simple cron-like task scheduler for Node.js",
   "author": "Lucas Merencia",
   "license": "ISC",

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -21,7 +21,7 @@ class Scheduler extends EventEmitter{
             const delay = 1000;
             const elapsedTime = process.hrtime(lastCheck);
             const elapsedMs = (elapsedTime[0] * 1e9 + elapsedTime[1]) / 1e6;
-            const missedExecutions = Math.floor(elapsedMs / 1000);
+            const missedExecutions = Math.max(0, Math.floor(elapsedMs / 1000) - 1);
             
             for(let i = missedExecutions; i >= 0; i--){
                 const date = new Date(new Date().getTime() - i * 1000);

--- a/test/node-cron-test.js
+++ b/test/node-cron-test.js
@@ -94,16 +94,16 @@ describe('node-cron', () => {
             let startedAt = new Date();
             
             while(wait){
-                if((new Date().getTime() - startedAt.getTime()) > 1000){
+                if((new Date().getTime() - startedAt.getTime()) > 2000){
                     wait = false;
                 }
             }
             
             setTimeout(() => {
                 scheduledTask.stop();
-                assert.equal(2, executed);
+                assert.equal(3, executed);
                 done();
-            }, 1000);
+            }, 1200); // give a 200ms buffer so we're not at the mercy of the event loop's particular scheduling
         }).timeout(4000);
 
         it('should schedule a background task', () => {

--- a/test/scheduler-test.js
+++ b/test/scheduler-test.js
@@ -62,7 +62,7 @@ describe('Scheduler', () => {
             scheduler.stop();
             assert.equal(2, emited);
             done();
-        }, 1000);
+        }, 1200); // give a 200ms buffer so we're not at the mercy of the event loop's particular scheduling
     }).timeout(3000);
 
     it('should ignore missed executions', (done) => {

--- a/test/time-matcher-test.js
+++ b/test/time-matcher-test.js
@@ -1,6 +1,9 @@
 const { assert } = require('chai');
 const TimeMatcher = require('../src/time-matcher');
 const moment = require('moment-timezone');
+const { DateTime, Settings } = require('luxon');
+
+Settings.throwOnInvalid = true;
 
 describe('TimeMatcher', () => {
     describe('wildcard', () => {
@@ -231,14 +234,15 @@ describe('TimeMatcher', () => {
 
         it('should match with all available timezone of moment-timezone', () => {
             const allTimeZone = moment.tz.names();
-            for (let zone in allTimeZone) {
-                const tmp = moment();
-                const expected = moment.tz(tmp,allTimeZone[zone]);
-                const pattern = expected.second() + ' ' + expected.minute() + ' ' + expected.hour() + ' ' + expected.date() + ' ' + (expected.month()+1) + ' ' + expected.day();
-                const matcher = new TimeMatcher(pattern, allTimeZone[zone]);
-                const utcTime = new Date(tmp.year(), tmp.month(), tmp.date(), tmp.hour(), tmp.minute(), tmp.second(), tmp.millisecond());
+            for (const zone of allTimeZone) {
+                const tmp = DateTime.now();
+                const expected = tmp.setZone(zone);
+                const pattern = expected.second + ' ' + expected.minute + ' ' + expected.hour + ' ' + expected.day + ' ' + expected.month + ' ' + (expected.weekday % 7);
+                const matcher = new TimeMatcher(pattern, zone);
+                const utcTime = tmp.toUTC().toJSDate();
                 assert.isTrue(matcher.match(utcTime));
             }
         });
     });
 });
+


### PR DESCRIPTION
### Problem
When `recoverMissedExecutions` is enabled, then jobs often (but not always) run twice instead of once, even without any sort of event loop blockage (see #400 for an example). This is because `setTimeout(matchTime, 1000)` doesn't guarantee that the delay will be exactly 1000ms when assessed by `process.hrtime`. Sometimes `elapsedMs` is 999, other times it's 1001. Those two values are evaluated to 0 and 1 respectively by `Math.floor`. Most of the time, the actual delay will be longer than 1000ms because `setTimeout` errs on the side of firing late rather than early, which means most of the time `missedExecutions` will be 1 instead of 0.

### Solution
I would suggest that if `elapsedMs` is 1050ms, for example, that we didn't miss an entire execution. That's essentially right on time. In fact, even if `elapsedMs` is 1900ms, I don't think that should warrant firing twice instead of once, because it implies we're firing early, before we're scheduled to. I think it's more stable to be delayed and offset on future runs by 900ms than fire early.

The solution is pretty straightforward:
```js
const missedExecutions = Math.max(Math.floor(elapsedMs / 1000) - 1, 0);
```
We actually estimate the number of missed executions as 1 fewer than we currently do, but ensure that it doesn't fall below 0.

### Notes
When running the tests, the test "should match with all available timezone of moment-timezone" kept failing for unknown reasons. I switched to use "luxon" just for that test and it started working. 🤷 