### PR TITLE
fix: tolerate late heartbeats so drifting timers don't skip executions

### DIFF
--- a/src/scheduler/plan-beat.test.ts
+++ b/src/scheduler/plan-beat.test.ts
@@ -1,0 +1,99 @@
+import { assert } from 'chai';
+import { planBeat } from './plan-beat';
+import { TimeMatcher } from '../time/time-matcher';
+
+// A heartbeat timer is armed to fire at `expected`. Because long setTimeout
+// delays are imprecise (OS sleep, GC, throttling, clock drift) the callback can
+// land late. planBeat decides, given the slot we armed for (`expected`), when
+// the beat actually woke (`now`) and the configured tolerance, whether to run
+// the slot, report it as missed, or keep waiting. The tolerance is always
+// bounded by the gap to the next slot so a late run can never bleed into it.
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+
+// 6-field crons pinned to UTC so the expectations hold on any machine.
+const daily = new TimeMatcher('0 0 9 * * *', 'Etc/UTC');    // 09:00:00 every day
+const hourly = new TimeMatcher('0 0 * * * *', 'Etc/UTC');   // HH:00:00 every hour
+const everySecond = new TimeMatcher('* * * * * *', 'Etc/UTC');
+
+const nextMatchOf = (matcher: TimeMatcher) => (d: Date) => matcher.getNextMatch(d);
+const at = (iso: string) => new Date(iso);
+const times = (dates: Date[]) => dates.map(d => d.toISOString());
+
+describe('scheduler/plan-beat', function(){
+  it('runs the slot when the beat is exactly on time', function(){
+    const plan = planBeat(at('2026-06-16T09:00:00Z'), at('2026-06-16T09:00:00Z'), SECOND, nextMatchOf(daily));
+    assert.equal(plan.run?.toISOString(), '2026-06-16T09:00:00.000Z');
+    assert.deepEqual(times(plan.missed), []);
+    assert.equal(plan.next.toISOString(), '2026-06-17T09:00:00.000Z');
+  });
+
+  it('runs the slot when the beat is late but within tolerance', function(){
+    const plan = planBeat(at('2026-06-16T09:00:00Z'), at('2026-06-16T09:00:01.500Z'), 2 * SECOND, nextMatchOf(daily));
+    assert.equal(plan.run?.toISOString(), '2026-06-16T09:00:00.000Z');
+    assert.deepEqual(times(plan.missed), []);
+    assert.equal(plan.next.toISOString(), '2026-06-17T09:00:00.000Z');
+  });
+
+  it('reports the slot as missed (and does not run it) when the beat is late beyond tolerance', function(){
+    const plan = planBeat(at('2026-06-16T09:00:00Z'), at('2026-06-16T09:00:03Z'), SECOND, nextMatchOf(daily));
+    assert.isUndefined(plan.run);
+    assert.deepEqual(times(plan.missed), ['2026-06-16T09:00:00.000Z']);
+    assert.equal(plan.next.toISOString(), '2026-06-17T09:00:00.000Z');
+  });
+
+  it('waits without running when the beat fires early (clock moved back)', function(){
+    const plan = planBeat(at('2026-06-16T09:00:00Z'), at('2026-06-16T08:59:59Z'), SECOND, nextMatchOf(daily));
+    assert.isUndefined(plan.run);
+    assert.deepEqual(times(plan.missed), []);
+    assert.equal(plan.next.toISOString(), '2026-06-16T09:00:00.000Z');
+  });
+
+  it('caps the tolerance to the interval so a 1s cron never double-fires a slot', function(){
+    // Tolerance dwarfs the 1s gap. On time -> run this slot, expect the very
+    // next second, never re-run the same slot.
+    const plan = planBeat(at('2026-06-16T09:00:05Z'), at('2026-06-16T09:00:05Z'), 5 * SECOND, nextMatchOf(everySecond));
+    assert.equal(plan.run?.toISOString(), '2026-06-16T09:00:05.000Z');
+    assert.deepEqual(times(plan.missed), []);
+    assert.equal(plan.next.toISOString(), '2026-06-16T09:00:06.000Z');
+  });
+
+  it('on a 1s cron with a large tolerance, a 1.5s-late beat misses the old slot and runs the current one', function(){
+    const plan = planBeat(at('2026-06-16T09:00:05Z'), at('2026-06-16T09:00:06.500Z'), 5 * SECOND, nextMatchOf(everySecond));
+    assert.equal(plan.run?.toISOString(), '2026-06-16T09:00:06.000Z');
+    assert.deepEqual(times(plan.missed), ['2026-06-16T09:00:05.000Z']);
+    assert.equal(plan.next.toISOString(), '2026-06-16T09:00:07.000Z');
+  });
+
+  it('recovers an hourly slot that woke 40min late (tolerance 1.5h, capped to 1h)', function(){
+    const plan = planBeat(at('2026-06-16T10:00:00Z'), at('2026-06-16T10:40:00Z'), 90 * MINUTE, nextMatchOf(hourly));
+    assert.equal(plan.run?.toISOString(), '2026-06-16T10:00:00.000Z');
+    assert.deepEqual(times(plan.missed), []);
+    assert.equal(plan.next.toISOString(), '2026-06-16T11:00:00.000Z');
+  });
+
+  it('treats an hourly slot as missed once the next slot has arrived, then runs the next', function(){
+    const plan = planBeat(at('2026-06-16T10:00:00Z'), at('2026-06-16T11:00:01Z'), 90 * MINUTE, nextMatchOf(hourly));
+    assert.equal(plan.run?.toISOString(), '2026-06-16T11:00:00.000Z');
+    assert.deepEqual(times(plan.missed), ['2026-06-16T10:00:00.000Z']);
+    assert.equal(plan.next.toISOString(), '2026-06-16T12:00:00.000Z');
+  });
+
+  it('after a long block reports every superseded slot missed and runs only the most recent', function(){
+    // Blocked 2.5h on an hourly cron: 10:00 and 11:00 are gone, 12:00 still runnable.
+    const plan = planBeat(at('2026-06-16T10:00:00Z'), at('2026-06-16T12:30:00Z'), 90 * MINUTE, nextMatchOf(hourly));
+    assert.equal(plan.run?.toISOString(), '2026-06-16T12:00:00.000Z');
+    assert.deepEqual(times(plan.missed), ['2026-06-16T10:00:00.000Z', '2026-06-16T11:00:00.000Z']);
+    assert.equal(plan.next.toISOString(), '2026-06-16T13:00:00.000Z');
+  });
+
+  it('reports the slot missed but keeps waiting for the future next slot (late beyond tolerance, next not yet due)', function(){
+    // Hourly, woke 30s late with a 1s tolerance: 10:00 is missed, but 11:00 is
+    // still in the future so nothing runs and we wait for it.
+    const plan = planBeat(at('2026-06-16T10:00:00Z'), at('2026-06-16T10:00:30Z'), SECOND, nextMatchOf(hourly));
+    assert.isUndefined(plan.run);
+    assert.deepEqual(times(plan.missed), ['2026-06-16T10:00:00.000Z']);
+    assert.equal(plan.next.toISOString(), '2026-06-16T11:00:00.000Z');
+  });
+});

