### PR TITLE
fix: surface real background task start errors and stop orphaned daemons

### DIFF
--- a/src/node-cron.test.ts
+++ b/src/node-cron.test.ts
@@ -127,6 +127,36 @@ describe('node-cron', function() {
             assert.isDefined(task);
             await task.destroy();
         });
+
+        it('logs a background task start failure instead of throwing unhandled', async function() {
+            const errors: any[] = [];
+            const fakeLogger: any = { error: (...a: any[]) => errors.push(a), warn(){}, info(){}, debug(){} };
+
+            vi.mocked(fork).mockImplementation(() => {
+              const child: any = new EventEmitter();
+              child.killed = false;
+              child.kill = () => { child.killed = true; };
+              child.send = () => {
+                queueMicrotask(() => child.emit('message', {
+                  event: 'daemon:error',
+                  jsonError: JSON.stringify({ name: 'Error', message: 'load failed in child' })
+                }));
+                return true;
+              };
+              return child;
+            });
+
+            // schedule() auto-starts and does not return the promise; the failure
+            // must be routed to the logger, not surface as an unhandled rejection.
+            const task = cron.schedule('* * * * *', '../test-assets/dummy-task.js', { logger: fakeLogger });
+            await wait(200);
+
+            assert.isTrue(
+              errors.some(e => JSON.stringify(e).includes('load failed in child')),
+              'the start failure should be logged via the configured logger'
+            );
+            await task.destroy();
+        });
     });
     
     describe('validate', function() {

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -11,6 +11,7 @@
 import { InlineScheduledTask } from "./tasks/inline-scheduled-task";
 import { ScheduledTask, TaskFn, TaskOptions } from "./tasks/scheduled-task";
 import { TaskRegistry } from "./task-registry";
+import logger from "./logger";
 
 import validation from "./pattern/validation/pattern-validation";
 import BackgroundScheduledTask from "./tasks/background-scheduled-task/background-scheduled-task";
@@ -44,7 +45,15 @@ const registry = new TaskRegistry();
  */
 export function schedule(expression:string, func: TaskFn | string, options?: TaskOptions): ScheduledTask {
     const task = createTask(expression, func, options);
-    task.start();
+    // Background tasks start asynchronously and can fail (e.g. the task file
+    // cannot be loaded). Route that failure to the logger instead of leaving it
+    // as an unhandled rejection.
+    const started = task.start();
+    if (started && typeof (started as Promise<void>).catch === 'function') {
+      (started as Promise<void>).catch((error: any) => {
+        (options?.logger || logger).error(`Failed to start scheduled task: ${error?.message ?? error}`);
+      });
+    }
     return task;
 }
 

--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -165,18 +165,83 @@ describe('BackgroundScheduledTask', function() {
     });
 
     it('fails on start timeout', async function(){
-      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
-      fakeChildProcess = Object.assign(new EventEmitter(), {
-        send: sinon.stub(),
-        kill: sinon.stub()
-      });
+      // fakeChildProcess.send is a no-op stub, so the daemon never reports back.
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', { startTimeout: 40 });
 
       try {
         await task.start();
         assert.fail("should fail before")
       } catch (error: any){
-        assert.equal(error.message, 'Start operation timed out');
+        assert.match(error.message, /Start operation timed out/);
       }
+    });
+
+    it('honours a custom startTimeout', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', { startTimeout: 40 });
+
+      const startedAt = Date.now();
+      try {
+        await task.start();
+        assert.fail("should time out");
+      } catch (error: any){
+        assert.isBelow(Date.now() - startedAt, 1000, 'should reject well before the 5s default');
+        assert.match(error.message, /Start operation timed out/);
+      }
+    });
+
+    it('explains likely causes in the start timeout error', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', { startTimeout: 40 });
+
+      try {
+        await task.start();
+        assert.fail("should time out");
+      } catch (error: any){
+        // actionable hint, not just "timed out"
+        assert.match(error.message, /load|import|startTimeout/i);
+      }
+    });
+
+    it('rejects start with the real cause when the daemon reports a load error', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', { startTimeout: 200 });
+
+      fakeChildProcess.send.callsFake(()=>{
+        fakeChildProcess.emit('message', {
+          event: 'daemon:error',
+          jsonError: JSON.stringify({ name: 'SyntaxError', message: 'TypeScript enum is not supported in strip-only mode' })
+        });
+      });
+
+      try {
+        await task.start();
+        assert.fail("should reject with the real cause");
+      } catch (error: any){
+        assert.equal(error.message, 'TypeScript enum is not supported in strip-only mode');
+      }
+    });
+
+    it('kills the daemon and clears the fork on a failed start (no orphan)', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', { startTimeout: 200 });
+
+      fakeChildProcess.send.callsFake(()=>{
+        fakeChildProcess.emit('message', {
+          event: 'daemon:error',
+          jsonError: JSON.stringify({ name: 'Error', message: 'boom' })
+        });
+      });
+
+      try { await task.start(); } catch { /* expected */ }
+
+      assert.isTrue(fakeChildProcess.kill.called, 'the daemon must be killed so it cannot keep running');
+      assert.isUndefined(task.forkProcess, 'forkProcess must be cleared after a failed start');
+    });
+
+    it('kills the daemon when the start times out (no orphan)', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', { startTimeout: 40 });
+
+      try { await task.start(); } catch { /* expected */ }
+
+      assert.isTrue(fakeChildProcess.kill.called, 'a daemon that started late must not be left running');
+      assert.isUndefined(task.forkProcess, 'forkProcess must be cleared after a timed-out start');
     });
   });
 

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -65,29 +65,49 @@ class BackgroundScheduledTask implements ScheduledTask{
       if (this.forkProcess) {
         return resolve(undefined);
       }
-      
+
+      const startTimeout = this.options?.startTimeout ?? 5000;
+
+      // Any failure to start must also tear down the daemon. Otherwise a daemon
+      // that loads slowly (past the timeout) stays alive and keeps running the
+      // schedule on its own, leading to orphaned/duplicate executions.
+      const failStart = (error: Error) => {
+        clearTimeout(timeout);
+        this.forkProcess?.kill();
+        this.forkProcess = undefined;
+        reject(error);
+      };
+
       const timeout = setTimeout(() => {
-        reject(new Error('Start operation timed out'));
-      }, 5000);
-      
+        failStart(new Error(
+          `Start operation timed out after ${startTimeout}ms. The background task file may have failed to load or taken too long to import; ` +
+          `verify it runs on its own and consider increasing the \`startTimeout\` option.`
+        ));
+      }, startTimeout);
+
       try {
         this.forkProcess = fork(daemonPath);
-        
+
         this.forkProcess.on('error', (err) => {
-          clearTimeout(timeout);
-          reject(new Error(`Error on daemon: ${err.message}`));
+          failStart(new Error(`Error on daemon: ${err.message}`));
         });
-        
+
         this.forkProcess.on('exit', (code, signal) => {
           if (code !== 0 && signal !== 'SIGTERM') {
             const erro = new Error(`node-cron daemon exited with code ${code || signal}`)
             this.logger.error(erro);
-            clearTimeout(timeout);
-            reject(erro)
+            failStart(erro);
           }
         });
-        
+
         this.forkProcess.on('message', (message: any) => {
+          if (message.event === 'daemon:error') {
+            // The daemon could not load/start the task file. Reject with the
+            // real cause so the user sees what actually went wrong.
+            failStart(message.jsonError ? deserializeError(message.jsonError) : new Error('Background task failed to start'));
+            return;
+          }
+
           if (message.jsonError) {
             if (message.context?.execution) {
               message.context.execution.error = deserializeError(message.jsonError);
@@ -123,7 +143,7 @@ class BackgroundScheduledTask implements ScheduledTask{
           options: serializableOptions(this.options)
         });
       } catch (error) {
-        reject(error);
+        failStart(error as Error);
       }
     });
   }

