### PR TITLE
fix: cleanup execution:finished listener when execute() fails

### DIFF
--- a/src/tasks/inline-scheduled-task.test.ts
+++ b/src/tasks/inline-scheduled-task.test.ts
@@ -65,6 +65,14 @@ describe('InlineScheduledTask', function() {
     }
   });
 
+  it('execute() removes execution:finished listener after failure', async function(){
+    const task = new InlineScheduledTask('* * * * * *', async () => {
+      throw new Error('fail');
+    });
+    try { await task.execute(); } catch { /* expected */ }
+    assert.equal(task.emitter.listenerCount('execution:finished'), 0);
+  });
+
   it('emmits task:started', async function(){
     const task = new InlineScheduledTask('* * * * * *', async ()=> { return "task result" });
     const eventCaught = new Promise<TaskContext>(resolve => {

--- a/src/tasks/inline-scheduled-task.ts
+++ b/src/tasks/inline-scheduled-task.ts
@@ -115,7 +115,7 @@ export class InlineScheduledTask implements ScheduledTask {
   execute() {
     return new Promise<any>((resolve, reject) => {
       const onFail = (context: TaskContext) => {
-        this.off('execution:finished', onFail);
+        this.off('execution:finished', onFinished);
         reject(context.execution?.error)
       };
 


### PR DESCRIPTION
# Fix: Proper listener cleanup on `execute()` failure

`InlineScheduledTask.execute()` registers one-time listeners for
`execution:finished` and `execution:failed` to bridge events into a
Promise. On the failure path, the cleanup call was passing the wrong
listener reference, so the `execution:finished` listener was never
detached when an execution rejected.

The fix passes the correct reference to `off()`, making the failure
path symmetric with the success path and preventing stale listeners
from accumulating on the emitter across repeated executions.