### PR TITLE
fix: sync package-lock.json version with package.json (4.2.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-cron",
-  "version": "5.0.0",
+  "version": "4.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-cron",
-      "version": "5.0.0",
+      "version": "4.2.1",
       "license": "ISC",
       "devDependencies": {
         "@eslint/js": "^9.26.0",


### PR DESCRIPTION
#527 restored `package.json` to `4.2.1`, but the lockfile kept the `5.0.0` self-version introduced by the #525 bump. That mismatch makes `npm ci` fail (it requires `package.json` and `package-lock.json` to agree).

Regenerated the lockfile from `package.json` (`npm install --package-lock-only`); the only change is the two node-cron self-version fields.