### PR TITLE
feat: configurable executeTimeout for background tasks (default: no timeout)

### DIFF
--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -293,15 +293,17 @@ describe('BackgroundScheduledTask', function() {
       }
     });
 
-    it('fails on execute timeout', async function(){
-      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
-      
+    it('fails on execute when executeTimeout is exceeded', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', { executeTimeout: 50 });
+
+      // Only acknowledges start; never reports the execution back, so the
+      // configured timeout is what ends execute().
       fakeChildProcess.send.callsFake((obj)=>{
         if(obj.command === 'task:start'){
           task.emitter.emit('task:started');
         }
       })
-   
+
       await task.start();
 
       try {
@@ -310,6 +312,25 @@ describe('BackgroundScheduledTask', function() {
       } catch (error: any){
         assert.equal(error.message, 'Execution timeout exceeded');
       }
+    });
+
+    it('does not impose a timeout by default', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+
+      // Report the result only after a delay; with no executeTimeout, execute()
+      // must wait for it rather than rejecting.
+      fakeChildProcess.send.callsFake((obj)=>{
+        if(obj.command === 'task:execute'){
+          setTimeout(() => task.emitter.emit('execution:finished', {execution: { result: "late result"}}), 50);
+        } else {
+          task.emitter.emit('task:started');
+        }
+      })
+
+      await task.start();
+
+      const result = await task.execute();
+      assert.equal(result, 'late result');
     });
   });
 });

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -194,13 +194,19 @@ class BackgroundScheduledTask implements ScheduledTask{
         return reject(new Error('Cannot execute background task because it hasn\'t been started yet. Please initialize the task using the start() method before attempting to execute it.'));
       }
       
-      const timeoutId = setTimeout(() => {
-        cleanupListeners();
-        reject(new Error('Execution timeout exceeded'));
-      }, 5000);
-      
+      // No timeout by default: wait for the task to actually finish or fail.
+      // An optional `executeTimeout` (ms) opts into a guard against a daemon
+      // that never reports back.
+      let timeoutId: NodeJS.Timeout | undefined;
+      if (typeof this.options?.executeTimeout === 'number') {
+        timeoutId = setTimeout(() => {
+          cleanupListeners();
+          reject(new Error('Execution timeout exceeded'));
+        }, this.options.executeTimeout);
+      }
+
       const cleanupListeners = () => {
-        clearTimeout(timeoutId);
+        if (timeoutId) clearTimeout(timeoutId);
         this.off('execution:finished', onFinished);
         this.off('execution:failed', onFail);
       };

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -45,7 +45,14 @@ export type TaskOptions = {
    * The warning is also suppressed automatically when an `execution:missed`
    * listener is attached.
    */
-  suppressMissedWarning?: boolean
+  suppressMissedWarning?: boolean,
+  /**
+   * Timeout in milliseconds for `execute()` on background tasks. When set,
+   * `execute()` rejects with "Execution timeout exceeded" if the task has not
+   * reported back in time. Defaults to no timeout (waits for the task to
+   * finish or fail). Has no effect on inline tasks.
+   */
+  executeTimeout?: number
 }
 
 export type Execution = {


### PR DESCRIPTION
Resolves #486. Builds on the RFC in #488 by @andrejcremoznik.

## Problem
`BackgroundScheduledTask.execute()` had a hardcoded 5s timeout. A background task that legitimately runs longer than 5s (a backup, a heavy job) would have `execute()` reject with `Execution timeout exceeded` even though it was running fine.

## Change
- Remove the hardcoded 5s timeout. By default `execute()` now waits for the task to actually finish or fail, which also matches how inline tasks' `execute()` behaves.
- Add an optional `executeTimeout` (ms) task option. When set, `execute()` rejects with `Execution timeout exceeded` after that duration, as an opt-in guard against a daemon that never reports back.

```js
// no timeout (default): waits for the real result
cron.createTask('* * * * *', './task.js');

// opt-in guard
cron.createTask('* * * * *', './task.js', { executeTimeout: 30000 });
```

## Design note
The default is intentionally no timeout: any fixed default is just a new arbitrary cutoff that would break some valid long task. Correct-by-default, with an opt-in for callers who want a bound.

## Tests
- `execute()` rejects when `executeTimeout` is exceeded.
- `execute()` does not impose a timeout by default (waits for a delayed result).
- Existing execute success/failure paths unchanged.

Supersedes #488.