### PR TITLE
fix: make test command compatible with windows shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     }
   },
   "scripts": {
-    "test": "c8 --reporter text --reporter=lcov --exclude '**/*.test.ts' mocha --recursive './src/**/*.test.ts'",
-    "test:nocov": "mocha --recursive **/*.test.ts",
+    "test": "c8 --reporter text --reporter=lcov --exclude \"**/*.test.ts\" mocha --recursive \"src/**/*.test.ts\"",
+    "test:nocov": "mocha --recursive \"**/*.test.ts\"",
     "lint": "./node_modules/.bin/eslint ./src",
     "check": "npm run lint && npm test",
     "build:esm": "tsc -p tsconfig.esm.json",


### PR DESCRIPTION
**Issue**:  The test command fails on Windows environments because single quotes are not interpreted correctly by PowerShell, causing Mocha to not detect test files

**Fix**: Replaced single quotes with double quotes in test script

**Result**: Mocha now correctly detects/finds and run tests on windows

**NOTE**: Test execution still fails due to a separate runtime issue related to EventEmitter import, which is unrelated to this fix
