### PR TITLE
fix: getNextMatch() returns past dates near DST boundaries

### DIFF
--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 
 import BackgroundScheduledTask from "./background-scheduled-task";
 
-import { EventEmitter } from 'stream';
+import { EventEmitter } from 'events';
 
 
 describe('BackgroundScheduledTask', function() {

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -3,7 +3,7 @@ import { fork, ChildProcess} from 'child_process';
 
 import { Execution, ScheduledTask, TaskContext, TaskEvent, TaskOptions } from '../scheduled-task';
 import { createID } from '../../create-id';
-import { EventEmitter } from 'stream';
+import { EventEmitter } from 'events';
 import { StateMachine } from '../state-machine';
 import { LocalizedTime } from '../../time/localized-time';
 import logger from '../../logger';

--- a/src/time/localized-time.ts
+++ b/src/time/localized-time.ts
@@ -125,6 +125,10 @@ function getTimezoneGMT(date: Date, timezone?: string) {
   if (!match) return 'Z';
 
   const sign = match[1];
+  const hoursNum = parseInt(match[2]);
+  const minutesNum = parseInt(match[3] || '0');
+  if (hoursNum === 0 && minutesNum === 0) return 'Z';
+
   const hours = match[2].padStart(2, '0');
   const minutes = (match[3] || '00').padStart(2, '0');
 

--- a/src/time/localized-time.ts
+++ b/src/time/localized-time.ts
@@ -42,10 +42,23 @@ export class LocalizedTime {
 
   set(field: string, value: number){
     this.parts[field] = value;
-    const newDate = new Date(this.toISO());
+    const isoString = this.toISO();
+    const newDate = new Date(isoString);
     this.timestamp = newDate.getTime();
 
-    this.parts = buildDateParts(newDate, this.timezone)
+    // Rebuild parts from the new timestamp
+    this.parts = buildDateParts(newDate, this.timezone);
+
+    // If the offset changed (DST boundary crossing), the local time fields
+    // may have drifted. Detect this and correct by adjusting the timestamp
+    // to preserve the intended local time.
+    const oldGmt = parseOffsetMinutes(isoString);
+    const newGmt = parseOffsetMinutes(this.toISO());
+    if (oldGmt !== null && newGmt !== null && oldGmt !== newGmt) {
+      const driftMs = (newGmt - oldGmt) * 60000;
+      this.timestamp -= driftMs;
+      this.parts = buildDateParts(new Date(this.timestamp), this.timezone);
+    }
   }
 }
 
@@ -87,15 +100,33 @@ function buildDateParts(date: Date, timezone?: string): DateParts {
 }
 
 
+function parseOffsetMinutes(isoString: string): number | null {
+  if (isoString.endsWith('Z')) return 0;
+  const match = isoString.match(/([+-])(\d{2}):(\d{2})$/);
+  if (!match) return null;
+  const sign = match[1] === '+' ? 1 : -1;
+  return sign * (parseInt(match[2]) * 60 + parseInt(match[3]));
+}
+
 function getTimezoneGMT(date: Date, timezone?: string) {
-  const utcDate = new Date(date.toLocaleString('en-US', { timeZone: 'UTC' }));
-  const tzDate = new Date(date.toLocaleString('en-US', { timeZone: timezone }));
-  let offsetInMinutes = (utcDate.getTime() - tzDate.getTime()) / 60000;
-  const sign = offsetInMinutes <= 0 ? '+' : '-';
-  offsetInMinutes = Math.abs(offsetInMinutes);
-  if(offsetInMinutes === 0) return 'Z';
-  const hours = Math.floor(offsetInMinutes / 60).toString().padStart(2, '0');
-  const minutes = Math.floor(offsetInMinutes % 60).toString().padStart(2, '0');
-  
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    timeZoneName: 'shortOffset'
+  });
+  const parts = fmt.formatToParts(date);
+  const tzPart = parts.find(p => p.type === 'timeZoneName');
+  if (!tzPart) return 'Z';
+
+  const tzValue = tzPart.value; // e.g. "GMT-5", "GMT+5:30", "GMT"
+  if (tzValue === 'GMT') return 'Z';
+
+  // Parse the offset from the Intl-provided string
+  const match = tzValue.match(/^GMT([+-])(\d{1,2})(?::(\d{2}))?$/);
+  if (!match) return 'Z';
+
+  const sign = match[1];
+  const hours = match[2].padStart(2, '0');
+  const minutes = (match[3] || '00').padStart(2, '0');
+
   return `GMT${sign}${hours}:${minutes}`;
 }

--- a/src/time/time-matcher.test.ts
+++ b/src/time/time-matcher.test.ts
@@ -237,5 +237,28 @@ describe('TimeMatcher', function() {
         const expected = new Date(Date.UTC(2025, 4, 21, 0, 1, 0))
         assert.deepEqual(nextMatch, expected)
       })
+
+      it('should return a future date near DST spring-forward boundary', ()=>{
+        // 2026-03-07 22:32:42 EST (night before US spring-forward on March 8)
+        const baseDate = new Date('2026-03-08T03:32:42Z');
+
+        const everyMinute = new TimeMatcher('* * * * *');
+        const next1 = everyMinute.getNextMatch(baseDate);
+        assert.isTrue(next1 > baseDate, 'every-minute next match must be in the future');
+
+        const every5 = new TimeMatcher('*/5 * * * *');
+        const next2 = every5.getNextMatch(baseDate);
+        assert.isTrue(next2 > baseDate, 'every-5-min next match must be in the future');
+      })
+
+      it('should return next day for daily schedule across DST boundary with timezone', ()=>{
+        // 2026-03-07 22:32:42 EST — next 7am ET should be ~8.5 hours away, not months
+        const baseDate = new Date('2026-03-08T03:32:42Z');
+        const matcher = new TimeMatcher('0 7 * * *', 'America/New_York');
+        const next = matcher.getNextMatch(baseDate);
+        const hoursAway = (next.getTime() - baseDate.getTime()) / (1000 * 60 * 60);
+        assert.isTrue(next > baseDate, 'next match must be in the future');
+        assert.isTrue(hoursAway < 48, `next 7am should be within 48 hours, got ${hoursAway.toFixed(1)}h`);
+      })
     })
 });


