### PR TITLE
feat: utcOffset (fixed numeric offset, no DST)

### DIFF
--- a/src/node-cron.test.ts
+++ b/src/node-cron.test.ts
@@ -239,6 +239,18 @@ describe('node-cron', function() {
         assert.isDefined(task.id);
         assert.equal(task.getStatus(), 'stopped');
       });
+
+      it('accepts a utcOffset', function(){
+        const task = cron.createTask('* * * * *', () => {}, { utcOffset: -180 }) as InlineScheduledTask;
+        assert.equal(task.utcOffset, -180);
+      });
+
+      it('rejects timezone and utcOffset together', function(){
+        assert.throws(
+          () => cron.createTask('* * * * *', () => {}, { timezone: 'UTC', utcOffset: 0 }),
+          'Provide either `timezone` or `utcOffset`, not both.'
+        );
+      });
     })
 
      describe('solvePath', function(){

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -72,6 +72,10 @@ export function schedule(expression:string, func: TaskFn | string, options?: Tas
  * @private
  */
 export function createTask(expression: string, func: TaskFn | string, options?: TaskOptions): ScheduledTask {
+    if (options?.timezone != null && options?.utcOffset != null) {
+      throw new Error('Provide either `timezone` or `utcOffset`, not both.');
+    }
+
     let task: ScheduledTask;
     if(func instanceof Function){
       task = new InlineScheduledTask(expression, func, options);

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -58,7 +58,7 @@ class BackgroundScheduledTask implements ScheduledTask{
 
   getNextRun(): Date | null {
     if ( this.stateMachine.state !== 'stopped'){
-      const timeMatcher = new TimeMatcher(this.cronExpression, this.options?.timezone);
+      const timeMatcher = new TimeMatcher(this.cronExpression, this.options?.timezone, this.options?.utcOffset);
       return timeMatcher.getNextMatch(new Date());
     }
     return null;
@@ -292,7 +292,7 @@ class BackgroundScheduledTask implements ScheduledTask{
   }
 
   private createContext(executionDate: Date, execution?: Execution): TaskContext{
-    const localTime = new LocalizedTime(executionDate, this.options?.timezone)
+    const localTime = new LocalizedTime(executionDate, this.options?.timezone, this.options?.utcOffset)
     const ctx: TaskContext = {
       date: localTime.toDate(),
       dateLocalIso: localTime.toISO(),

--- a/src/tasks/inline-scheduled-task.ts
+++ b/src/tasks/inline-scheduled-task.ts
@@ -18,6 +18,7 @@ export class InlineScheduledTask implements ScheduledTask {
   name: string;
   stateMachine: StateMachine;
   timezone?: string;
+  utcOffset?: number;
   logger: Logger;
   suppressMissedWarning: boolean;
 
@@ -28,10 +29,11 @@ export class InlineScheduledTask implements ScheduledTask {
     this.id = createID('task', 12);
     this.name = options?.name || this.id;
     this.timezone = options?.timezone;
+    this.utcOffset = options?.utcOffset;
     this.logger = options?.logger || logger;
     this.suppressMissedWarning = options?.suppressMissedWarning || false;
 
-    this.timeMatcher = new TimeMatcher(cronExpression, options?.timezone)
+    this.timeMatcher = new TimeMatcher(cronExpression, options?.timezone, options?.utcOffset)
     this.stateMachine = new StateMachine();
 
     const runnerOptions: RunnerOptions = {
@@ -156,7 +158,7 @@ export class InlineScheduledTask implements ScheduledTask {
   }
 
   private createContext(executionDate: Date, execution?: Execution): TaskContext{
-    const localTime = new LocalizedTime(executionDate, this.timezone)
+    const localTime = new LocalizedTime(executionDate, this.timezone, this.utcOffset)
     const ctx: TaskContext = {
       date: localTime.toDate(),
       dateLocalIso: localTime.toISO(),

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -30,6 +30,12 @@ export type TaskEvent =
 
 export type TaskOptions = {
   timezone?: string,
+  /**
+   * A fixed UTC offset in minutes (negative = west of UTC, e.g. `-180` for
+   * UTC-3, `330` for UTC+5:30). An alternative to `timezone` for a constant
+   * offset with no DST. Mutually exclusive with `timezone`.
+   */
+  utcOffset?: number,
   name?: string,
   noOverlap?: boolean,
   maxExecutions?: number,

--- a/src/time/localized-time.ts
+++ b/src/time/localized-time.ts
@@ -17,11 +17,13 @@ export class LocalizedTime {
   timestamp: number
   parts: DateParts
   timezone?: string | undefined
+  utcOffset?: number | undefined
 
-  constructor(date: Date, timezone?: string){
+  constructor(date: Date, timezone?: string, utcOffset?: number){
     this.timestamp = date.getTime();
     this.timezone = timezone;
-    this.parts = buildDateParts(date, timezone);
+    this.utcOffset = utcOffset;
+    this.parts = buildDateParts(date, timezone, utcOffset);
   }
 
   toDate(): Date{
@@ -75,11 +77,18 @@ function readsBackTo(timestamp: number, parts: WallClock, timezone?: string): bo
  * gap) neither reads back, so we resolve forward to the later instant instead
  * of drifting backwards into the gap (which used to yield a past date).
  */
-export function localTimeToTimestamp(parts: WallClock, timezone?: string): number {
+export function localTimeToTimestamp(parts: WallClock, timezone?: string, utcOffset?: number): number {
   const guess = Date.UTC(
     parts.year, parts.month - 1, parts.day,
     parts.hour, parts.minute, parts.second, parts.milisecond
   );
+
+  // A fixed offset has no transitions: the wall-clock maps to exactly one
+  // instant, with no spring-forward gap or fall-back ambiguity. Pure arithmetic,
+  // no Intl.
+  if (utcOffset !== undefined) {
+    return guess - utcOffset * 60000;
+  }
 
   const firstOffset = getOffsetMinutes(new Date(guess), timezone);
   const candidate1 = guess - firstOffset * 60000;
@@ -97,7 +106,36 @@ export function localTimeToTimestamp(parts: WallClock, timezone?: string): numbe
   return Math.max(candidate1, candidate2);
 }
 
-function buildDateParts(date: Date, timezone?: string): DateParts {
+const SHORT_WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+/** Formats a fixed offset (minutes) the same way getTimezoneGMT does. */
+function offsetToGmt(minutes: number): string {
+  if (minutes === 0) return 'Z';
+  const sign = minutes > 0 ? '+' : '-';
+  const abs = Math.abs(minutes);
+  const hours = String(Math.floor(abs / 60)).padStart(2, '0');
+  const mins = String(abs % 60).padStart(2, '0');
+  return `GMT${sign}${hours}:${mins}`;
+}
+
+function buildDateParts(date: Date, timezone?: string, utcOffset?: number): DateParts {
+  // Fixed offset: read the wall-clock arithmetically by shifting the instant,
+  // no Intl, no DST.
+  if (utcOffset !== undefined) {
+    const shifted = new Date(date.getTime() + utcOffset * 60000);
+    return {
+      year: shifted.getUTCFullYear(),
+      month: shifted.getUTCMonth() + 1,
+      day: shifted.getUTCDate(),
+      hour: shifted.getUTCHours(),
+      minute: shifted.getUTCMinutes(),
+      second: shifted.getUTCSeconds(),
+      milisecond: shifted.getUTCMilliseconds(),
+      weekday: SHORT_WEEKDAYS[shifted.getUTCDay()],
+      gmt: offsetToGmt(utcOffset),
+    };
+  }
+
   const dftOptions: Intl.DateTimeFormatOptions = {
     year: 'numeric',
     month: '2-digit',

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -13,6 +13,7 @@ export class MatcherWalker {
   baseDate: Date;
   timeMatcher: TimeMatcher;
   timezone?: string;
+  utcOffset?: number;
 
   // Time fields are sorted so they can be iterated in ascending order; day and
   // month are only membership-tested, so their order does not matter.
@@ -22,11 +23,12 @@ export class MatcherWalker {
   private readonly days: DayOfMonthField;
   private readonly months: number[];
 
-  constructor(cronExpression: string, baseDate: Date, timezone?: string) {
+  constructor(cronExpression: string, baseDate: Date, timezone?: string, utcOffset?: number) {
     this.cronExpression = cronExpression;
     this.baseDate = baseDate;
-    this.timeMatcher = new TimeMatcher(cronExpression, timezone);
+    this.timeMatcher = new TimeMatcher(cronExpression, timezone, utcOffset);
     this.timezone = timezone;
+    this.utcOffset = utcOffset;
 
     const expressions = convertExpression(cronExpression);
     this.seconds = sortedAsc(expressions[0]);
@@ -57,7 +59,7 @@ export class MatcherWalker {
     const days = this.days;
 
     const baseMs = Math.floor(this.baseDate.getTime() / 1000) * 1000;
-    const baseParts = new LocalizedTime(new Date(baseMs), this.timezone).getParts();
+    const baseParts = new LocalizedTime(new Date(baseMs), this.timezone, this.utcOffset).getParts();
 
     let { year, month, day } = baseParts;
 
@@ -68,7 +70,7 @@ export class MatcherWalker {
         const lowerBound = i === 0 ? baseParts : null;
         const found = this.firstTimeOnDay(year, month, day, lowerBound, baseMs);
         if (found !== null) {
-          return new LocalizedTime(new Date(found), this.timezone);
+          return new LocalizedTime(new Date(found), this.timezone, this.utcOffset);
         }
       }
 
@@ -105,6 +107,7 @@ export class MatcherWalker {
           const ts = localTimeToTimestamp(
             { year, month, day, hour, minute, second, milisecond: 0 },
             this.timezone,
+            this.utcOffset,
           );
 
           // The real matcher confirms every field on the actual instant. A

--- a/src/time/time-matcher.ts
+++ b/src/time/time-matcher.ts
@@ -11,17 +11,19 @@ function matchValue(allowedValues: number[], value: number){
 
 export class TimeMatcher{
     timezone?: string;
+    utcOffset?: number;
     pattern: string;
     expressions: any[];
 
-    constructor(pattern:string, timezone?:string){
+    constructor(pattern:string, timezone?:string, utcOffset?:number){
         this.timezone = timezone;
-        this.pattern = pattern 
+        this.utcOffset = utcOffset;
+        this.pattern = pattern
         this.expressions = convertExpression(pattern);
     }
 
     match(date: Date){
-        const localizedTime = new LocalizedTime(date, this.timezone)
+        const localizedTime = new LocalizedTime(date, this.timezone, this.utcOffset)
         const parts = localizedTime.getParts();
         const runOnSecond = matchValue(this.expressions[0], parts.second);
         const runOnMinute = matchValue(this.expressions[1], parts.minute);
@@ -34,7 +36,7 @@ export class TimeMatcher{
     }
 
     getNextMatch(date: Date){
-      const walker = new MatcherWalker(this.pattern, date, this.timezone);
+      const walker = new MatcherWalker(this.pattern, date, this.timezone, this.utcOffset);
       const next = walker.matchNext();
       return next.toDate();
     }

--- a/src/time/utc-offset.test.ts
+++ b/src/time/utc-offset.test.ts
@@ -1,0 +1,63 @@
+import { assert } from 'chai';
+import { TimeMatcher } from './time-matcher';
+
+// utcOffset: a fixed numeric offset in minutes (negative = west of UTC), used
+// as an alternative to a timezone name. It never observes DST, so it behaves
+// like a zone with no transitions, computed arithmetically (no Intl).
+
+describe('utcOffset', function () {
+  describe('match', function () {
+    it('matches the wall-clock in a negative (west) offset (UTC-3)', function () {
+      const m = new TimeMatcher('30 14 * * *', undefined, -180);
+      // 14:30 at UTC-3 is 17:30 UTC
+      assert.isTrue(m.match(new Date('2025-06-15T17:30:00Z')));
+      assert.isFalse(m.match(new Date('2025-06-15T14:30:00Z')));
+      assert.isFalse(m.match(new Date('2025-06-15T17:31:00Z')));
+    });
+
+    it('matches a half-hour offset (UTC+5:30)', function () {
+      const m = new TimeMatcher('0 9 * * *', undefined, 330);
+      // 09:00 at UTC+5:30 is 03:30 UTC
+      assert.isTrue(m.match(new Date('2025-06-15T03:30:00Z')));
+      assert.isFalse(m.match(new Date('2025-06-15T09:00:00Z')));
+    });
+
+    it('offset 0 behaves like UTC', function () {
+      const m = new TimeMatcher('0 12 * * *', undefined, 0);
+      assert.isTrue(m.match(new Date('2025-06-15T12:00:00Z')));
+    });
+
+    it('matches the weekday in the offset, not UTC', function () {
+      // 2025-06-15 is a Sunday. At UTC-3, 23:30 local on Sun = 02:30 UTC Mon.
+      // `0 30 23 * * 0` (Sunday 23:30) must match the Sunday-local instant.
+      const m = new TimeMatcher('0 23 * * 0', undefined, -180);
+      assert.isTrue(m.match(new Date('2025-06-16T02:00:00Z')));  // Sun 23:00 local
+      assert.isFalse(m.match(new Date('2025-06-15T23:00:00Z'))); // that's Sun 20:00 local
+    });
+  });
+
+  describe('getNextMatch', function () {
+    it('finds the next daily instant in a fixed offset', function () {
+      const next = new TimeMatcher('30 14 * * *', undefined, -180)
+        .getNextMatch(new Date('2025-06-15T00:00:00Z'));
+      assert.equal(next.toISOString(), '2025-06-15T17:30:00.000Z');
+    });
+
+    it('does not drift across a DST boundary (fixed offset, no transitions)', function () {
+      // Across the US spring-forward, a real America/New_York would shift; a
+      // fixed UTC-3 must stay exactly 24h apart every day.
+      const m = new TimeMatcher('30 14 * * *', undefined, -180);
+      let d = new Date('2025-03-08T00:00:00Z');
+      const a = m.getNextMatch(d);
+      const b = m.getNextMatch(a);
+      assert.equal(a.toISOString(), '2025-03-08T17:30:00.000Z');
+      assert.equal(b.getTime() - a.getTime(), 24 * 60 * 60 * 1000);
+    });
+
+    it('half-hour offset getNextMatch', function () {
+      const next = new TimeMatcher('0 9 * * *', undefined, 330)
+        .getNextMatch(new Date('2025-06-15T00:00:00Z'));
+      assert.equal(next.toISOString(), '2025-06-15T03:30:00.000Z');
+    });
+  });
+});

--- a/src/time/utc-offset.test.ts
+++ b/src/time/utc-offset.test.ts
@@ -47,7 +47,7 @@ describe('utcOffset', function () {
       // Across the US spring-forward, a real America/New_York would shift; a
       // fixed UTC-3 must stay exactly 24h apart every day.
       const m = new TimeMatcher('30 14 * * *', undefined, -180);
-      let d = new Date('2025-03-08T00:00:00Z');
+      const d = new Date('2025-03-08T00:00:00Z');
       const a = m.getNextMatch(d);
       const b = m.getNextMatch(a);
       assert.equal(a.toISOString(), '2025-03-08T17:30:00.000Z');


### PR DESCRIPTION
PR2 of the DST work (spec `05-spec-dst` §5.4, scenario CN-3).

## What

A task can now use a **fixed UTC offset** instead of a timezone name:

```js
cron.schedule('30 14 * * *', task, { utcOffset: -180 });  // 14:30 at UTC-3, every day
cron.schedule('0 9 * * *',  task, { utcOffset: 330 });    // 09:00 at UTC+5:30
```

- `utcOffset` is in **minutes**, negative = west of UTC.
- It's a **constant** offset: no DST, so no spring-forward gap or fall-back. Any minute offset works (including `:30`/`:45`).
- Conversions in this mode are **pure arithmetic, no `Intl`** (per spec).
- `timezone` and `utcOffset` are **mutually exclusive** — passing both throws.

## How

`utcOffset` is threaded through `TimeMatcher` → `MatcherWalker` → `LocalizedTime`/`localTimeToTimestamp`. When set, `buildDateParts` reads the wall-clock by shifting the instant arithmetically, and `localTimeToTimestamp` is a single subtraction — no candidates, no transitions. Mutual exclusivity is validated in `createTask`.

## Tests

- `utc-offset.test.ts`: match + getNextMatch for negative offset, half-hour offset (UTC+5:30), offset 0 == UTC, weekday-in-offset, and **no-drift across a DST boundary** (a fixed offset stays exactly 24h apart where a real zone would shift).
- `createTask` accepts `utcOffset` and rejects `timezone` + `utcOffset` together.

Full suite green: **319 tests**, passing under both `TZ=UTC` and `TZ=America/Sao_Paulo`.

## Next

- **PR3**: fuzz testing (§3.6).
- DST model docs (§1) — site repo.