### PR TITLE
fix: import EventEmitter as a named import in the inline task

### DIFF
--- a/src/tasks/inline-scheduled-task.ts
+++ b/src/tasks/inline-scheduled-task.ts
@@ -1,4 +1,4 @@
-import EventEmitter from "events";
+import { EventEmitter } from "events";
 import { Execution, ScheduledTask, TaskContext, TaskEvent, TaskFn, TaskOptions } from "./scheduled-task";
 import { Runner, RunnerOptions } from "../scheduler/runner";
 import { TimeMatcher } from "../time/time-matcher";


### PR DESCRIPTION
Fixes #465.

## Problem
`inline-scheduled-task.ts` used a default import:

```ts
import EventEmitter from "events";
class TaskEmitter extends EventEmitter {}
```

Some bundlers and interop layers (Nuxt, Nitro, pnpm) resolve the default import of the `events` builtin to the module namespace object instead of the class. `class ... extends <namespace>` then throws:

```
TypeError: Class extends value [object Module] is not a constructor or null
```

This is exactly what #465 reported (the stack pointed at `inline-scheduled-task.js`). `background-scheduled-task.ts` was already using the named import and is unaffected.

## Fix
```ts
import { EventEmitter } from "events";
```

The named import is resolved correctly by every interop layer.

## Verification (real before/after)
Ran node-cron's actual built ESM with a loader that resolves `events` to a module whose `default` is the namespace (mimicking the broken bundler interop):

- Before (default import): `TypeError: Class extends value [object Module] is not a constructor or null`
- After (named import): loads and creates a task fine

Lint clean, full suite green (231 tests).