### PR TITLE
docs: mention the L (last day of month) token in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Need a task that doesn't start immediately? Use `cron.createTask(...)` and call 
 | second       | 0-59 (optional)                   |
 | minute       | 0-59                              |
 | hour         | 0-23                              |
-| day of month | 1-31                              |
+| day of month | 1-31 (or `L` for the last day)    |
 | month        | 1-12 (or names)                   |
 | day of week  | 0-7 (or names, 0 or 7 are sunday) |
 
-See the [Cron Syntax guide](https://nodecron.com/cron-syntax) for ranges, steps, lists, and named months/weekdays.
+See the [Cron Syntax guide](https://nodecron.com/cron-syntax) for ranges, steps, lists, named months/weekdays, and the `L` (last day of month) token.
 
 ## Options
 


### PR DESCRIPTION
Reflects the day-of-month `L` support added in #396.

- Notes `L` (last day of the month) in the cron values table.
- Mentions the `L` token in the link to the Cron Syntax guide.

The full behavior (leap-year aware, combinable as `15,L`, valid only in the day-of-month field) is documented on the site in node-cron-site#16.