### PR TITLE
refactor: rewrite matcher-walker to infer next run from cron fields

### DIFF
--- a/src/time/localized-time.test.ts
+++ b/src/time/localized-time.test.ts
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { LocalizedTime } from './localized-time';
+import { LocalizedTime, localTimeToTimestamp } from './localized-time';
 
 describe('LocalizedTime', function(){
   it('converts to a timezone', function(){
@@ -44,7 +44,35 @@ describe('LocalizedTime', function(){
       second: 5, 
       milisecond: 78, 
       weekday: 'Wed', 
-      gmt: 'GMT+03:00' 
+      gmt: 'GMT+03:00'
     });
+  });
+})
+
+describe('localTimeToTimestamp', function(){
+  it('resolves a wall-clock outside any DST transition', function(){
+    const ts = localTimeToTimestamp(
+      { year: 2026, month: 1, day: 15, hour: 10, minute: 30, second: 0, milisecond: 0 },
+      'America/New_York'
+    );
+    assert.equal(new Date(ts).toISOString(), '2026-01-15T15:30:00.000Z');
+  });
+
+  it('resolves a non-existent spring-forward wall-clock forward', function(){
+    // 2026-03-08 02:30 does not exist in America/New_York (clocks jump 02:00 -> 03:00).
+    const ts = localTimeToTimestamp(
+      { year: 2026, month: 3, day: 8, hour: 2, minute: 30, second: 0, milisecond: 0 },
+      'America/New_York'
+    );
+    assert.equal(new Date(ts).toISOString(), '2026-03-08T07:30:00.000Z');
+  });
+
+  it('resolves an ambiguous fall-back wall-clock to the first occurrence', function(){
+    // 2026-11-01 01:30 happens twice in America/New_York (clocks fall back 02:00 -> 01:00).
+    const ts = localTimeToTimestamp(
+      { year: 2026, month: 11, day: 1, hour: 1, minute: 30, second: 0, milisecond: 0 },
+      'America/New_York'
+    );
+    assert.equal(new Date(ts).toISOString(), '2026-11-01T05:30:00.000Z');
   });
 })

--- a/src/time/localized-time.ts
+++ b/src/time/localized-time.ts
@@ -42,19 +42,6 @@ export class LocalizedTime {
   getParts(): DateParts {
     return this.parts;
   }
-
-  set(field: string, value: number){
-    this.parts[field] = value;
-
-    // Convert the intended local wall-clock back to an absolute instant. This
-    // must be DST-aware: the timezone offset valid for the requested wall-clock
-    // is not necessarily the one currently stored in this.parts.gmt, and around
-    // a transition it can change. Doing this naively (building an ISO string
-    // with the *old* offset) shifts the local time by the DST delta, which used
-    // to make getNextMatch overshoot to the next year or return a past date.
-    this.timestamp = localTimeToTimestamp(this.parts, this.timezone);
-    this.parts = buildDateParts(new Date(this.timestamp), this.timezone);
-  }
 }
 
 /**

--- a/src/time/localized-time.ts
+++ b/src/time/localized-time.ts
@@ -1,11 +1,14 @@
-type DateParts = {
-  day: number
-  month: number
+export type WallClock = {
   year: number
+  month: number
+  day: number
   hour: number
   minute: number
   second: number
   milisecond: number
+}
+
+type DateParts = WallClock & {
   weekday: string
   gmt: string
 }
@@ -67,7 +70,7 @@ function getOffsetMinutes(date: Date, timezone?: string): number {
  * Returns true if the given instant, read back in the timezone, matches the
  * requested local wall-clock down to the second.
  */