--- a/src/scheduler/plan-beat.ts
+++ b/src/scheduler/plan-beat.ts
@@ -1,0 +1,66 @@
+export type BeatPlan = {
+  /** Slots that were superseded and can no longer run, in chronological order. */
+  missed: Date[];
+  /** The slot to execute now, if the beat woke close enough to it. */
+  run?: Date;
+  /** The slot the next heartbeat should be armed for. */
+  next: Date;
+};
+
+/**
+ * Decides what a heartbeat should do when it wakes.
+ *
+ * A heartbeat is armed to fire at `expected`, but long `setTimeout` delays are
+ * imprecise (OS sleep, GC, throttling, clock drift), so the callback can land
+ * late. Given the slot we armed for, the instant the beat actually woke and the
+ * configured tolerance, this returns which slots are missed, which slot (if
+ * any) to run, and the slot to arm next.
+ *
+ * The effective tolerance is always bounded by the gap to the following slot:
+ * a slot stays runnable only until the next one is due. That keeps a late run
+ * from ever bleeding into the next slot, so even a tolerance far larger than a
+ * cron's interval can never run the same slot twice.
+ */
+export function planBeat(
+  expected: Date,
+  now: Date,
+  toleranceMs: number,
+  getNextMatch: (date: Date) => Date
+): BeatPlan {
+  const missed: Date[] = [];
+  let slot = expected;
+
+  while (true) {
+    const nowMs = now.getTime();
+    const slotMs = slot.getTime();
+
+    // Timer woke before this slot is due (e.g. the clock moved back). Nothing
+    // to run yet; keep waiting for it.
+    if (nowMs < slotMs) {
+      return { missed, next: slot };
+    }
+
+    const next = getNextMatch(slot);
+
+    // Defense in depth: getNextMatch must always advance. If it ever does not
+    // (e.g. a bug around a DST boundary), re-base from now to avoid looping
+    // forever.
+    if (next.getTime() <= slotMs) {
+      return { missed, next: getNextMatch(now) };
+    }
+
+    const gap = next.getTime() - slotMs;
+    const lateBy = nowMs - slotMs;
+
+    // Runnable while we are within tolerance AND the next slot has not arrived
+    // yet. The gap bound means a late run can never bleed into the following
+    // slot, so a tolerance larger than the interval can never run a slot twice.
+    if (lateBy <= toleranceMs && lateBy < gap) {
+      return { missed, run: slot, next };
+    }
+
+    // Too late for this slot. Report it missed and consider the next one.
+    missed.push(slot);
+    slot = next;
+  }
+}

