### PR TITLE
test: destroy task in listener-leak test

### DIFF
--- a/src/tasks/inline-scheduled-task.test.ts
+++ b/src/tasks/inline-scheduled-task.test.ts
@@ -71,6 +71,7 @@ describe('InlineScheduledTask', function() {
     });
     try { await task.execute(); } catch { /* expected */ }
     assert.equal(task.emitter.listenerCount('execution:finished'), 0);
+    task.destroy();
   });
 
   it('emmits task:started', async function(){


### PR DESCRIPTION
Follow-up to #513.

The regression test it added (`execute() removes execution:finished listener after failure`) creates an `InlineScheduledTask` but never calls `destroy()`, leaving a scheduled runner alive after the test finishes. This adds the missing `task.destroy()` so the test cleans up after itself.

No production code change — test hygiene only.