### PR TITLE
chore: restore version to 4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cron",
-  "version": "5.0.0",
+  "version": "4.2.1",
   "description": "A Lightweight Task Scheduler for Node.js",
   "author": "Lucas Merencia",
   "license": "ISC",


### PR DESCRIPTION
The build refactor (#525) inadvertently carried a `5.0.0` version bump. Version is bumped at release time (its own `vX.Y.Z` commit), not in a build/chore PR, so this restores it to `4.2.1`.

`engines.node` stays at `>=20.11` since that reflects the build's real Node requirement (`import.meta.dirname`), independent of the package version.