### PR DESCRIPTION
## Summary

`getNextMatch()` / `getNextRun()` can return timestamps in the past near DST transitions, causing infinite "missed execution" warnings in the scheduler.

Two bugs in `localized-time.ts`:

1. **`getTimezoneGMT()`** derives offsets via `new Date(date.toLocaleString(...))` roundtrip — the re-parsed string picks up the host timezone's offset at that wall-clock time, not the target timezone's. Replaced with `Intl.DateTimeFormat('en-US', { timeZone, timeZoneName: 'shortOffset' })` to parse the offset directly.

2. **`set()`** doesn't account for DST boundary crossings. When setting a field moves the date across a DST transition, the offset changes and local time drifts by the offset delta. Added drift detection and timestamp correction after rebuilding parts.

## Reproduction

```js
const { TimeMatcher } = require('node-cron/dist/cjs/time/time-matcher.js')
const tm = new TimeMatcher('* * * * *')
// Run with TZ=America/New_York
console.log(tm.getNextMatch(new Date('2026-03-07T22:32:42-05:00')).toString())
// Before fix: Sat Mar 07 2026 21:33:00 GMT-0500 (1 hour in the past)
// After fix:  Sat Mar 07 2026 22:33:00 GMT-0500 ✅
```

Verified across `America/New_York`, `America/Los_Angeles`, `America/Phoenix`, and `UTC`.

## Test plan

- [x] `* * * * *` in DST-observing host TZ returns future timestamp
- [x] `*/5 * * * *` in DST-observing host TZ returns future timestamp
- [x] `0 7 * * *` with `{ timezone: 'America/New_York' }` returns next day (~8.5 hours), not Jan 2027
- [x] All above pass in UTC and non-DST host timezones
- [x] Build passes (`npm run build`)