### PR TITLE
test: make daemon event assertions robust to ordering

### DIFF
--- a/src/tasks/background-scheduled-task/daemon.test.ts
+++ b/src/tasks/background-scheduled-task/daemon.test.ts
@@ -87,10 +87,10 @@ describe('daemon - register', function () {
 
     task.destroy();
 
-    assert.equal(messages[0].event, 'daemon:started');
-    assert.equal(messages[1].event, 'task:started');
-    assert.equal(messages[2].event, 'execution:started');
-    assert.equal(messages[3].event, 'execution:failed');
+    assert.isDefined(messages.find(m => m.event === 'daemon:started'), 'daemon:started should be sent');
+    assert.isDefined(messages.find(m => m.event === 'task:started'), 'task:started should be sent');
+    assert.isDefined(messages.find(m => m.event === 'execution:started'), 'execution:started should be sent');
+    assert.isDefined(messages.find(m => m.event === 'execution:failed'), 'execution:failed should be sent');
   });
 
   it('should send overlap event', async function () {
@@ -111,10 +111,10 @@ describe('daemon - register', function () {
 
     task.destroy();
 
-    assert.equal(messages[0].event, 'daemon:started');
-    assert.equal(messages[1].event, 'task:started');
-    assert.equal(messages[2].event, 'execution:started');
-    assert.equal(messages[3].event, 'execution:overlap');
+    assert.isDefined(messages.find(m => m.event === 'daemon:started'), 'daemon:started should be sent');
+    assert.isDefined(messages.find(m => m.event === 'task:started'), 'task:started should be sent');
+    assert.isDefined(messages.find(m => m.event === 'execution:started'), 'execution:started should be sent');
+    assert.isDefined(messages.find(m => m.event === 'execution:overlap'), 'execution:overlap should be sent');
   });
 
   it('should send missed event', async function () {


### PR DESCRIPTION
The `should send error event` and `should send overlap event` tests in `daemon.test.ts` asserted events by array index (`messages[3]`). With a 1-second cron, a slower CI runner can emit extra events within the wait window and shift the indices, making the tests flaky (this turned `main` red after #419 merged, with `execution:overlap` landing where `execution:failed` was expected).

Switched both to assert by event presence (`messages.find(...)`), matching the robust pattern already used by the other tests in the same file. No production change. Ran the daemon suite repeatedly to confirm.