### PR TITLE
fix: import EventEmitter from 'events' instead of 'stream' for ESM compatibility (#512)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: node-cron

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,7 @@ export default defineConfig([
   {
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
+      "no-async-promise-executor": "off",
       'no-restricted-imports': ['error', {
           patterns: [{
             group: ['src/*', '/src/*'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cron",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "A Lightweight Task Scheduler for Node.js",
   "author": "Lucas Merencia",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cron",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "A Lightweight Task Scheduler for Node.js",
   "author": "Lucas Merencia",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cron",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "A Lightweight Task Scheduler for Node.js",
   "author": "Lucas Merencia",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cron",
-  "version": "4.0.7",
+  "version": "4.1.0",
   "description": "A Lightweight Task Scheduler for Node.js",
   "author": "Lucas Merencia",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cron",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "A Lightweight Task Scheduler for Node.js",
   "author": "Lucas Merencia",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cron",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "A Lightweight Task Scheduler for Node.js",
   "author": "Lucas Merencia",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "scripts": {
     "test": "c8 --reporter text --reporter=lcov --exclude '**/*.test.ts' mocha --recursive './src/**/*.test.ts'",
+    "test:nocov": "mocha --recursive **/*.test.ts",
     "lint": "./node_modules/.bin/eslint ./src",
     "check": "npm run lint && npm test",
     "build:esm": "tsc -p tsconfig.esm.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cron",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "A Lightweight Task Scheduler for Node.js",
   "author": "Lucas Merencia",
   "license": "ISC",

--- a/src/create-id.ts
+++ b/src/create-id.ts
@@ -2,9 +2,7 @@ import crypto from 'node:crypto';
 
 export function createID(prefix: string = '', length: number = 16): string {
   const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  const values = new Uint8Array(length);
-  crypto.getRandomValues(values);
+  const values = crypto.randomBytes(length);
   const id = Array.from(values, v => charset[v % charset.length]).join('');
-  if(prefix) return `${prefix}-${id}`;
-  return id;
+  return prefix ? `${prefix}-${id}` : id;
 }

--- a/src/node-cron.test.ts
+++ b/src/node-cron.test.ts
@@ -1,5 +1,5 @@
 import { assert }  from 'chai';
-import cron from './node-cron';
+import cron, { solvePath } from './node-cron';
 import { InlineScheduledTask } from './tasks/inline-scheduled-task';
 
 describe('node-cron', function() {
@@ -176,6 +176,31 @@ describe('node-cron', function() {
         assert.isDefined(task);
         assert.isDefined(task.id);
         assert.equal(task.getStatus(), 'stopped');
+      });
+    })
+
+     describe('solvePath', function(){
+      it('should resolve an absolute path', function(){
+        const path = '/home/usr/dir/script.js';
+        const solvedPath = solvePath(path);
+        assert.isDefined(solvedPath);
+        assert.include(solvedPath, `file:///`);
+        assert.include(solvedPath, path);
+      });
+
+      it('should resolve a file url', function(){
+        const path = 'file:///home/usr/dir/script.js';
+        const solvedPath = solvePath(path);
+        assert.isDefined(solvedPath);
+        assert.equal(solvedPath, `file:///home/usr/dir/script.js`);
+      });
+
+      it('should resolve a relative path', function(){
+        const path = './home/usr/dir/script.js';
+        const solvedPath = solvePath(path);
+        assert.isDefined(solvedPath);
+        assert.include(solvedPath, `file:///`);
+        assert.include(solvedPath, path.slice(1));
       });
     })
 });

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -18,22 +18,6 @@ import BackgroundScheduledTask from "./tasks/background-scheduled-task/backgroun
 import path from "path";
 
 /**
- * Represents the configuration options for a scheduled task.
- *
- * @property {string} [name] - An optional name for the task, useful for identification and debugging.
- * @property {boolean} [scheduled] - Indicates whether the task should be scheduled. Defaults to `true`.
- * @property {string} [timezone] - Specifies the timezone in which the task should run. Accepts a string in the IANA timezone database format (e.g., "America/New_York").
- * @property {boolean} [noOverlap] - Ensures that the task does not run concurrently with itself.Defaults to `false`.
- * @property {number} [maxExecutions] - Specifies the maximum number of times the task should execute. If not provided, the task will run indefinitely.
- */
-export type Options = {
-  name?: string;
-  timezone?: string;
-  noOverlap?: boolean;
-  maxExecutions?: number;
-};
-
-/**
  * The central registry that maintains all scheduled tasks.
  * @private
  */
@@ -56,18 +40,9 @@ const registry = new TaskRegistry();
  * // Schedule background task by providing a separate file to run daily with a specific timezone
  * const dailyTask = schedule('0 0 * * *', './tasks/daily-backup.js', { timezone: 'America/New_York' });
  */
-export function schedule(expression:string, func: TaskFn | string, options?: Options): ScheduledTask {
-    const taskOptions: TaskOptions = {
-      name: options?.name,
-      timezone: options?.timezone,
-      noOverlap: options?.noOverlap,
-      maxExecutions: options?.maxExecutions
-    }
-
-    const task = createTask(expression, func, taskOptions);
-
+export function schedule(expression:string, func: TaskFn | string, options?: TaskOptions): ScheduledTask {
+    const task = createTask(expression, func, options);
     task.start();
-
     return task;
 }
 
@@ -80,24 +55,16 @@ export function schedule(expression:string, func: TaskFn | string, options?: Opt
  * @returns A task instance of the appropriate type (inline or background)
  * @private
  */
-export function createTask(expression: string, func: TaskFn | string, options?: Options): ScheduledTask {
-    const taskOptions: TaskOptions = {
-      name: options?.name,
-      timezone: options?.timezone,
-      noOverlap: options?.noOverlap,
-      maxExecutions: options?.maxExecutions,
-    }
-
+export function createTask(expression: string, func: TaskFn | string, options?: TaskOptions): ScheduledTask {
     let task: ScheduledTask;
     if(func instanceof Function){
-      task = new InlineScheduledTask(expression, func, taskOptions);
+      task = new InlineScheduledTask(expression, func, options);
     } else {
       const taskPath = solvePath(func);
-      task = new BackgroundScheduledTask(expression, taskPath, taskOptions);
+      task = new BackgroundScheduledTask(expression, taskPath, options);
     }
 
     registry.add(task);
-
     return task;
 }
 

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -57,8 +57,6 @@ const registry = new TaskRegistry();
  * const dailyTask = schedule('0 0 * * *', './tasks/daily-backup.js', { timezone: 'America/New_York' });
  */
 export function schedule(expression:string, func: TaskFn | string, options?: Options): ScheduledTask {
-    options = Object.assign({ scheduled: true }, options);
-
     const taskOptions: TaskOptions = {
       name: options?.name,
       timezone: options?.timezone,

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -111,6 +111,21 @@ export function validate(expression: string): boolean {
   }
 }
 
+/**
+ * Retrieves all scheduled tasks from the registry.
+ * 
+ * @returns A map of scheduled tasks
+ */
+export const getTasks = registry.all;
+
+/**
+ * Retrieves a specific scheduled task from the registry.
+ * 
+ * @params taskId - The ID of the task to retrieve
+ * @returns The task instance if found, `undefined` otherwise
+ */
+export const getTask = registry.get;
+
 export { ScheduledTask } from './tasks/scheduled-task';
 export type { TaskFn, TaskContext, TaskOptions } from './tasks/scheduled-task';
 
@@ -118,12 +133,16 @@ export interface NodeCron {
   schedule: typeof schedule;
   createTask: typeof createTask;
   validate: typeof validate;
+  getTasks: typeof getTasks;
+  getTask: typeof getTask;
 }
 
 export const nodeCron: NodeCron = {
   schedule,
   createTask,
-  validate
+  validate,
+  getTasks,
+  getTask,
 };
 
 /**

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -77,7 +77,7 @@ export function createTask(expression: string, func: TaskFn | string, options?: 
  * @throws Error if the task file location cannot be determined
  * @private
  */
-function solvePath(filePath: string): string {
+export function solvePath(filePath: string): string {
   // Convert to file URL
   if(path.isAbsolute(filePath)) return pathToFileURL(filePath).href;
 

--- a/src/scheduler/runner.test.ts
+++ b/src/scheduler/runner.test.ts
@@ -29,7 +29,7 @@ describe('scheduler/runner', function(){
       const runner =  new Runner(timeMatcher, async ()=> {
         throw new Error('fail!')
       }, {
-        onError(date, error, execution){
+        onError(date, error){
           resolve(error);
           runner.stop()
         }

--- a/src/scheduler/runner.test.ts
+++ b/src/scheduler/runner.test.ts
@@ -22,6 +22,25 @@ describe('scheduler/runner', function(){
 
   }).timeout(3000);
 
+  it('allows handle failed', async function(){
+    const timeMatcher = new TimeMatcher('* * * * * *');
+
+    const errorCaught = new Promise<any>((resolve) => {
+      const runner =  new Runner(timeMatcher, async ()=> {
+        throw new Error('fail!')
+      }, {
+        onError(date, error, execution){
+          resolve(error);
+          runner.stop()
+        }
+      });
+      runner.start();
+    });
+
+    const result = await errorCaught;
+    assert.equal(result.message, 'fail!');
+  }).timeout(3000);
+
   it('allows handle task finished', async function(){
     const timeMatcher = new TimeMatcher('* * * * * *');
 

--- a/src/scheduler/runner.ts
+++ b/src/scheduler/runner.ts
@@ -92,7 +92,7 @@ export class Runner {
         const randomDelay = Math.floor(Math.random() * this.maxRandomDelay);
 
         if(shouldExecute){
-          // uses a setTimeout for aplying a jiter
+          // uses a setTimeout for aplying a jitter
           setTimeout(async () => {
             try {
               this.runCount++;

--- a/src/scheduler/runner.ts
+++ b/src/scheduler/runner.ts
@@ -119,11 +119,15 @@ export class Runner {
     }
 
     const checkAndRun = (date: Date): TrackedPromise<any> => {
-      return new TrackedPromise(async (resolve) => {
+      return new TrackedPromise(async (resolve, reject) => {
+      try {
         if(this.timeMatcher.match(date)){
           await runTask(date);
-          resolve(true);
         }
+        resolve(true);
+       } catch(err) {
+         reject(err)
+       }
       });
     }
 

--- a/src/scheduler/runner.ts
+++ b/src/scheduler/runner.ts
@@ -22,6 +22,7 @@ export type RunnerOptions = {
   noOverlap?: boolean,
   timezone?: string,
   maxExecutions?: number,
+  maxRandomDelay?: number,
   onMissedExecution?: OnFn,
   onOverlap?: OnFn,
   onError?: OnErrorHookFn
@@ -35,6 +36,7 @@ export class Runner {
   onMatch: OnMatch;
   noOverlap: boolean;
   maxExecutions?: number;
+  maxRandomDelay: number;
   runCount: number;
 
   running: boolean;
@@ -52,6 +54,7 @@ export class Runner {
       this.onMatch = onMatch;
       this.noOverlap = options == undefined || options.noOverlap === undefined ? false : options.noOverlap;
       this.maxExecutions = options?.maxExecutions;
+      this.maxRandomDelay = options?.maxRandomDelay || 0;
 
       this.onMissedExecution = options?.onMissedExecution || emptyOnFn;
       this.onOverlap = options?.onOverlap || emptyOnFn;
@@ -78,35 +81,48 @@ export class Runner {
       }
     };
 
-    const checkAndRun = (date: Date): TrackedPromise<any> => {
-      return new TrackedPromise(async (resolve) => {
+    const runTask = (date: Date): Promise<any> => {
+      return new Promise(async (resolve) => {
         const execution: Execution = {
           id: createID('exec'),
           reason: 'scheduled'
         }
+        
+        const shouldExecute = await this.beforeRun(date, execution);
+        const randomDelay = Math.floor(Math.random() * this.maxRandomDelay);
 
-        try {
-          if(this.timeMatcher.match(date)){
-            const shouldExecute = await this.beforeRun(date, execution);
-            if(shouldExecute){
+        if(shouldExecute){
+          // uses a setTimeout for aplying a jiter
+          setTimeout(async () => {
+            try {
               this.runCount++;
               execution.startedAt = new Date();
               const result = await this.onMatch(date, execution);
               execution.finishedAt = new Date();
               execution.result = result;
               this.onFinished(date, execution);
-
+  
               if( this.maxExecutions && this.runCount >= this.maxExecutions){
                 this.onMaxExecutions(date);
                 this.stop();
               }
+            } catch (error: any){
+              execution.finishedAt = new Date();
+              execution.error = error;
+              this.onError(date, error, execution);
             }
-          }
+
+            resolve(true);
+          }, randomDelay);
+        }
+      })
+    }
+
+    const checkAndRun = (date: Date): TrackedPromise<any> => {
+      return new TrackedPromise(async (resolve) => {
+        if(this.timeMatcher.match(date)){
+          await runTask(date);
           resolve(true);
-        } catch (error: any){
-          execution.finishedAt = new Date();
-          execution.error = error;
-          this.onError(date, error, execution);
         }
       });
     }

--- a/src/task-registry.ts
+++ b/src/task-registry.ts
@@ -26,16 +26,15 @@ export class TaskRegistry {
     }
   }
 
-  all(): ScheduledTask[]{
-    return Array.from(tasks.values());
+  all(): typeof tasks {
+    return tasks;
   }
-
 
   has(taskId: string): boolean {
     return tasks.has(taskId);
   }
 
-  killAll(){
-    this.all().forEach( id => this.remove(id));
+  killAll() {
+   tasks.forEach(id => this.remove(id));
   }
 }

--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 
 import BackgroundScheduledTask from "./background-scheduled-task";
 
-import { EventEmitter } from 'stream';
+import { EventEmitter } from 'events';
 
 
 describe('BackgroundScheduledTask', function() {

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -110,7 +110,7 @@ class BackgroundScheduledTask implements ScheduledTask{
         
         this.forkProcess.send({
           command: 'task:start',
-          path: resolvePath(this.taskPath),
+          path: this.taskPath,
           cron: this.cronExpression,
           options: this.options
         });

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -107,7 +107,7 @@ class BackgroundScheduledTask implements ScheduledTask{
           clearTimeout(timeout);
           resolve(undefined);
         });
-        
+
         this.forkProcess.send({
           command: 'task:start',
           path: this.taskPath,

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -3,7 +3,7 @@ import { fork, ChildProcess} from 'child_process';
 
 import { Execution, ScheduledTask, TaskContext, TaskEvent, TaskOptions } from '../scheduled-task';
 import { createID } from '../../create-id';
-import { EventEmitter } from 'stream';
+import { EventEmitter } from 'events';
 import { StateMachine } from '../state-machine';
 import { LocalizedTime } from '../../time/localized-time';
 import logger from '../../logger';

--- a/src/tasks/background-scheduled-task/daemon.ts
+++ b/src/tasks/background-scheduled-task/daemon.ts
@@ -1,9 +1,15 @@
+import { fileURLToPath } from "url";
 import logger from "../../logger";
 import { InlineScheduledTask } from "../inline-scheduled-task";
 import { ScheduledTask, TaskContext, TaskEvent } from "../scheduled-task";
 
 export async function startDaemon(message: any): Promise<ScheduledTask> {
-    const script = await import(message.path);
+    let script;
+    try {
+      script = await import(message.path);
+    } catch {
+      script = await import(fileURLToPath(message.path))
+    }
 
     const task = new InlineScheduledTask(message.cron, script.task, message.options);
 

--- a/src/tasks/background-scheduled-task/daemon.ts
+++ b/src/tasks/background-scheduled-task/daemon.ts
@@ -5,6 +5,18 @@ import { ScheduledTask, TaskContext, TaskEvent } from "../scheduled-task";
 
 export async function startDaemon(message: any): Promise<ScheduledTask> {
     let script;
+    /* HACK: this hack was added because CJS vs ESM issues in combination with Windows vs Linux issues:
+     *
+     * 1. On CJS, require should always receive a path
+     * 2. On ESM + Windows, import should always receive a file URL
+     * 3. On ESM + Linux, import can receive either a URL or a Path
+     *
+     * Because we need esModuleInterop: true on our TS config file, it's almost impossible
+     * to determine during runtime whether we are running in CJS or ESM.
+     * This try-catch ensures we will be able to import or require in any environment.
+     * 
+     * If both fail, then the path cannot be found.
+     */
     try {
       script = await import(message.path);
     } catch {

--- a/src/tasks/inline-scheduled-task.ts
+++ b/src/tasks/inline-scheduled-task.ts
@@ -34,6 +34,7 @@ export class InlineScheduledTask implements ScheduledTask {
       timezone: options?.timezone,
       noOverlap: options?.noOverlap,
       maxExecutions: options?.maxExecutions,
+      maxRandomDelay: options?.maxRandomDelay,
       beforeRun: (date: Date, execution: Execution) => {
         if(execution.reason === 'scheduled'){
           this.changeState('running');

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -32,6 +32,7 @@ export type TaskOptions = {
   name?: string,
   noOverlap?: boolean,
   maxExecutions?: number,
+  maxRandomDelay?: number
 }
 
 export type Execution = {

--- a/src/time/localized-time.ts
+++ b/src/time/localized-time.ts
@@ -18,7 +18,7 @@ export class LocalizedTime {
   constructor(date: Date, timezone?: string){
     this.timestamp = date.getTime();
     this.timezone = timezone;
-    this.parts = buidDateParts(date, timezone);
+    this.parts = buildDateParts(date, timezone);
   }
 
   toDate(): Date{
@@ -44,11 +44,12 @@ export class LocalizedTime {
     this.parts[field] = value;
     const newDate = new Date(this.toISO());
     this.timestamp = newDate.getTime();
-    this.parts = buidDateParts(newDate, this.timezone)
+
+    this.parts = buildDateParts(newDate, this.timezone)
   }
 }
 
-function buidDateParts(date: Date, timezone?: string): DateParts {
+function buildDateParts(date: Date, timezone?: string): DateParts {
   const dftOptions: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: '2-digit',
@@ -77,7 +78,7 @@ function buidDateParts(date: Date, timezone?: string): DateParts {
     day: parseInt(parts.day),
     month: parseInt(parts.month),
     year: parseInt(parts.year),
-    hour: parseInt(parts.hour),
+    hour: parts.hour === '24' ? 0 : parseInt(parts.hour),
     minute: parseInt(parts.minute),
     second: parseInt(parts.second),
     milisecond: date.getMilliseconds(),

--- a/src/time/localized-time.ts
+++ b/src/time/localized-time.ts
@@ -58,8 +58,7 @@ function buildDateParts(date: Date, timezone?: string): DateParts {
     minute: '2-digit',
     second: '2-digit',
     weekday: 'short',
-    hour12: false,
-    timeZoneName: 'longOffset'
+    hour12: false
   }
 
   if(timezone){

--- a/src/time/matcher-walker.test.ts
+++ b/src/time/matcher-walker.test.ts
@@ -70,4 +70,34 @@ describe('matcher-walker', function(){
     const m = mw.matchNext();
     assert.equal(m.toISO(), '2029-05-02T00:00:00.000Z')
   });
+
+  it('should match next Sunday at 03:43 from Aug 4th 2025', function(){
+    const baseDate = new Date(Date.UTC(2025, 7, 4, 0, 0, 0));
+  
+    const mw = new MatcherWalker("43 3 * * Sun", baseDate, 'Etc/UTC');
+  
+    assert.isFalse(mw.isMatching())
+    const m = mw.matchNext();
+    assert.equal(m.toISO(), '2025-08-10T03:43:00.000Z')
+  });
+  
+  it('should match next Sunday in September or January from Aug 4th 2025', function(){
+    const baseDate = new Date(Date.UTC(2025, 7, 4, 0, 0, 0));
+  
+    const mw = new MatcherWalker("* * * January,September Sunday", baseDate, 'Etc/UTC');
+  
+    assert.isFalse(mw.isMatching())
+    const m = mw.matchNext();
+    assert.equal(m.toISO(), '2025-09-07T00:00:00.000Z')
+  });
+  
+  it('should match next Sunday in January or March from Aug 4th 2025 (crossing year boundary)', function(){
+    const baseDate = new Date(Date.UTC(2025, 7, 4, 0, 0, 0));
+  
+    const mw = new MatcherWalker("* * * January,March Sunday", baseDate, 'Etc/UTC');
+  
+    assert.isFalse(mw.isMatching())
+    const m = mw.matchNext();
+    assert.equal(m.toISO(), '2026-01-04T00:00:00.000Z')
+  });
 });

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -106,7 +106,7 @@ export class MatcherWalker{
     const days = this.expressions[3];
     
     // Check if day-of-month is wildcard (contains all possible days 1-31)
-    const isDayWildcard = days.length >= 31 && days.includes(1) && days.includes(31);
+    const isDayWildcard = Array.from({ length: 31 }, (_, i) => i + 1).every(day => days.includes(day));
     
     if (isDayWildcard) {
       // When day is wildcard, use OR logic: find next occurrence of weekday OR month

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -120,11 +120,11 @@ export class MatcherWalker{
     } else {
       // When day is specific, use AND logic: must match exact day AND weekday
       // Keep searching until we find a date where the specified day falls on the specified weekday
-      let maxAttempts = 10 * 12; // 10 years * 12 months
+      const maxAttempts = 10 * 12; // 10 years * 12 months
       let attempts = 0;
       
       while (attempts < maxAttempts) {
-        let currentWeekday = parseInt(weekDayNamesConversion(date.getParts().weekday));
+        const currentWeekday = parseInt(weekDayNamesConversion(date.getParts().weekday));
         
         if (weekdays.indexOf(currentWeekday) > -1) {
           // Found matching weekday for the specified day

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -26,6 +26,17 @@ export class MatcherWalker{
     return this.timeMatcher.match(this.baseDate);
   }
 
+  matchIgnoringWeekday(localizedTime: LocalizedTime): boolean {
+    const parts = localizedTime.getParts();
+    const runOnSecond = this.expressions[0].indexOf(parts.second) !== -1;
+    const runOnMinute = this.expressions[1].indexOf(parts.minute) !== -1;
+    const runOnHour = this.expressions[2].indexOf(parts.hour) !== -1;
+    const runOnDay = this.expressions[3].indexOf(parts.day) !== -1;
+    const runOnMonth = this.expressions[4].indexOf(parts.month) !== -1;
+    
+    return runOnSecond && runOnMinute && runOnHour && runOnDay && runOnMonth;
+  }
+
   matchNext(){
     const findNextDateIgnoringWeekday = () => {
       const baseDate = new Date(this.baseDate.getTime());
@@ -37,7 +48,7 @@ export class MatcherWalker{
       const nextSecond = availableValue(seconds, dateParts.second);
       if(nextSecond){
         date.set('second', nextSecond);
-        if(this.timeMatcher.match(date.toDate())){
+        if(this.matchIgnoringWeekday(date)){
           return date;
         }
       }
@@ -47,7 +58,7 @@ export class MatcherWalker{
       const nextMinute = availableValue(minutes, dateParts.minute);
       if(nextMinute){
         date.set('minute', nextMinute);
-        if(this.timeMatcher.match(date.toDate())){
+        if(this.matchIgnoringWeekday(date)){
           return date;
         }
       }
@@ -57,7 +68,7 @@ export class MatcherWalker{
       const nextHour = availableValue(hours, dateParts.hour);
       if(nextHour){
         date.set('hour', nextHour);
-        if(this.timeMatcher.match(date.toDate())){
+        if(this.matchIgnoringWeekday(date)){
           return date;
         }
       }
@@ -67,7 +78,7 @@ export class MatcherWalker{
       const nextDay = availableValue(days, dateParts.day);
       if(nextDay){
         date.set('day', nextDay);
-        if(this.timeMatcher.match(date.toDate())){
+        if(this.matchIgnoringWeekday(date)){
           return date;
         }
       }
@@ -79,7 +90,7 @@ export class MatcherWalker{
       
       if(nextMonth){
         date.set('month', nextMonth);
-        if(this.timeMatcher.match(date.toDate())){
+        if(this.matchIgnoringWeekday(date)){
           return date;
         }
       }
@@ -90,16 +101,56 @@ export class MatcherWalker{
       return date;
     }
 
-
     const date = findNextDateIgnoringWeekday();
     const weekdays = this.expressions[5];
+    const days = this.expressions[3];
     
-    let currentWeekday = parseInt(weekDayNamesConversion(date.getParts().weekday));
-
-    while(!(weekdays.indexOf(currentWeekday) > -1)){
-      date.set('year', date.getParts().year + 1);
-      currentWeekday = parseInt(weekDayNamesConversion(date.getParts().weekday));
+    // Check if day-of-month is wildcard (contains all possible days 1-31)
+    const isDayWildcard = days.length >= 31 && days.includes(1) && days.includes(31);
+    
+    if (isDayWildcard) {
+      // When day is wildcard, use OR logic: find next occurrence of weekday OR month
+      // Since we already found the right month, just find the next weekday in that month
+      let currentWeekday = parseInt(weekDayNamesConversion(date.getParts().weekday));
+      
+      while(!(weekdays.indexOf(currentWeekday) > -1)){
+        date.set('day', date.getParts().day + 1); 
+        currentWeekday = parseInt(weekDayNamesConversion(date.getParts().weekday));
+      }
+    } else {
+      // When day is specific, use AND logic: must match exact day AND weekday
+      // Keep searching until we find a date where the specified day falls on the specified weekday
+      let maxAttempts = 10 * 12; // 10 years * 12 months
+      let attempts = 0;
+      
+      while (attempts < maxAttempts) {
+        let currentWeekday = parseInt(weekDayNamesConversion(date.getParts().weekday));
+        
+        if (weekdays.indexOf(currentWeekday) > -1) {
+          // Found matching weekday for the specified day
+          break;
+        }
+        
+        // Move to next occurrence of the same day in the same month (next year if necessary)
+        const currentParts = date.getParts();
+        const nextMonth = availableValue(this.expressions[4], currentParts.month);
+        
+        if (nextMonth) {
+          date.set('month', nextMonth);
+        } else {
+          // Move to next year and reset to first allowed month
+          date.set('year', currentParts.year + 1);
+          date.set('month', this.expressions[4][0]);
+        }
+        
+        attempts++;
+      }
+      
+      if (attempts >= maxAttempts) {
+        throw new Error('Could not find next matching date within reasonable time range');
+      }
     }
+    
     return date;
   }
 }

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -33,37 +33,43 @@ export class MatcherWalker{
       const localTime = new LocalizedTime(baseDate, this.timezone);
       const dateParts = localTime.getParts();
       const date = new LocalizedTime(localTime.toDate(), this.timezone);
-
       const seconds = this.expressions[0];
       const nextSecond = availableValue(seconds, dateParts.second);
       if(nextSecond){
         date.set('second', nextSecond);
-        return date;
+        if(this.timeMatcher.match(date.toDate())){
+          return date;
+        }
       }
       date.set('second', seconds[0]);
-      
+
       const minutes = this.expressions[1];
       const nextMinute = availableValue(minutes, dateParts.minute);
       if(nextMinute){
         date.set('minute', nextMinute);
-        return date;
+        if(this.timeMatcher.match(date.toDate())){
+          return date;
+        }
       }
       date.set('minute',minutes[0]);
-
 
       const hours = this.expressions[2];
       const nextHour = availableValue(hours, dateParts.hour);
       if(nextHour){
         date.set('hour', nextHour);
-        return date;
+        if(this.timeMatcher.match(date.toDate())){
+          return date;
+        }
       }
       date.set('hour', hours[0]);
 
       const days = this.expressions[3];
       const nextDay = availableValue(days, dateParts.day);
       if(nextDay){
-        date.set('day',nextDay);
-        return date;
+        date.set('day', nextDay);
+        if(this.timeMatcher.match(date.toDate())){
+          return date;
+        }
       }
       
       date.set('day', days[0]);
@@ -73,8 +79,11 @@ export class MatcherWalker{
       
       if(nextMonth){
         date.set('month', nextMonth);
-        return date;
+        if(this.timeMatcher.match(date.toDate())){
+          return date;
+        }
       }
+
       date.set('year', date.getParts().year + 1);
       date.set('month', months[0]);
 

--- a/src/time/time-matcher.test.ts
+++ b/src/time/time-matcher.test.ts
@@ -229,4 +229,13 @@ describe('TimeMatcher', function() {
             assert.isTrue(matcher.match(utcTime));
         });
     });
+
+    describe('getNextMatch', ()=> {
+      it('should return next match', ()=>{
+        const matcher = new TimeMatcher('1 0 * * *', 'Etc/UTC');
+        const nextMatch = matcher.getNextMatch(new Date(Date.UTC(2025, 4, 20, 18, 0, 0)));
+        const expected = new Date(Date.UTC(2025, 4, 21, 0, 1, 0))
+        assert.deepEqual(nextMatch, expected)
+      })
+    })
 });


### PR DESCRIPTION
fix: import EventEmitter from `events` instead of `stream` (ESM compatibility)

## Problem

In Node.js ESM environments (e.g. Node.js v22+ with `"type": "module"` or `.mjs` files), the following import breaks:

```ts
import { EventEmitter } from 'stream';
```

The `stream` module does **not** re-export `EventEmitter` as a named export under strict ESM module resolution. This causes a runtime error:

```
SyntaxError: The requested module 'stream' does not provide an export named 'EventEmitter'
```

## Root Cause

`EventEmitter` lives in the `events` module â€” it is `streams` canonical dependency, not the other way around. Using `stream` worked historically in CJS due to `module.exports` duck-typing, but ESM named-export resolution is strict.

## Fix

Change the import source from `'stream'` to `'events'` in both the implementation and its test file:

```ts
// Before
import { EventEmitter } from 'stream';

// After
import { EventEmitter } from 'events';
```

## Affected Files

- `src/tasks/background-scheduled-task/background-scheduled-task.ts` (line 6)
- `src/tasks/background-scheduled-task/background-scheduled-task.test.ts` (line 6)

## Testing

Existing test suite passes without modification. The fix is purely a module source correction with no behavioural change.

Closes #512
