### PR TITLE
chore: use prepack instead of prepublishOnly to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "check": "npm run lint && npm test",
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "prepublishOnly": "npm run build"
+    "prepack": "npm run build"
   },
   "engines": {
     "node": ">=20.11"


### PR DESCRIPTION
Switches the build hook from `prepublishOnly` to `prepack`.

`prepack` runs on both `npm pack` and `npm publish`, so the packed tarball always ships a freshly built `dist`. With `prepublishOnly` (publish-only), `npm pack` could produce a stale or missing `dist` (we hit exactly this while building local end-to-end consumer tests).

Credit to @wojtekmaj, who introduced this in #479. That PR is being closed as superseded by the Rollup build (#525), but this improvement from it is worth keeping.