### PR TITLE
fix: getNextMatch returns past dates near DST boundaries

### DIFF
--- a/src/scheduler/runner.ts
+++ b/src/scheduler/runner.ts
@@ -139,7 +139,16 @@ export class Runner {
       if(expectedNextExecution && expectedNextExecution.getTime() < currentDate.getTime()){
         while(expectedNextExecution.getTime() < currentDate.getTime()){
           logger.warn(`missed execution at ${expectedNextExecution}! Possible blocking IO or high CPU user at the same process used by node-cron.`);
-          expectedNextExecution = this.timeMatcher.getNextMatch(expectedNextExecution);
+          const nextMatch = this.timeMatcher.getNextMatch(expectedNextExecution);
+          // Defense in depth: getNextMatch must always move forward. If it ever
+          // returns a date that does not advance (e.g. a bug around a DST
+          // boundary), re-base from the current date instead of looping forever.
+          if(nextMatch.getTime() <= expectedNextExecution.getTime()){
+            logger.error(`getNextMatch did not advance past ${expectedNextExecution}; aborting missed-execution catch-up to avoid an infinite loop.`);
+            expectedNextExecution = this.timeMatcher.getNextMatch(currentDate);
+            break;
+          }
+          expectedNextExecution = nextMatch;
           runAsync(this.onMissedExecution, expectedNextExecution, defaultOnError);
         }
       }

--- a/src/time/localized-time.ts
+++ b/src/time/localized-time.ts
@@ -42,24 +42,69 @@ export class LocalizedTime {
 
   set(field: string, value: number){
     this.parts[field] = value;
-    const isoString = this.toISO();
-    const newDate = new Date(isoString);
-    this.timestamp = newDate.getTime();
 
-    // Rebuild parts from the new timestamp
-    this.parts = buildDateParts(newDate, this.timezone);
-
-    // If the offset changed (DST boundary crossing), the local time fields
-    // may have drifted. Detect this and correct by adjusting the timestamp
-    // to preserve the intended local time.
-    const oldGmt = parseOffsetMinutes(isoString);
-    const newGmt = parseOffsetMinutes(this.toISO());
-    if (oldGmt !== null && newGmt !== null && oldGmt !== newGmt) {
-      const driftMs = (newGmt - oldGmt) * 60000;
-      this.timestamp -= driftMs;
-      this.parts = buildDateParts(new Date(this.timestamp), this.timezone);
-    }
+    // Convert the intended local wall-clock back to an absolute instant. This
+    // must be DST-aware: the timezone offset valid for the requested wall-clock
+    // is not necessarily the one currently stored in this.parts.gmt, and around
+    // a transition it can change. Doing this naively (building an ISO string
+    // with the *old* offset) shifts the local time by the DST delta, which used
+    // to make getNextMatch overshoot to the next year or return a past date.
+    this.timestamp = localTimeToTimestamp(this.parts, this.timezone);
+    this.parts = buildDateParts(new Date(this.timestamp), this.timezone);
   }
+}
+
+/**
+ * Returns the timezone offset, in minutes, for the given instant
+ * (local - UTC). e.g. New York in winter (EST) returns -300.
+ */
+function getOffsetMinutes(date: Date, timezone?: string): number {
+  const offset = parseOffsetMinutes(getTimezoneGMT(date, timezone).replace(/^GMT/, '') || 'Z');
+  return offset ?? 0;
+}
+
+/**
+ * Returns true if the given instant, read back in the timezone, matches the
+ * requested local wall-clock down to the second.
+ */
+function readsBackTo(timestamp: number, parts: DateParts, timezone?: string): boolean {
+  const p = buildDateParts(new Date(timestamp), timezone);
+  return p.year === parts.year && p.month === parts.month && p.day === parts.day
+      && p.hour === parts.hour && p.minute === parts.minute && p.second === parts.second;
+}
+
+/**
+ * Converts a set of local wall-clock fields to the absolute timestamp that
+ * reads back as those fields in the given timezone.
+ *
+ * It guesses the instant by treating the wall-clock as if it were UTC, then
+ * corrects with the offset actually in effect. Away from DST transitions the
+ * first correction is exact. Near a transition both the pre- and post-shift
+ * offsets are considered and the one that genuinely reads back to the
+ * requested wall-clock wins. For a non-existent local time (the spring-forward
+ * gap) neither reads back, so we resolve forward to the later instant instead
+ * of drifting backwards into the gap (which used to yield a past date).
+ */
+function localTimeToTimestamp(parts: DateParts, timezone?: string): number {
+  const guess = Date.UTC(
+    parts.year, parts.month - 1, parts.day,
+    parts.hour, parts.minute, parts.second, parts.milisecond
+  );
+
+  const firstOffset = getOffsetMinutes(new Date(guess), timezone);
+  const candidate1 = guess - firstOffset * 60000;
+
+  const secondOffset = getOffsetMinutes(new Date(candidate1), timezone);
+  if (secondOffset === firstOffset) {
+    return candidate1;
+  }
+
+  const candidate2 = guess - secondOffset * 60000;
+  if (readsBackTo(candidate1, parts, timezone)) return candidate1;
+  if (readsBackTo(candidate2, parts, timezone)) return candidate2;
+
+  // Non-existent local time (spring-forward gap): resolve forward.
+  return Math.max(candidate1, candidate2);
 }
 
 function buildDateParts(date: Date, timezone?: string): DateParts {

--- a/src/time/time-matcher.test.ts
+++ b/src/time/time-matcher.test.ts
@@ -260,5 +260,36 @@ describe('TimeMatcher', function() {
         assert.isTrue(next > baseDate, 'next match must be in the future');
         assert.isTrue(hoursAway < 48, `next 7am should be within 48 hours, got ${hoursAway.toFixed(1)}h`);
       })
+
+      it('should never return a past date during the spring-forward skipped hour', ()=>{
+        // The local hour 02:00-02:59 does not exist on 2026-03-08 in New York
+        // (clocks jump 02:00 EST -> 03:00 EDT at 07:00Z). A base anywhere in the
+        // hour right before the jump must still yield a future match, not a past one.
+        const expressions = ['* * * * *', '*/5 * * * *', '0 * * * *'];
+        const bases = [
+          '2026-03-08T06:30:00Z',
+          '2026-03-08T06:58:00Z',
+          '2026-03-08T06:59:00Z',
+          '2026-03-08T06:59:30Z',
+        ];
+
+        for (const expression of expressions) {
+          for (const base of bases) {
+            const baseDate = new Date(base);
+            const next = new TimeMatcher(expression, 'America/New_York').getNextMatch(baseDate);
+            assert.isTrue(
+              next > baseDate,
+              `"${expression}" at ${base} must return a future date, got ${next.toISOString()}`
+            );
+          }
+        }
+      })
+
+      it('should return a future date during the fall-back repeated hour', ()=>{
+        // 2026-11-01: clocks fall back 02:00 EDT -> 01:00 EST at 06:00Z.
+        const baseDate = new Date('2026-11-01T05:30:00Z');
+        const next = new TimeMatcher('* * * * *', 'America/New_York').getNextMatch(baseDate);
+        assert.isTrue(next > baseDate, `expected future date, got ${next.toISOString()}`);
+      })
     })
 });


