### PR TITLE
feat: added maxRandomDelay to the tasks

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ export default defineConfig([
   {
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
+      "no-async-promise-executor": "off",
       'no-restricted-imports': ['error', {
           patterns: [{
             group: ['src/*', '/src/*'],

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -18,22 +18,6 @@ import BackgroundScheduledTask from "./tasks/background-scheduled-task/backgroun
 import path from "path";
 
 /**
- * Represents the configuration options for a scheduled task.
- *
- * @property {string} [name] - An optional name for the task, useful for identification and debugging.
- * @property {boolean} [scheduled] - Indicates whether the task should be scheduled. Defaults to `true`.
- * @property {string} [timezone] - Specifies the timezone in which the task should run. Accepts a string in the IANA timezone database format (e.g., "America/New_York").
- * @property {boolean} [noOverlap] - Ensures that the task does not run concurrently with itself.Defaults to `false`.
- * @property {number} [maxExecutions] - Specifies the maximum number of times the task should execute. If not provided, the task will run indefinitely.
- */
-export type Options = {
-  name?: string;
-  timezone?: string;
-  noOverlap?: boolean;
-  maxExecutions?: number;
-};
-
-/**
  * The central registry that maintains all scheduled tasks.
  * @private
  */
@@ -56,18 +40,9 @@ const registry = new TaskRegistry();
  * // Schedule background task by providing a separate file to run daily with a specific timezone
  * const dailyTask = schedule('0 0 * * *', './tasks/daily-backup.js', { timezone: 'America/New_York' });
  */
-export function schedule(expression:string, func: TaskFn | string, options?: Options): ScheduledTask {
-    const taskOptions: TaskOptions = {
-      name: options?.name,
-      timezone: options?.timezone,
-      noOverlap: options?.noOverlap,
-      maxExecutions: options?.maxExecutions
-    }
-
-    const task = createTask(expression, func, taskOptions);
-
+export function schedule(expression:string, func: TaskFn | string, options?: TaskOptions): ScheduledTask {
+    const task = createTask(expression, func, options);
     task.start();
-
     return task;
 }
 
@@ -80,24 +55,16 @@ export function schedule(expression:string, func: TaskFn | string, options?: Opt
  * @returns A task instance of the appropriate type (inline or background)
  * @private
  */
-export function createTask(expression: string, func: TaskFn | string, options?: Options): ScheduledTask {
-    const taskOptions: TaskOptions = {
-      name: options?.name,
-      timezone: options?.timezone,
-      noOverlap: options?.noOverlap,
-      maxExecutions: options?.maxExecutions,
-    }
-
+export function createTask(expression: string, func: TaskFn | string, options?: TaskOptions): ScheduledTask {
     let task: ScheduledTask;
     if(func instanceof Function){
-      task = new InlineScheduledTask(expression, func, taskOptions);
+      task = new InlineScheduledTask(expression, func, options);
     } else {
       const taskPath = solvePath(func);
-      task = new BackgroundScheduledTask(expression, taskPath, taskOptions);
+      task = new BackgroundScheduledTask(expression, taskPath, options);
     }
 
     registry.add(task);
-
     return task;
 }
 

--- a/src/scheduler/runner.ts
+++ b/src/scheduler/runner.ts
@@ -92,7 +92,7 @@ export class Runner {
         const randomDelay = Math.floor(Math.random() * this.maxRandomDelay);
 
         if(shouldExecute){
-          // uses a setTimeout for aplying a jiter
+          // uses a setTimeout for aplying a jitter
           setTimeout(async () => {
             try {
               this.runCount++;

--- a/src/scheduler/runner.ts
+++ b/src/scheduler/runner.ts
@@ -22,6 +22,7 @@ export type RunnerOptions = {
   noOverlap?: boolean,
   timezone?: string,
   maxExecutions?: number,
+  maxRandomDelay?: number,
   onMissedExecution?: OnFn,
   onOverlap?: OnFn,
   onError?: OnErrorHookFn
@@ -35,6 +36,7 @@ export class Runner {
   onMatch: OnMatch;
   noOverlap: boolean;
   maxExecutions?: number;
+  maxRandomDelay: number;
   runCount: number;
 
   running: boolean;
@@ -52,6 +54,7 @@ export class Runner {
       this.onMatch = onMatch;
       this.noOverlap = options == undefined || options.noOverlap === undefined ? false : options.noOverlap;
       this.maxExecutions = options?.maxExecutions;
+      this.maxRandomDelay = options?.maxRandomDelay || 0;
 
       this.onMissedExecution = options?.onMissedExecution || emptyOnFn;
       this.onOverlap = options?.onOverlap || emptyOnFn;
@@ -78,35 +81,48 @@ export class Runner {
       }
     };
 
-    const checkAndRun = (date: Date): TrackedPromise<any> => {
-      return new TrackedPromise(async (resolve) => {
+    const runTask = (date: Date): Promise<any> => {
+      return new Promise(async (resolve) => {
         const execution: Execution = {
           id: createID('exec'),
           reason: 'scheduled'
         }
+        
+        const shouldExecute = await this.beforeRun(date, execution);
+        const randomDelay = Math.floor(Math.random() * this.maxRandomDelay);
 
-        try {
-          if(this.timeMatcher.match(date)){
-            const shouldExecute = await this.beforeRun(date, execution);
-            if(shouldExecute){
+        if(shouldExecute){
+          // uses a setTimeout for aplying a jiter
+          setTimeout(async () => {
+            try {
               this.runCount++;
               execution.startedAt = new Date();
               const result = await this.onMatch(date, execution);
               execution.finishedAt = new Date();
               execution.result = result;
               this.onFinished(date, execution);
-
+  
               if( this.maxExecutions && this.runCount >= this.maxExecutions){
                 this.onMaxExecutions(date);
                 this.stop();
               }
+            } catch (error: any){
+              execution.finishedAt = new Date();
+              execution.error = error;
+              this.onError(date, error, execution);
             }
-          }
+
+            resolve(true);
+          }, randomDelay);
+        }
+      })
+    }
+
+    const checkAndRun = (date: Date): TrackedPromise<any> => {
+      return new TrackedPromise(async (resolve) => {
+        if(this.timeMatcher.match(date)){
+          await runTask(date);
           resolve(true);
-        } catch (error: any){
-          execution.finishedAt = new Date();
-          execution.error = error;
-          this.onError(date, error, execution);
         }
       });
     }

--- a/src/tasks/inline-scheduled-task.ts
+++ b/src/tasks/inline-scheduled-task.ts
@@ -34,6 +34,7 @@ export class InlineScheduledTask implements ScheduledTask {
       timezone: options?.timezone,
       noOverlap: options?.noOverlap,
       maxExecutions: options?.maxExecutions,
+      maxRandomDelay: options?.maxRandomDelay,
       beforeRun: (date: Date, execution: Execution) => {
         if(execution.reason === 'scheduled'){
           this.changeState('running');

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -32,6 +32,7 @@ export type TaskOptions = {
   name?: string,
   noOverlap?: boolean,
   maxExecutions?: number,
+  maxRandomDelay?: number
 }
 
 export type Execution = {


### PR DESCRIPTION
This change adds a new `maxRandomDelay` option to task definitions, allowing an additional random delay (up to the specified maximum) before task execution. This can help distribute task load more evenly over time.