### PR TITLE
chore: support Node.js >= 20 (not just 20.11) and test it in CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,7 +32,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ["20", "22", "24"]
+        node-version: ["18", "20", "22", "24"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,14 +30,18 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-24.04-arm
 
+    strategy:
+      matrix:
+        node-version: ["20", "22", "24"]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
         run: npm ci
@@ -46,6 +50,7 @@ jobs:
         run: node --run test
 
       - name: Coveralls
+        if: matrix.node-version == '22'
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm ci
 
       - name: Run unit tests
-        run: node --run test
+        run: npm test
 
       - name: Coveralls
         if: matrix.node-version == '22'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,7 +32,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ["18", "20", "22", "24"]
+        node-version: ["20", "22", "24"]
 
     steps:
       - name: Checkout

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepack": "npm run build"
   },
   "engines": {
-    "node": ">=20.11"
+    "node": ">=20"
   },
   "files": [
     "dist/"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -46,8 +46,7 @@ const cjsReplace = () =>
     preventAssignment: true,
     delimiters: ["", ""],
     values: {
-      "import.meta.dirname": "__dirname",
-      "import.meta.filename": "__filename",
+      "fileURLToPath(import.meta.url)": "__filename",
       "'daemon.js'": "'daemon.cjs'",
     },
   });

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -18,7 +18,12 @@ import BackgroundScheduledTask from "./tasks/background-scheduled-task/backgroun
 import { setLogger } from "./logger";
 
 import path from "path";
-import { pathToFileURL } from "url";
+import { pathToFileURL, fileURLToPath } from "url";
+
+// fileURLToPath(import.meta.url) works on every ESM-capable Node (unlike
+// import.meta.filename, which requires >= 20.11). The CJS build rewrites it to
+// __filename.
+const moduleFilename = fileURLToPath(import.meta.url);
 
 /**
  * The central registry that maintains all scheduled tasks.
@@ -97,7 +102,7 @@ export function solvePath(filePath: string): string {
   const stackLines = new Error().stack?.split('\n');
   if(stackLines){
     stackLines?.shift();
-    const callerLine = stackLines?.find((line) => { return line.indexOf(import.meta.filename) === -1; });
+    const callerLine = stackLines?.find((line) => { return line.indexOf(moduleFilename) === -1; });
     const match = callerLine?.match(/(file:\/\/)?(((\/?)(\w:))?([/\\].+)):\d+:\d+/);
    
     if (match) {

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -1,4 +1,5 @@
-import { resolve as resolvePath } from 'path';
+import { dirname, resolve as resolvePath } from 'path';
+import { fileURLToPath } from 'url';
 import { fork, ChildProcess} from 'child_process';
 
 import { Execution, ScheduledTask, TaskContext, TaskEvent, TaskOptions } from '../scheduled-task';
@@ -9,7 +10,10 @@ import { LocalizedTime } from '../../time/localized-time';
 import logger, { Logger } from '../../logger';
 import { TimeMatcher } from '../../time/time-matcher';
 
-const daemonPath = resolvePath(import.meta.dirname, 'daemon.js');
+// fileURLToPath(import.meta.url) works on every ESM-capable Node (unlike
+// import.meta.dirname, which requires >= 20.11). The CJS build rewrites it to
+// __filename.
+const daemonPath = resolvePath(dirname(fileURLToPath(import.meta.url)), 'daemon.js');
 
 class TaskEmitter extends EventEmitter{}
 


### PR DESCRIPTION
Prep for the 4.3.0 release: make the supported Node.js floor honest and tested.

## Why

The ESM build only ran on Node **>= 20.11** because of `import.meta.dirname` / `import.meta.filename` (added in 20.11). That excluded early Node 20 LTS (20.0–20.10) for no real reason.

## Changes

- Replace `import.meta.dirname` / `import.meta.filename` with `fileURLToPath(import.meta.url)` (works on any ESM-capable Node). The CJS build's replace step rewrites it to `__filename`, so both builds keep working. Verified by running a real background task on both the ESM and CJS builds.
- Lower `engines.node` to `>=20`.
- Run the unit tests on Node **20, 22 and 24** (previously only 22), so the supported range is actually exercised. Coveralls still uploads once (from the 22 job).

The next real floor below this is the timezone code's `Intl` `timeZoneName: 'shortOffset'` (~Node 18, now EOL), so >=20 LTS is the sensible, honest floor.

Full suite green (260 tests), build and lint pass.

> Note: this PR touches `.github/workflows/`, so it needs to be merged via the GitHub UI (the CLI token lacks the `workflow` scope).