--- a/src/scheduler/runner.test.ts
+++ b/src/scheduler/runner.test.ts
@@ -5,6 +5,16 @@ import { TimeMatcher } from '../time/time-matcher';
 import logger from '../logger';
 
 describe('scheduler/runner', function(){
+  it('defaults the missed-execution tolerance to 1000ms', function(){
+    const runner = createRunner(new TimeMatcher('* * * * * *'), 200);
+    assert.equal(runner.missedExecutionTolerance, 1000);
+  });
+
+  it('honours a custom missed-execution tolerance', function(){
+    const runner = createRunner(new TimeMatcher('* * * * * *'), 200, { missedExecutionTolerance: 0 });
+    assert.equal(runner.missedExecutionTolerance, 0);
+  });
+
   it('starts running',  async function(){
     const timeMatcher = new TimeMatcher('* * * * * *');
     const runner = createRunner(timeMatcher, 200);

--- a/src/scheduler/runner.ts
+++ b/src/scheduler/runner.ts
@@ -3,6 +3,15 @@ import logger, { Logger } from "../logger";
 import { TrackedPromise } from "../promise/tracked-promise";
 import { Execution } from "../tasks/scheduled-task";
 import { TimeMatcher } from "../time/time-matcher";
+import { planBeat } from "./plan-beat";
+
+/**
+ * How late, in milliseconds, a heartbeat may wake and still run the slot it was
+ * armed for instead of reporting it missed. Long setTimeout delays drift, so a
+ * small grace keeps daily/weekly schedules from being skipped. Always bounded
+ * by the gap to the next slot (see planBeat).
+ */
+const DEFAULT_MISSED_EXECUTION_TOLERANCE = 1000;
 
 type OnFn = (date: Date) => void | Promise<void>;
 type OnErrorHookFn = (date: Date, error: Error, execution: Execution) => void | Promise<void>;
@@ -19,6 +28,7 @@ export type RunnerOptions = {
   timezone?: string,
   maxExecutions?: number,
   maxRandomDelay?: number,
+  missedExecutionTolerance?: number,
   logger?: Logger,
   onMissedExecution?: OnFn,
   onOverlap?: OnFn,
@@ -34,6 +44,7 @@ export class Runner {
   noOverlap: boolean;
   maxExecutions?: number;
   maxRandomDelay: number;
+  missedExecutionTolerance: number;
   runCount: number;
 
   running: boolean;
@@ -53,6 +64,7 @@ export class Runner {
       this.noOverlap = options == undefined || options.noOverlap === undefined ? false : options.noOverlap;
       this.maxExecutions = options?.maxExecutions;
       this.maxRandomDelay = options?.maxRandomDelay || 0;
+      this.missedExecutionTolerance = options?.missedExecutionTolerance ?? DEFAULT_MISSED_EXECUTION_TOLERANCE;
       this.logger = options?.logger || logger;
 
       this.onMissedExecution = options?.onMissedExecution || emptyOnFn;
@@ -75,12 +87,13 @@ export class Runner {
   start() {
     this.running = true;
     let lastExecution: TrackedPromise<any>;
-    let expectedNextExecution: Date;
+    // The slot the current heartbeat is armed for.
+    let expectedNextExecution: Date = this.timeMatcher.getNextMatch(nowWithoutMs());
 
-    const scheduleNextHeartBeat = (currentDate: Date) => {
+    const armHeartBeat = () => {
       if (this.running) {
-          clearTimeout(this.heartBeatTimeout);
-          this.heartBeatTimeout = setTimeout(heartBeat, getDelay(this.timeMatcher, currentDate));
+        clearTimeout(this.heartBeatTimeout);
+        this.heartBeatTimeout = setTimeout(heartBeat, getDelay(expectedNextExecution));
       }
     };
 
@@ -90,7 +103,7 @@ export class Runner {
           id: createID('exec'),
           reason: 'scheduled'
         }
-        
+
         const shouldExecute = await this.beforeRun(date, execution);
         const randomDelay = Math.floor(Math.random() * this.maxRandomDelay);
 
@@ -104,7 +117,7 @@ export class Runner {
               execution.finishedAt = new Date();
               execution.result = result;
               this.onFinished(date, execution);
-  
+
               if( this.maxExecutions && this.runCount >= this.maxExecutions){
                 this.onMaxExecutions(date);
                 this.stop();
@@ -117,70 +130,58 @@ export class Runner {
 
             resolve(true);
           }, randomDelay);
+        } else {
+          resolve(true);
         }
       })
     }
 
-    const checkAndRun = (date: Date): TrackedPromise<any> => {
-      return new TrackedPromise(async (resolve, reject) => {
-      try {
-        if(this.timeMatcher.match(date)){
-          await runTask(date);
-        }
-        resolve(true);
-       } catch(err) {
-         reject(err)
-       }
-      });
-    }
-
     const heartBeat = async () => {
-      // get next is ignoring millisecond setting to zero to get a closer time here.
-      const currentDate = nowWithoutMs()
+      // ignore milliseconds so the comparison against the matched slot is exact.
+      const currentDate = nowWithoutMs();
 
-      // blocking IO detection
-      if(expectedNextExecution && expectedNextExecution.getTime() < currentDate.getTime()){
-        while(expectedNextExecution.getTime() < currentDate.getTime()){
-          const nextMatch = this.timeMatcher.getNextMatch(expectedNextExecution);
-          // Defense in depth: getNextMatch must always move forward. If it ever
-          // returns a date that does not advance (e.g. a bug around a DST
-          // boundary), re-base from the current date instead of looping forever.
-          if(nextMatch.getTime() <= expectedNextExecution.getTime()){
-            this.logger.error(`getNextMatch did not advance past ${expectedNextExecution}; aborting missed-execution catch-up to avoid an infinite loop.`);
-            expectedNextExecution = this.timeMatcher.getNextMatch(currentDate);
-            break;
+      const plan = planBeat(
+        expectedNextExecution,
+        currentDate,
+        this.missedExecutionTolerance,
+        (date: Date) => this.timeMatcher.getNextMatch(date)
+      );
+
+      expectedNextExecution = plan.next;
+
+      // Report every superseded slot. The "missed execution" warning is emitted
+      // by the task's onMissedExecution handler so it can honour listener-based
+      // and explicit suppression and use the task's logger.
+      for (const missedSlot of plan.missed) {
+        runAsync(this.onMissedExecution, missedSlot, this.onErrorFallback);
+      }
+
+      if (plan.run) {
+        // overlap prevention
+        if (lastExecution && lastExecution.getState() === 'pending') {
+          runAsync(this.onOverlap, plan.run, this.onErrorFallback);
+          if (this.noOverlap) {
+            this.logger.warn('task still running, new execution blocked by overlap prevention!');
+            armHeartBeat();
+            return;
           }
-          expectedNextExecution = nextMatch;
-          // The "missed execution" warning is emitted by the task's
-          // onMissedExecution handler so it can honour listener-based and
-          // explicit suppression and use the task's logger.
-          runAsync(this.onMissedExecution, expectedNextExecution, this.onErrorFallback);
         }
+
+        const slot = plan.run;
+        lastExecution = new TrackedPromise(async (resolve, reject) => {
+          try {
+            await runTask(slot);
+            resolve(true);
+          } catch (err) {
+            reject(err);
+          }
+        });
       }
 
-      // overlap prevention
-      if(lastExecution && lastExecution.getState() === 'pending'){
-        runAsync(this.onOverlap, currentDate, this.onErrorFallback);
-        if(this.noOverlap){
-          this.logger.warn('task still running, new execution blocked by overlap prevention!');
-          expectedNextExecution = this.timeMatcher.getNextMatch(currentDate);
-          scheduleNextHeartBeat(currentDate);
-          return;
-        }
-      }
-
-      // execute the task
-      lastExecution = checkAndRun(currentDate);
-
-      expectedNextExecution = this.timeMatcher.getNextMatch(currentDate);
-
-      // schedule the next run
-      scheduleNextHeartBeat(currentDate);
+      armHeartBeat();
     }
-    
-    this.heartBeatTimeout = setTimeout(()=>{
-      heartBeat();
-    }, getDelay(this.timeMatcher, nowWithoutMs()));
+
+    armHeartBeat();
   }
 
   nextRun(){
@@ -235,9 +236,8 @@ async function runAsync(fn: OnFn, date: Date, onError: OnErrorFn){
   }
 }
 
-function getDelay(timeMatcher: TimeMatcher, currentDate: Date) {
+function getDelay(nextRun: Date) {
   const maxDelay = 86400000;
-  const nextRun = timeMatcher.getNextMatch(currentDate);
   // must use now for calculating the delay, it avoids miliseconds addition to the timeout.
   const now = new Date();
   const delay = nextRun.getTime() - now.getTime();

--- a/src/tasks/inline-scheduled-task.ts
+++ b/src/tasks/inline-scheduled-task.ts
@@ -39,6 +39,7 @@ export class InlineScheduledTask implements ScheduledTask {
       noOverlap: options?.noOverlap,
       maxExecutions: options?.maxExecutions,
       maxRandomDelay: options?.maxRandomDelay,
+      missedExecutionTolerance: options?.missedExecutionTolerance,
       logger: this.logger,
       beforeRun: (date: Date, execution: Execution) => {
         if(execution.reason === 'scheduled'){

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -47,6 +47,14 @@ export type TaskOptions = {
    */
   suppressMissedWarning?: boolean,
   /**
+   * How late, in milliseconds, a scheduled execution may wake and still run
+   * instead of being reported as missed. Long timers drift (OS sleep, GC,
+   * throttling, clock skew), which on daily/weekly schedules can skip the run
+   * entirely. The tolerance is always capped to the gap to the next execution,
+   * so it can never run a slot twice. Defaults to 1000.
+   */
+  missedExecutionTolerance?: number,
+  /**
    * Timeout in milliseconds for `execute()` on background tasks. When set,
    * `execute()` rejects with "Execution timeout exceeded" if the task has not
    * reported back in time. Defaults to no timeout (waits for the task to


### PR DESCRIPTION
Closes #485

## Problem

Long `setTimeout` delays drift (OS sleep, GC, throttling, clock skew). On daily/weekly schedules a heartbeat could wake a few seconds late, fail the exact-second `match()`, **skip the execution** and emit a spurious `missed execution` warning. The miss rate scaled with timer duration, so daily/weekly jobs were hit hardest.

Reported in #485 (with a strong inspector-level diagnosis showing the timer fires but the callback is skipped, miss rate correlating with timer duration) and the WSL2 clock-drift reports in #475.

## Fix

New configurable option `missedExecutionTolerance` (ms, **default 1000**): a heartbeat that wakes within the tolerance of the slot it was armed for runs that slot instead of reporting it missed.

The tolerance is **always bounded by the gap to the next slot**, so:
- a late run can never bleed into the following slot, and
- a tolerance larger than the cron interval can never run a slot twice.

The run / miss / wait decision is extracted into a pure `planBeat` function with exhaustive scenario tests (on-time, late-within-tolerance, late-beyond-tolerance, early fire, the 1s-cron cap, hourly recovery, the superseded-slot boundary, long-block catch-up). The runner now drives off the slot it armed for rather than re-matching the late wall clock.

The existing "missed execution" suppression (`suppressMissedWarning` and the auto-suppress when an `execution:missed` listener is attached) is unchanged.

## Notes for #475 (WSL2)

That one is environmental: the WSL2 guest clock desyncs from the Windows host (microsoft/WSL#10006). The grace window softens minor drift, but a large clock jump is still a genuine miss. The confirmed user fix is an NTP/`hwclock` resync.