--- a/src/tasks/background-scheduled-task/daemon.test.ts
+++ b/src/tasks/background-scheduled-task/daemon.test.ts
@@ -242,6 +242,33 @@ describe('daemon - register', function () {
     assert.equal(JSON.parse(failedEvent.jsonError).extra, 'extra');
     task.destroy();
   });
+
+  it('forwards the real load error to the parent instead of crashing', async function () {
+    messages = [];
+    const message = {
+      command: 'task:start',
+      path: '/does/not/exist-484-xyz.ts',
+      cron: '* * * * * *',
+      options: {},
+    };
+
+    bind();
+    const onMessage = listeners.find(l => l.event === 'message');
+
+    // The handler must not throw/reject: a failed import is reported, not crashed.
+    let threw = false;
+    try {
+      await onMessage.fn(message);
+    } catch {
+      threw = true;
+    }
+    assert.isFalse(threw, 'daemon should not throw when the task fails to load');
+
+    const errorMessage = messages.find(m => m.event === 'daemon:error');
+    assert.isDefined(errorMessage, 'daemon should send a daemon:error message');
+    assert.isDefined(errorMessage.jsonError, 'the real error should be serialized');
+    assert.match(JSON.parse(errorMessage.jsonError).message, /exist-484-xyz|find|module/i);
+  });
 });
 
 function blockIO(ms: number) {

--- a/src/tasks/background-scheduled-task/daemon.ts
+++ b/src/tasks/background-scheduled-task/daemon.ts
@@ -4,24 +4,7 @@ import { InlineScheduledTask } from "../inline-scheduled-task";
 import { ScheduledTask, TaskContext, TaskEvent } from "../scheduled-task";
 
 export async function startDaemon(message: any): Promise<ScheduledTask> {
-    let script;
-    /* HACK: this hack was added because CJS vs ESM issues in combination with Windows vs Linux issues:
-     *
-     * 1. On CJS, require should always receive a path
-     * 2. On ESM + Windows, import should always receive a file URL
-     * 3. On ESM + Linux, import can receive either a URL or a Path
-     *
-     * Because we need esModuleInterop: true on our TS config file, it's almost impossible
-     * to determine during runtime whether we are running in CJS or ESM.
-     * This try-catch ensures we will be able to import or require in any environment.
-     * 
-     * If both fail, then the path cannot be found.
-     */
-    try {
-      script = await import(message.path);
-    } catch {
-      script = await import(fileURLToPath(message.path))
-    }
+    const script = await importTaskModule(message.path);
 
     // The inline task in the daemon stays silent; the parent process logs from
     // the forwarded events using the user's configured logger.
@@ -46,9 +29,33 @@ export async function startDaemon(message: any): Promise<ScheduledTask> {
     task.on('execution:maxReached', (context => sendEvent('execution:maxReached', context)));
 
     if (process.send) process.send({ event: 'daemon:started' });
-    
+
     task.start();
     return task;
+}
+
+/* Loading the task file is the one step that legitimately fails at runtime
+ * (missing file, a runtime that cannot run the file, unsupported TS syntax in
+ * strip-only mode, etc.). We must surface the real reason rather than crash.
+ *
+ * HACK: CJS vs ESM combined with Windows vs Linux path/URL rules:
+ *   1. On CJS, require should always receive a path
+ *   2. On ESM + Windows, import should always receive a file URL
+ *   3. On ESM + Linux, import can receive either a URL or a path
+ * We cannot reliably tell at runtime which we are in, so we try the path first
+ * and fall back to a file URL. If both fail we throw the FIRST error, which is
+ * the meaningful one (the fallback usually fails with an unrelated URL error).
+ */
+async function importTaskModule(path: string) {
+  try {
+    return await import(path);
+  } catch (firstError) {
+    try {
+      return await import(fileURLToPath(path));
+    } catch {
+      throw firstError;
+    }
+  }
 }
 
 function sendEvent(event: TaskEvent, context: TaskContext) {
@@ -112,7 +119,13 @@ export function bind(){
   process.on('message', async (message: any) => {
     switch(message.command){
     case 'task:start':
-        task = await startDaemon(message);
+        try {
+          task = await startDaemon(message);
+        } catch (error: any) {
+          // Report the failure to the parent so it can reject start() with the
+          // real cause, instead of crashing the daemon with an opaque exit.
+          if (process.send) process.send({ event: 'daemon:error', jsonError: serializeError(error) });
+        }
         return task;
     case 'task:stop':
       if(task) task.stop();

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -60,7 +60,15 @@ export type TaskOptions = {
    * reported back in time. Defaults to no timeout (waits for the task to
    * finish or fail). Has no effect on inline tasks.
    */
-  executeTimeout?: number
+  executeTimeout?: number,
+  /**
+   * Timeout in milliseconds for a background task's initial start handshake
+   * (forking the daemon and importing the task file). If the task file is large
+   * or transpiled on load, the default may be too short and `start()` rejects
+   * with "Start operation timed out"; increase it in that case. Defaults to
+   * 5000. Has no effect on inline tasks.
+   */
+  startTimeout?: number
 }
 
 export type Execution = {


### PR DESCRIPTION
Closes #484

## Problem

Starting a background task forks a daemon that imports the task file. Three problems made failures opaque and unsafe, reproduced against the real build on Node 24:

1. **Real load error hidden.** A failed import (missing file; a runtime that cannot run the file; or unsupported TypeScript syntax in Node's strip-only mode, e.g. `enum`/`namespace`/decorators) crashed the daemon. The parent only saw `Start operation timed out` or `node-cron daemon exited with code 1`; the actual cause (`TypeScript enum is not supported in strip-only mode`, `Cannot find module ...`) only reached the child's stderr. This matches @rudewalt (Node 24) and @merencia's loader hypothesis.
2. **Hard-coded 5s start timeout.** A task file that loads slowly (transpile, large dependency graph) could not be accommodated. This matches the OP and @jsa4000.
3. **Orphaned daemons.** On a failed/timed-out start the daemon was never killed, so a daemon that finished loading *after* the timeout kept running the schedule on its own. With retries/nodemon this produced "so many task been executed" (@jsa4000).

## Fix

- The daemon catches load/start failures and forwards the real error to the parent (`daemon:error`); `start()` rejects with the actual cause.
- New **`startTimeout`** option (ms, default 5000) and an actionable timeout message.
- Any failed start now **kills the daemon and clears the fork** (no orphans/duplicates).
- `schedule()` routes a background task's auto-start failure to the configured logger instead of leaving an unhandled rejection (the OP's `UnhandledRejection`).

## Tests

Deterministic, written first (red), then made green:
- daemon forwards the real load error instead of crashing;
- parent rejects `start()` with the real cause on `daemon:error`;
- parent kills the daemon and clears the fork on a failed start, and on a timeout (no orphan);
- `startTimeout` is honoured and the timeout message is actionable;
- `schedule()` logs a background start failure instead of throwing unhandled.

End-to-end verified against the built `dist` (enum `.ts` -> real error surfaced; slow load + short `startTimeout` -> daemon killed, no orphan executions).

## Honest scope note

node-cron cannot transpile TypeScript for you: on a strip-only runtime an `enum` still will not run. This change makes the failure **diagnosable** (you see the exact reason and how to fix it: `--experimental-transform-types`, tsx/ts-node, or a compiled `.js`) and stops the orphaned executions. It does not magically run unsupported syntax.