### PR TITLE
change: Disable forced timeout for execute() [RFC]

### DIFF
--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -186,13 +186,7 @@ class BackgroundScheduledTask implements ScheduledTask{
         return reject(new Error('Cannot execute background task because it hasn\'t been started yet. Please initialize the task using the start() method before attempting to execute it.'));
       }
       
-      const timeoutId = setTimeout(() => {
-        cleanupListeners();
-        reject(new Error('Execution timeout exceeded'));
-      }, 5000);
-      
       const cleanupListeners = () => {
-        clearTimeout(timeoutId);
         this.off('execution:finished', onFinished);
         this.off('execution:failed', onFail);
       };


### PR DESCRIPTION
As mentioned in https://github.com/node-cron/node-cron/issues/486 this is my proposal for dealing with the problem.

I tried running the tests but they are broken with node 24 and I didn't want to include the fixes for that with this PR for readability. They seem to be already present on the Rollup PR https://github.com/node-cron/node-cron/pull/481

This is a request for comments PR since I personally can't come up with any drawbacks for removing this timeout.