### PR TITLE
fix: change getStatus() return type to string

### DIFF
--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -55,7 +55,7 @@ export interface ScheduledTask {
   
   start(): void | Promise<void>;
   stop(): void | Promise<void>;
-  getStatus(): string | Promise<string>;
+  getStatus(): string;
   destroy(): void | Promise<void>;
   execute(): Promise<any>;
   getNextRun(): Date | null;


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
Promise\<string\> was added in [1] but its implementations only ever
returned strings. I suspect it was just caught in the similar changes to
other methods.

[1] https://github.com/node-cron/node-cron/commit/f10ad8a3ef5ff00d8e6b69cf94e67e04ec816ba6#diff-1d52084a4265cb2ab89812078b6452920da6eec1136eb9268bfd710b73aab563L54
<!-- === GH HISTORY FENCE === -->

---

Though it's perhaps better to export and use `TaskState` instead of
`string` while we are at it? Happy to do this if you agree.
