### PR TITLE
chore: release 4.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-cron",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-cron",
-      "version": "4.2.1",
+      "version": "4.3.0",
       "license": "ISC",
       "devDependencies": {
         "@eslint/js": "^9.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cron",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "description": "A Lightweight Task Scheduler for Node.js",
   "author": "Lucas Merencia",
   "license": "ISC",


### PR DESCRIPTION
Version bump to **4.3.0** (minor: additive features + fixes, no breaking changes). Notes below are ready to paste into the GitHub release.

---

## node-cron 4.3.0

### Features
- **`L` (last day of month)** in the day-of-month field — e.g. `0 0 12 L * *`, leap-year aware, and combinable with explicit days (`15,L`). (#396, closes #147 — thanks @antonidasyang)
- **`missedExecutionTolerance`** option (ms, default `1000`): a heartbeat that wakes a little late still runs its slot instead of being reported as missed. Always capped to the gap to the next slot. (#534, closes #485)
- **`startTimeout`** option for background tasks (ms, default `5000`). (#535)

### Fixes
- Rewrote `getNextMatch` for correctness around DST: no more ~1-year overshoot when a daily time falls in the spring-forward gap. (#533, closes #518)
- Background task start failures now reject with the **real cause** (e.g. unsupported TypeScript syntax, missing file) instead of an opaque timeout, and a failed/timed-out start no longer leaves an **orphaned daemon** running. (#535, closes #484)
- Long-timer drift no longer produces spurious "missed execution" warnings / skipped runs on daily/weekly schedules. (#534, closes #485)

### Compatibility
- Supported Node.js is now **>= 20** (was >= 20.11), tested on Node 20, 22 and 24. (#538)

### Docs
- README refreshed for v4; API reference documents `getTasks`/`getTask`. (#536, site)

### Behavior note
- `missedExecutionTolerance` defaults to `1000`ms, so a scheduled run that wakes up to ~1s late now **executes** instead of emitting `execution:missed`. This is a bug-fix improvement, not an API break.