### PR DESCRIPTION
## Problem

After #508, `getNextMatch()` could return a date **earlier than the base date** when the requested local wall-clock fell inside the spring-forward gap (e.g. `02:00`–`02:59` in `America/New_York`, which does not exist on the transition day).

Reproduces with common expressions when the base is in the hour right before the jump:

| expression | base | merged #508 result |
| --- | --- | --- |
| `* * * * *` | `2026-03-08T06:59:00Z` | `2026-03-08T06:00:00Z` ⬅️ past |
| `*/5 * * * *` | `2026-03-08T06:59:00Z` | `2026-03-08T06:00:00Z` ⬅️ past |
| `0 * * * *` | `2026-03-08T06:30:00Z` | `2026-03-08T06:00:00Z` ⬅️ past |

A past "next match" is also dangerous: the runner's missed-execution catch-up loop advances `expectedNextExecution` via `getNextMatch`, so a non-advancing result can spin it indefinitely.

## Root cause

The drift correction added to `LocalizedTime.set()` built the new instant from the *old* offset and then subtracted the DST delta, which pushes a non-existent local time **backwards** into the gap.

## Fix

- Replace the offset-patching hack with a proper DST-aware wall-clock → instant inversion: guess the instant, correct with the offset actually in effect, and near a transition pick the candidate that genuinely reads back to the requested wall-clock. Non-existent local times resolve **forward**.
- Harden `Runner` so the missed-execution loop bails out (re-basing from the current date) if `getNextMatch` ever fails to advance.
- Add regression tests for the spring-forward skipped hour and the fall-back repeated hour.

## Verified

- `0 7 * * *` (the case #508 fixed) still returns next morning, not next year.
- Spring-forward skipped-hour and fall-back repeated-hour cases all return future dates.
- Half-hour zones (`Asia/Kolkata`), 30-min DST (`Australia/Lord_Howe`), no-timezone and UTC cases unchanged.
- Time-module test suites green (53 passing); lint clean.

## Known limitation (follow-up)

A daily schedule whose exact time lands in the skipped hour (e.g. `30 2 * * *` in New York on the spring-forward day) still overshoots to the next year instead of running the following day. This is a pre-existing structural limitation of the field-walking algorithm and is tracked separately.