-function readsBackTo(timestamp: number, parts: DateParts, timezone?: string): boolean {
+function readsBackTo(timestamp: number, parts: WallClock, timezone?: string): boolean {
   const p = buildDateParts(new Date(timestamp), timezone);
   return p.year === parts.year && p.month === parts.month && p.day === parts.day
       && p.hour === parts.hour && p.minute === parts.minute && p.second === parts.second;
@@ -85,7 +88,7 @@ function readsBackTo(timestamp: number, parts: DateParts, timezone?: string): bo
  * gap) neither reads back, so we resolve forward to the later instant instead
  * of drifting backwards into the gap (which used to yield a past date).
  */
-function localTimeToTimestamp(parts: DateParts, timezone?: string): number {
+export function localTimeToTimestamp(parts: WallClock, timezone?: string): number {
   const guess = Date.UTC(
     parts.year, parts.month - 1, parts.day,
     parts.hour, parts.minute, parts.second, parts.milisecond

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -2,9 +2,10 @@ import convertExpression from '../pattern/convertion';
 import { LocalizedTime, localTimeToTimestamp } from './localized-time';
 import { TimeMatcher } from './time-matcher';
 
-// Upper bound on the calendar search before giving up (roughly ten years of
-// days). Reaching it means the expression can never match (e.g. `0 0 31 2 *`).
-const MAX_DAYS = 366 * 10;
+// Upper bound on the calendar search before giving up. A century is far beyond
+// any real recurrence (the calendar repeats within 28 years) and the loop is
+// cheap, so reaching it means the expression can never match (e.g. `0 0 31 2 *`).
+const MAX_DAYS = 366 * 100;
 
 export class MatcherWalker {
   cronExpression: string;
@@ -13,12 +14,25 @@ export class MatcherWalker {
   timeMatcher: TimeMatcher;
   timezone?: string;
 
+  private readonly seconds: number[];
+  private readonly minutes: number[];
+  private readonly hours: number[];
+  private readonly days: number[];
+  private readonly months: number[];
+
   constructor(cronExpression: string, baseDate: Date, timezone?: string) {
     this.cronExpression = cronExpression;
     this.baseDate = baseDate;
     this.timeMatcher = new TimeMatcher(cronExpression, timezone);
     this.timezone = timezone;
     this.expressions = convertExpression(cronExpression);
+
+    // Sorted once; the time fields are iterated in ascending order per day.
+    this.seconds = sortedAsc(this.expressions[0]);
+    this.minutes = sortedAsc(this.expressions[1]);
+    this.hours = sortedAsc(this.expressions[2]);
+    this.days = this.expressions[3];
+    this.months = this.expressions[4];
   }
 
   isMatching() {
@@ -38,8 +52,8 @@ export class MatcherWalker {
    * non-existent local times (the DST spring-forward gap) by construction.
    */
   matchNext(): LocalizedTime {
-    const months = this.expressions[4];
-    const days = this.expressions[3];
+    const months = this.months;
+    const days = this.days;
 
     const baseMs = Math.floor(this.baseDate.getTime() / 1000) * 1000;
     const baseParts = new LocalizedTime(new Date(baseMs), this.timezone).getParts();
@@ -77,9 +91,7 @@ export class MatcherWalker {
     lowerBound: { hour: number; minute: number; second: number } | null,
     baseMs: number,
   ): number | null {
-    const seconds = sortedAsc(this.expressions[0]);
-    const minutes = sortedAsc(this.expressions[1]);
-    const hours = sortedAsc(this.expressions[2]);
+    const { seconds, minutes, hours } = this;
 
     for (const hour of hours) {
       if (lowerBound && hour < lowerBound.hour) continue;

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -10,10 +10,11 @@ const MAX_DAYS = 366 * 100;
 export class MatcherWalker {
   cronExpression: string;
   baseDate: Date;
-  expressions: number[][];
   timeMatcher: TimeMatcher;
   timezone?: string;
 
+  // Time fields are sorted so they can be iterated in ascending order; day and
+  // month are only membership-tested, so their order does not matter.
   private readonly seconds: number[];
   private readonly minutes: number[];
   private readonly hours: number[];
@@ -25,14 +26,13 @@ export class MatcherWalker {
     this.baseDate = baseDate;
     this.timeMatcher = new TimeMatcher(cronExpression, timezone);
     this.timezone = timezone;
-    this.expressions = convertExpression(cronExpression);
 
-    // Sorted once; the time fields are iterated in ascending order per day.
-    this.seconds = sortedAsc(this.expressions[0]);
-    this.minutes = sortedAsc(this.expressions[1]);
-    this.hours = sortedAsc(this.expressions[2]);
-    this.days = this.expressions[3];
-    this.months = this.expressions[4];
+    const expressions = convertExpression(cronExpression);
+    this.seconds = sortedAsc(expressions[0]);
+    this.minutes = sortedAsc(expressions[1]);
+    this.hours = sortedAsc(expressions[2]);
+    this.days = expressions[3];
+    this.months = expressions[4];
   }
 
   isMatching() {
@@ -94,18 +94,12 @@ export class MatcherWalker {
     const { seconds, minutes, hours } = this;
 
     for (const hour of hours) {
+      // On the base day, whole earlier hours can be skipped cheaply.
       if (lowerBound && hour < lowerBound.hour) continue;
       for (const minute of minutes) {
-        if (lowerBound && hour === lowerBound.hour && minute < lowerBound.minute) continue;
         for (const second of seconds) {
-          if (
-            lowerBound &&
-            hour === lowerBound.hour &&
-            minute === lowerBound.minute &&
-            second <= lowerBound.second
-          ) {
-            continue;
-          }
+          // Skip times of day at or before the base instant on the base day.
+          if (lowerBound && !isLaterInDay(hour, minute, second, lowerBound)) continue;
 
           const ts = localTimeToTimestamp(
             { year, month, day, hour, minute, second, milisecond: 0 },
@@ -133,4 +127,14 @@ function nextDay(year: number, month: number, day: number): { year: number; mont
 
 function sortedAsc(values: number[]): number[] {
   return [...values].sort((a, b) => a - b);
+}
+
+// True when (hour, minute, second) is strictly later in the day than the bound.
+function isLaterInDay(
+  hour: number,
+  minute: number,
+  second: number,
+  bound: { hour: number; minute: number; second: number },
+): boolean {
+  return hour * 3600 + minute * 60 + second > bound.hour * 3600 + bound.minute * 60 + bound.second;
 }

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -1,162 +1,124 @@
-
 import convertExpression from '../pattern/convertion';
-import { LocalizedTime } from './localized-time';
+import { LocalizedTime, localTimeToTimestamp } from './localized-time';
 import { TimeMatcher } from './time-matcher';
 
-import weekDayNamesConversion from '../pattern/convertion/week-day-names-conversion';
+// Upper bound on the calendar search before giving up (roughly ten years of
+// days). Reaching it means the expression can never match (e.g. `0 0 31 2 *`).
+const MAX_DAYS = 366 * 10;
 
-export class MatcherWalker{
+export class MatcherWalker {
   cronExpression: string;
   baseDate: Date;
-  pattern: any;
   expressions: number[][];
   timeMatcher: TimeMatcher;
   timezone?: string;
 
-  constructor(cronExpression: string, baseDate: Date, timezone?:string){
+  constructor(cronExpression: string, baseDate: Date, timezone?: string) {
     this.cronExpression = cronExpression;
     this.baseDate = baseDate;
     this.timeMatcher = new TimeMatcher(cronExpression, timezone);
     this.timezone = timezone;
-    
-    this.expressions = convertExpression(cronExpression)
+    this.expressions = convertExpression(cronExpression);
   }
 
-  isMatching(){
+  isMatching() {
     return this.timeMatcher.match(this.baseDate);
   }
 
-  matchIgnoringWeekday(localizedTime: LocalizedTime): boolean {
-    const parts = localizedTime.getParts();
-    const runOnSecond = this.expressions[0].indexOf(parts.second) !== -1;
-    const runOnMinute = this.expressions[1].indexOf(parts.minute) !== -1;
-    const runOnHour = this.expressions[2].indexOf(parts.hour) !== -1;
-    const runOnDay = this.expressions[3].indexOf(parts.day) !== -1;
-    const runOnMonth = this.expressions[4].indexOf(parts.month) !== -1;
-    
-    return runOnSecond && runOnMinute && runOnHour && runOnDay && runOnMonth;
+  /**
+   * Finds the next instant that satisfies the expression, strictly after the
+   * base date.
+   *
+   * Instead of scanning time tick by tick, it infers candidates directly from
+   * the cron fields: it walks the calendar day by day (a Y/M/D is the same
+   * weekday in every timezone), and on each day that satisfies month and
+   * day-of-month it tries the matching times in ascending order. Each candidate
+   * is materialized to a real instant in the timezone and confirmed with the
+   * real matcher, which both enforces the weekday constraint and rejects
+   * non-existent local times (the DST spring-forward gap) by construction.
+   */
+  matchNext(): LocalizedTime {
+    const months = this.expressions[4];
+    const days = this.expressions[3];
+
+    const baseMs = Math.floor(this.baseDate.getTime() / 1000) * 1000;
+    const baseParts = new LocalizedTime(new Date(baseMs), this.timezone).getParts();
+
+    let { year, month, day } = baseParts;
+
+    for (let i = 0; i < MAX_DAYS; i++) {
+      if (months.includes(month) && days.includes(day)) {
+        // On the base day the result must be strictly after the base instant;
+        // on later days any matching time of day qualifies.
+        const lowerBound = i === 0 ? baseParts : null;
+        const found = this.firstTimeOnDay(year, month, day, lowerBound, baseMs);
+        if (found !== null) {
+          return new LocalizedTime(new Date(found), this.timezone);
+        }
+      }
+
+      ({ year, month, day } = nextDay(year, month, day));
+    }
+
+    throw new Error('Could not find next matching date within reasonable time range');
   }
 
-  matchNext(){
-    const findNextDateIgnoringWeekday = () => {
-      const baseDate = new Date(this.baseDate.getTime());
-      baseDate.setMilliseconds(0);
-      const localTime = new LocalizedTime(baseDate, this.timezone);
-      const dateParts = localTime.getParts();
-      const date = new LocalizedTime(localTime.toDate(), this.timezone);
-      const seconds = this.expressions[0];
-      const nextSecond = availableValue(seconds, dateParts.second);
-      if(nextSecond){
-        date.set('second', nextSecond);
-        if(this.matchIgnoringWeekday(date)){
-          return date;
+  /**
+   * Smallest matching (hour, minute, second) on the given calendar day that
+   * materializes to a real instant strictly after the base. Returns the
+   * timestamp, or null when no matching time of day qualifies (for example the
+   * only matching wall-clock time falls in a DST spring-forward gap, or every
+   * match on the base day is at or before the base instant).
+   */
+  private firstTimeOnDay(
+    year: number,
+    month: number,
+    day: number,
+    lowerBound: { hour: number; minute: number; second: number } | null,
+    baseMs: number,
+  ): number | null {
+    const seconds = sortedAsc(this.expressions[0]);
+    const minutes = sortedAsc(this.expressions[1]);
+    const hours = sortedAsc(this.expressions[2]);
+
+    for (const hour of hours) {
+      if (lowerBound && hour < lowerBound.hour) continue;
+      for (const minute of minutes) {
+        if (lowerBound && hour === lowerBound.hour && minute < lowerBound.minute) continue;
+        for (const second of seconds) {
+          if (
+            lowerBound &&
+            hour === lowerBound.hour &&
+            minute === lowerBound.minute &&
+            second <= lowerBound.second
+          ) {
+            continue;
+          }
+
+          const ts = localTimeToTimestamp(
+            { year, month, day, hour, minute, second, milisecond: 0 },
+            this.timezone,
+          );
+
+          // The real matcher confirms every field on the actual instant. A
+          // wall-clock time that does not exist (DST gap) materializes to a
+          // different instant whose hour will not match, so it is rejected here.
+          if (ts > baseMs && this.timeMatcher.match(new Date(ts))) {
+            return ts;
+          }
         }
       }
-      date.set('second', seconds[0]);
-
-      const minutes = this.expressions[1];
-      const nextMinute = availableValue(minutes, dateParts.minute);
-      if(nextMinute){
-        date.set('minute', nextMinute);
-        if(this.matchIgnoringWeekday(date)){
-          return date;
-        }
-      }
-      date.set('minute',minutes[0]);
-
-      const hours = this.expressions[2];
-      const nextHour = availableValue(hours, dateParts.hour);
-      if(nextHour){
-        date.set('hour', nextHour);
-        if(this.matchIgnoringWeekday(date)){
-          return date;
-        }
-      }
-      date.set('hour', hours[0]);
-
-      const days = this.expressions[3];
-      const nextDay = availableValue(days, dateParts.day);
-      if(nextDay){
-        date.set('day', nextDay);
-        if(this.matchIgnoringWeekday(date)){
-          return date;
-        }
-      }
-      
-      date.set('day', days[0]);
-
-      const months = this.expressions[4];
-      const nextMonth = availableValue(months, dateParts.month);
-      
-      if(nextMonth){
-        date.set('month', nextMonth);
-        if(this.matchIgnoringWeekday(date)){
-          return date;
-        }
-      }
-
-      date.set('year', date.getParts().year + 1);
-      date.set('month', months[0]);
-
-      return date;
     }
 
-    const date = findNextDateIgnoringWeekday();
-    const weekdays = this.expressions[5];
-    const days = this.expressions[3];
-    
-    // Check if day-of-month is wildcard (contains all possible days 1-31)
-    const isDayWildcard = Array.from({ length: 31 }, (_, i) => i + 1).every(day => days.includes(day));
-    
-    if (isDayWildcard) {
-      // When day is wildcard, use OR logic: find next occurrence of weekday OR month
-      // Since we already found the right month, just find the next weekday in that month
-      let currentWeekday = parseInt(weekDayNamesConversion(date.getParts().weekday));
-      
-      while(!(weekdays.indexOf(currentWeekday) > -1)){
-        date.set('day', date.getParts().day + 1); 
-        currentWeekday = parseInt(weekDayNamesConversion(date.getParts().weekday));
-      }
-    } else {
-      // When day is specific, use AND logic: must match exact day AND weekday
-      // Keep searching until we find a date where the specified day falls on the specified weekday
-      const maxAttempts = 10 * 12; // 10 years * 12 months
-      let attempts = 0;
-      
-      while (attempts < maxAttempts) {
-        const currentWeekday = parseInt(weekDayNamesConversion(date.getParts().weekday));
-        
-        if (weekdays.indexOf(currentWeekday) > -1) {
-          // Found matching weekday for the specified day
-          break;
-        }
-        
-        // Move to next occurrence of the same day in the same month (next year if necessary)
-        const currentParts = date.getParts();
-        const nextMonth = availableValue(this.expressions[4], currentParts.month);
-        
-        if (nextMonth) {
-          date.set('month', nextMonth);
-        } else {
-          // Move to next year and reset to first allowed month
-          date.set('year', currentParts.year + 1);
-          date.set('month', this.expressions[4][0]);
-        }
-        
-        attempts++;
-      }
-      
-      if (attempts >= maxAttempts) {
-        throw new Error('Could not find next matching date within reasonable time range');
-      }
-    }
-    
-    return date;
+    return null;
   }
 }
 
-function availableValue(values: number[], currentValue: number) : number | false {
-  const availableValues = values.sort((a,b) => a - b).filter(s => s > currentValue);
-  if(availableValues.length > 0) return availableValues[0];
-  return false;
+function nextDay(year: number, month: number, day: number): { year: number; month: number; day: number } {
+  const d = new Date(Date.UTC(year, month - 1, day + 1));
+  return { year: d.getUTCFullYear(), month: d.getUTCMonth() + 1, day: d.getUTCDate() };
+}
+
+function sortedAsc(values: number[]): number[] {
+  return [...values].sort((a, b) => a - b);
 }

--- a/src/time/time-matcher.test.ts
+++ b/src/time/time-matcher.test.ts
@@ -291,5 +291,37 @@ describe('TimeMatcher', function() {
         const next = new TimeMatcher('* * * * *', 'America/New_York').getNextMatch(baseDate);
         assert.isTrue(next > baseDate, `expected future date, got ${next.toISOString()}`);
       })
+
+      it('should skip the day when the scheduled time falls in the spring-forward gap', ()=>{
+        // 2026-03-08 New York: 02:00-02:59 do not exist. "30 2 * * *" cannot run
+        // that day, so the next run is 02:30 the following day, not next year.
+        const next = new TimeMatcher('30 2 * * *', 'America/New_York').getNextMatch(new Date('2026-03-08T06:30:00Z'));
+        assert.equal(next.toISOString(), '2026-03-09T06:30:00.000Z');
+      })
+
+      it('should return the next occurrence for weekday-constrained schedules without overshooting', ()=>{
+        // base 2026-06-15 (Mon). Each weekday should resolve to its next
+        // occurrence within a week, never years ahead.
+        const base = new Date('2026-06-15T18:47:58Z');
+        const expected: Record<string, string> = {
+          '0 18 * * 3': '2026-06-17T22:00:00.000Z', // Wed
+          '0 18 * * 4': '2026-06-18T22:00:00.000Z', // Thu
+          '0 18 * * 0': '2026-06-21T22:00:00.000Z', // Sun
+        };
+        for (const [expr, want] of Object.entries(expected)) {
+          const next = new TimeMatcher(expr, 'America/New_York').getNextMatch(base);
+          assert.equal(next.toISOString(), want, `expr ${expr}`);
+        }
+      })
+
+      it('should jump across years for a Feb 29 schedule', ()=>{
+        const next = new TimeMatcher('0 0 29 2 *', 'Etc/UTC').getNextMatch(new Date('2026-03-01T00:00:00Z'));
+        assert.equal(next.toISOString(), '2028-02-29T00:00:00.000Z');
+      })
+
+      it('should skip months that do not have day 31', ()=>{
+        const next = new TimeMatcher('0 0 31 * *', 'Etc/UTC').getNextMatch(new Date('2026-04-15T00:00:00Z'));
+        assert.equal(next.toISOString(), '2026-05-31T00:00:00.000Z');
+      })
     })
 });

--- a/src/time/time-matcher.test.ts
+++ b/src/time/time-matcher.test.ts
@@ -323,5 +323,20 @@ describe('TimeMatcher', function() {
         const next = new TimeMatcher('0 0 31 * *', 'Etc/UTC').getNextMatch(new Date('2026-04-15T00:00:00Z'));
         assert.equal(next.toISOString(), '2026-05-31T00:00:00.000Z');
       })
+
+      it('should throw for an expression that can never match', ()=>{
+        // Feb 31 does not exist, so there is no next run.
+        assert.throws(
+          () => new TimeMatcher('0 0 31 2 *', 'Etc/UTC').getNextMatch(new Date('2026-01-01T00:00:00Z')),
+          'Could not find next matching date within reasonable time range'
+        );
+      })
+
+      it('should return the first occurrence of a time in the fall-back repeated hour', ()=>{
+        // 2026-11-01 New York: 01:00-01:59 happen twice (02:00 EDT -> 01:00 EST at 06:00Z).
+        // 01:30 daily resolves to the first occurrence (EDT), strictly after the base.
+        const next = new TimeMatcher('30 1 * * *', 'America/New_York').getNextMatch(new Date('2026-11-01T04:00:00Z'));
+        assert.equal(next.toISOString(), '2026-11-01T05:30:00.000Z');
+      })
     })
 });


### PR DESCRIPTION
Fixes #518.

## Problem
The field-by-field walker resolved a non-existent local time (DST spring-forward gap) forward and carried the drifted hour as it advanced day/month/year. `30 2 * * *` in `America/New_York` returned `2027-01-01` (the 02:xx hour does not exist on the transition day), and the final fallthrough returned the date without re-checking that it matched.

## Approach
Infer the next run from the fields instead of scanning time tick by tick:
- Walk the calendar day by day (a Y/M/D is the same weekday in every timezone).
- On each day that matches month and day-of-month, try the matching times in ascending order.
- Materialize each candidate to a real instant in the timezone and confirm it with the real matcher (`match()`).

The matcher enforces the weekday constraint and rejects DST-gap times by construction (a wall-clock that does not exist materializes to a different instant whose hour will not match), so a gap day is skipped to the next day where the time exists. No date is ever returned unverified. The search is bounded (~10 years of days) and throws for impossible expressions like `0 0 31 2 *`.

## Verified
- `30 2 * * *` gap day -> next day 02:30 (#518).
- Weekday table `0 18 * * 0..6` -> next occurrence, no 2032/2034 overshoot (#510).
- Feb 29 -> next leap year; day 31 skips 30-day months; every-second returns instantly (no brute force).
- All existing matcher/time-matcher tests stay green. Full suite: 236 tests. Lint clean.