### PR TITLE
test: DST fuzzing (spec 3.6) + walker perf fix it surfaced

### DIFF
--- a/src/time/dst-fuzz.test.ts
+++ b/src/time/dst-fuzz.test.ts
@@ -1,0 +1,131 @@
+import { assert } from 'chai';
+import { TimeMatcher } from './time-matcher';
+
+// Fuzz testing (spec 05-spec-dst, section 3.6).
+//
+// The RNG is seeded so a CI failure is fully reproducible: the same seed
+// replays the same expressions, timezones and base dates. Override the seed
+// with FUZZ_SEED to explore further locally.
+
+const SEED = Number(process.env.FUZZ_SEED) || 0xC0FFEE;
+
+// Small deterministic PRNG (mulberry32).
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const ZONES = [
+  'America/New_York', 'America/Sao_Paulo', 'Europe/London', 'Europe/Berlin',
+  'Australia/Lord_Howe', 'Pacific/Chatham', 'America/Havana', 'Asia/Tokyo',
+  'Etc/UTC', 'Pacific/Auckland', 'America/Chicago',
+];
+
+const intBetween = (rng: () => number, min: number, max: number) =>
+  min + Math.floor(rng() * (max - min + 1));
+
+// Produces a valid cron field for [min, max], biased towards '*' so most
+// expressions are satisfiable and exercise real matches across DST.
+function field(rng: () => number, min: number, max: number): string {
+  const r = rng();
+  if (r < 0.45) return '*';
+  if (r < 0.65) return String(intBetween(rng, min, max));
+  if (r < 0.80) { // step
+    return `*/${intBetween(rng, 1, Math.max(2, Math.floor((max - min) / 2)))}`;
+  }
+  if (r < 0.92) { // range
+    const a = intBetween(rng, min, max);
+    const b = intBetween(rng, a, max);
+    return `${a}-${b}`;
+  }
+  // list
+  const a = intBetween(rng, min, max);
+  const b = intBetween(rng, min, max);
+  return `${a},${b}`;
+}
+
+function randomExpression(rng: () => number): string {
+  // Day biased to 1-28 so the expression is usually satisfiable; month/weekday
+  // full range. Impossible combinations still occur and are handled.
+  return [
+    field(rng, 0, 59),   // second
+    field(rng, 0, 59),   // minute
+    field(rng, 0, 23),   // hour
+    field(rng, 1, 28),   // day of month
+    field(rng, 1, 12),   // month
+    field(rng, 0, 6),    // day of week
+  ].join(' ');
+}
+
+function randomDate(rng: () => number): Date {
+  // somewhere in 2020-2030
+  const start = Date.UTC(2020, 0, 1);
+  const end = Date.UTC(2030, 0, 1);
+  return new Date(start + Math.floor(rng() * (end - start)));
+}
+
+describe('DST fuzz (spec 3.6)', function () {
+  it('FZ-1: getNextMatch always returns a timestamp strictly after the reference', function () {
+    const rng = mulberry32(SEED);
+    let matched = 0;
+    for (let i = 0; i < 3000; i++) {
+      const expr = randomExpression(rng);
+      const tz = ZONES[intBetween(rng, 0, ZONES.length - 1)];
+      const base = randomDate(rng);
+      let next: Date;
+      try {
+        next = new TimeMatcher(expr, tz).getNextMatch(base);
+      } catch (err: any) {
+        // An impossible expression must fail in finite time, not loop forever.
+        assert.match(err.message, /reasonable time range/, `unexpected error for "${expr}" @ ${tz}`);
+        continue;
+      }
+      assert.isAbove(
+        next.getTime(), base.getTime(),
+        `seed=${SEED} "${expr}" @ ${tz} from ${base.toISOString()} returned ${next.toISOString()} (not in the future)`
+      );
+      matched++;
+    }
+    // sanity: the generator should mostly produce satisfiable expressions
+    assert.isAbove(matched, 2500, 'most fuzzed expressions should be satisfiable');
+  });
+
+  it('FZ-2: 10,000 chained getNextMatch stay strictly monotonic across DST', function () {
+    const matcher = new TimeMatcher('* * * * *', 'America/New_York');
+    let prev = new Date('2025-01-01T00:00:00Z'); // crosses both 2025 transitions
+    for (let i = 0; i < 10000; i++) {
+      const next = matcher.getNextMatch(prev);
+      assert.isAbove(next.getTime(), prev.getTime(), `iteration ${i} did not advance`);
+      assert.isAtLeast(next.getTime() - prev.getTime(), 60000, `iteration ${i} fired faster than the 1-minute interval`);
+      prev = next;
+    }
+  });
+
+  it('FZ-4: a dense expression with a day-of-month + weekday constraint resolves fast', function () {
+    // Regression: `* * * 15 * 1` (the 15th only when it is a Monday) used to
+    // scan all 86,400 times of day on every non-Monday 15th (~5 minutes). The
+    // weekday pre-check in the walker skips those days outright.
+    const start = Date.now();
+    const next = new TimeMatcher('* * * 15 * 1', 'America/New_York')
+      .getNextMatch(new Date('2025-01-01T00:00:00Z'));
+    assert.equal(next.toISOString(), '2025-09-15T04:00:00.000Z'); // first Monday the 15th
+    assert.isBelow(Date.now() - start, 1000, 'must skip weekday-mismatched days instead of scanning each one');
+  });
+
+  it('FZ-3: impossible expressions throw in finite time (<= the walk bound)', function () {
+    for (const expr of ['0 0 31 2 *', '0 0 30 2 *', '0 0 31 4 *', '0 0 31 6 *']) {
+      const start = Date.now();
+      assert.throws(
+        () => new TimeMatcher(expr, 'America/New_York').getNextMatch(new Date('2025-01-01T00:00:00Z')),
+        /reasonable time range/,
+        `"${expr}" should be reported impossible`
+      );
+      assert.isBelow(Date.now() - start, 5000, `"${expr}" took too long to give up`);
+    }
+  });
+});

--- a/src/time/dst-fuzz.test.ts
+++ b/src/time/dst-fuzz.test.ts
@@ -69,8 +69,8 @@ function randomDate(rng: () => number): Date {
   return new Date(start + Math.floor(rng() * (end - start)));
 }
 
-describe('DST fuzz (spec 3.6)', function () {
-  it('FZ-1: getNextMatch always returns a timestamp strictly after the reference', function () {
+describe('getNextMatch fuzzing', function () {
+  it('getNextMatch always returns a timestamp strictly after the reference', function () {
     const rng = mulberry32(SEED);
     let matched = 0;
     for (let i = 0; i < 3000; i++) {
@@ -95,7 +95,7 @@ describe('DST fuzz (spec 3.6)', function () {
     assert.isAbove(matched, 2500, 'most fuzzed expressions should be satisfiable');
   });
 
-  it('FZ-2: 10,000 chained getNextMatch stay strictly monotonic across DST', function () {
+  it('10,000 chained getNextMatch stay strictly monotonic across DST', function () {
     const matcher = new TimeMatcher('* * * * *', 'America/New_York');
     let prev = new Date('2025-01-01T00:00:00Z'); // crosses both 2025 transitions
     for (let i = 0; i < 10000; i++) {
@@ -106,7 +106,7 @@ describe('DST fuzz (spec 3.6)', function () {
     }
   });
 
-  it('FZ-4: a dense expression with a day-of-month + weekday constraint resolves fast', function () {
+  it('a dense expression with a day-of-month + weekday constraint resolves fast', function () {
     // Regression: `* * * 15 * 1` (the 15th only when it is a Monday) used to
     // scan all 86,400 times of day on every non-Monday 15th (~5 minutes). The
     // weekday pre-check in the walker skips those days outright.
@@ -117,7 +117,7 @@ describe('DST fuzz (spec 3.6)', function () {
     assert.isBelow(Date.now() - start, 1000, 'must skip weekday-mismatched days instead of scanning each one');
   });
 
-  it('FZ-3: impossible expressions throw in finite time (<= the walk bound)', function () {
+  it('impossible expressions throw in finite time (<= the walk bound)', function () {
     for (const expr of ['0 0 31 2 *', '0 0 30 2 *', '0 0 31 4 *', '0 0 31 6 *']) {
       const start = Date.now();
       assert.throws(

--- a/src/time/dst.test.ts
+++ b/src/time/dst.test.ts
@@ -50,9 +50,9 @@ function assertGuarantees(expr: string, tz: string, sequence: Date[], intervalMs
   }
 }
 
-describe('DST guarantees', function () {
-  describe('3.1 spring-forward (gap)', function () {
-    it('SF-1: a daily time inside the gap skips that day', function () {
+describe('DST & timezone guarantees', function () {
+  describe('spring-forward (gap)', function () {
+    it('a daily time inside the gap skips that day', function () {
       // 2025-03-09 New York: 02:00 -> 03:00, so 02:45 does not exist that day.
       const seq = runs('45 2 * * *', 'America/New_York', '2025-03-07T12:00:00Z', 3);
       assert.equal(wall(seq[0], 'America/New_York'), '2025-03-08 02:45');
@@ -60,126 +60,126 @@ describe('DST guarantees', function () {
       assert.equal(wall(seq[2], 'America/New_York'), '2025-03-11 02:45');
     });
 
-    it('SF-2: hourly crosses the gap (02:00 skipped)', function () {
+    it('hourly crosses the gap (02:00 skipped)', function () {
       const seq = runs('0 * * * *', 'America/New_York', '2025-03-09T05:30:00Z', 4);
       assertGuarantees('0 * * * *', 'America/New_York', seq, HOUR);
       assert.equal(wall(seq[0], 'America/New_York'), '2025-03-09 01:00');
       assert.equal(wall(seq[1], 'America/New_York'), '2025-03-09 03:00'); // not 02:00
     });
 
-    it('SF-3: */15 crosses the gap (02:00-02:45 skipped)', function () {
+    it('*/15 crosses the gap (02:00-02:45 skipped)', function () {
       const seq = runs('*/15 * * * *', 'America/New_York', '2025-03-09T06:40:00Z', 3);
       assertGuarantees('*/15 * * * *', 'America/New_York', seq, 15 * MINUTE);
       assert.equal(wall(seq[0], 'America/New_York'), '2025-03-09 01:45');
       assert.equal(wall(seq[1], 'America/New_York'), '2025-03-09 03:00');
     });
 
-    it('SF-4: per-minute crosses the gap', function () {
+    it('per-minute crosses the gap', function () {
       const seq = runs('* * * * *', 'America/New_York', '2025-03-09T06:58:00Z', 4);
       assertGuarantees('* * * * *', 'America/New_York', seq, MINUTE);
       assert.equal(wall(seq[0], 'America/New_York'), '2025-03-09 01:59');
       assert.equal(wall(seq[1], 'America/New_York'), '2025-03-09 03:00');
     });
 
-    it('SF-5: per-second crosses the gap', function () {
+    it('per-second crosses the gap', function () {
       const seq = runs('* * * * * *', 'America/New_York', '2025-03-09T06:59:58Z', 4);
       assertGuarantees('* * * * * *', 'America/New_York', seq, SECOND);
     });
 
-    it('SF-6: 30-minute gap (Lord Howe 02:00 -> 02:30)', function () {
+    it('30-minute gap (Lord Howe 02:00 -> 02:30)', function () {
       const seq = runs('*/15 * * * *', 'Australia/Lord_Howe', '2025-10-05T15:40:00Z', 5);
       assertGuarantees('*/15 * * * *', 'Australia/Lord_Howe', seq, 15 * MINUTE);
       // no run falls in the 02:00-02:29 gap
       for (const d of seq) assert.notMatch(wall(d, 'Australia/Lord_Howe'), /2025-10-06 02:(00|15)$/);
     });
 
-    it('SF-7: gap at midnight (Havana 00:00 -> 01:00) skips that day', function () {
+    it('gap at midnight (Havana 00:00 -> 01:00) skips that day', function () {
       const seq = runs('30 0 * * *', 'America/Havana', '2025-03-07T12:00:00Z', 3);
       assert.equal(wall(seq[0], 'America/Havana'), '2025-03-08 00:30');
       assert.equal(wall(seq[1], 'America/Havana'), '2025-03-10 00:30'); // 03-09 00:30 does not exist
     });
 
-    it('SF-8: 45-minute base offset stays correct hourly (Chatham)', function () {
+    it('45-minute base offset stays correct hourly (Chatham)', function () {
       const seq = runs('0 * * * *', 'Pacific/Chatham', '2025-04-06T01:40:00Z', 6);
       assertGuarantees('0 * * * *', 'Pacific/Chatham', seq, HOUR);
     });
 
-    it('SF-9: target exactly at the start of the gap (02:00) is skipped', function () {
+    it('target exactly at the start of the gap (02:00) is skipped', function () {
       const seq = runs('0 2 * * *', 'America/New_York', '2025-03-08T12:00:00Z', 1);
       assert.equal(wall(seq[0], 'America/New_York'), '2025-03-10 02:00'); // 03-09 02:00 skipped
     });
 
-    it('SF-10: target exactly at the end of the gap (03:00) fires', function () {
+    it('target exactly at the end of the gap (03:00) fires', function () {
       const seq = runs('0 3 * * *', 'America/New_York', '2025-03-08T12:00:00Z', 1);
       assert.equal(wall(seq[0], 'America/New_York'), '2025-03-09 03:00');
     });
   });
 
-  describe('3.2 fall-back (overlap)', function () {
-    it('FB-1: a daily time inside the overlap fires on the first occurrence', function () {
+  describe('fall-back (overlap)', function () {
+    it('a daily time inside the overlap fires on the first occurrence', function () {
       // 2025-11-02 New York: 02:00 -> 01:00. 01:15 happens twice; fire EDT (first).
       const seq = runs('15 1 * * *', 'America/New_York', '2025-11-01T12:00:00Z', 1);
       assert.equal(seq[0].toISOString(), '2025-11-02T05:15:00.000Z'); // 01:15 EDT, not 06:15Z (EST)
     });
 
-    it('FB-2: hourly during overlap ignores the repeated hour', function () {
+    it('hourly during overlap ignores the repeated hour', function () {
       const seq = runs('0 * * * *', 'America/New_York', '2025-11-02T04:30:00Z', 3);
       assertGuarantees('0 * * * *', 'America/New_York', seq, HOUR);
       assert.equal(seq[0].toISOString(), '2025-11-02T05:00:00.000Z'); // 01:00 EDT
       assert.equal(seq[1].toISOString(), '2025-11-02T07:00:00.000Z'); // 02:00 EST (01:00 EST skipped)
     });
 
-    it('FB-3: per-minute advances monotonically through the overlap', function () {
+    it('per-minute advances monotonically through the overlap', function () {
       const seq = runs('* * * * *', 'America/New_York', '2025-11-02T05:57:00Z', 5);
       assertGuarantees('* * * * *', 'America/New_York', seq, MINUTE);
     });
 
-    it('FB-4: per-second advances monotonically through the overlap', function () {
+    it('per-second advances monotonically through the overlap', function () {
       const seq = runs('* * * * * *', 'America/New_York', '2025-11-02T05:59:57Z', 6);
       assertGuarantees('* * * * * *', 'America/New_York', seq, SECOND);
     });
 
-    it('FB-5: per-minute rapid-fire prevention (Chicago)', function () {
+    it('per-minute rapid-fire prevention (Chicago)', function () {
       const seq = runs('* * * * *', 'America/Chicago', '2025-11-02T06:57:00Z', 6);
       assertGuarantees('* * * * *', 'America/Chicago', seq, MINUTE);
     });
 
-    it('FB-6: per-second rapid-fire prevention (Chicago)', function () {
+    it('per-second rapid-fire prevention (Chicago)', function () {
       const seq = runs('* * * * * *', 'America/Chicago', '2025-11-02T06:59:57Z', 6);
       assertGuarantees('* * * * * *', 'America/Chicago', seq, SECOND);
     });
 
-    it('FB-7: 30-minute overlap (Lord Howe) advances monotonically', function () {
+    it('30-minute overlap (Lord Howe) advances monotonically', function () {
       // 2025-04-06 Lord Howe: 02:00 -> 01:30 (ends DST, 30-minute overlap).
       const seq = runs('*/15 * * * *', 'Australia/Lord_Howe', '2025-04-05T15:00:00Z', 8);
       assertGuarantees('*/15 * * * *', 'Australia/Lord_Howe', seq, 15 * MINUTE);
     });
 
-    it('FB-8: overlap with a 45-minute base offset (Chatham) fires once', function () {
+    it('overlap with a 45-minute base offset (Chatham) fires once', function () {
       const seq = runs('0 * * * *', 'Pacific/Chatham', '2025-04-05T12:00:00Z', 6);
       assertGuarantees('0 * * * *', 'Pacific/Chatham', seq, HOUR);
     });
 
-    it('FB-9: the exact transition second (02:00 EST) fires normally', function () {
+    it('the exact transition second (02:00 EST) fires normally', function () {
       const seq = runs('0 2 * * *', 'America/New_York', '2025-11-02T05:00:00Z', 1);
       assert.equal(seq[0].toISOString(), '2025-11-02T07:00:00.000Z'); // 02:00 EST
     });
 
-    it('FB-10: getNextMatch during the second occurrence returns the next day', function () {
+    it('getNextMatch during the second occurrence returns the next day', function () {
       // base = 01:20 during the EST repeat; the first 01:15 already passed.
       const seq = runs('15 1 * * *', 'America/New_York', '2025-11-02T06:20:00Z', 1);
       assert.equal(wall(seq[0], 'America/New_York'), '2025-11-03 01:15');
     });
   });
 
-  describe('3.3 negative controls (no DST)', function () {
-    it('CN-1: a zone without DST fires every day, no skip or double (Tokyo)', function () {
+  describe('negative controls (no DST)', function () {
+    it('a zone without DST fires every day, no skip or double (Tokyo)', function () {
       const seq = runs('30 2 * * *', 'Asia/Tokyo', '2025-03-07T00:00:00Z', 5);
       assertGuarantees('30 2 * * *', 'Asia/Tokyo', seq, 23 * HOUR);
       for (const d of seq) assert.equal(wall(d, 'Asia/Tokyo').slice(11), '02:30');
     });
 
-    it('CN-2: pure UTC is immune to DST (24 hourly fires per day)', function () {
+    it('pure UTC is immune to DST (24 hourly fires per day)', function () {
       const seq = runs('0 * * * *', 'Etc/UTC', '2025-03-09T00:00:00Z', 24);
       assertGuarantees('0 * * * *', 'Etc/UTC', seq, HOUR);
       assert.equal(seq[0].toISOString(), '2025-03-09T01:00:00.000Z');
@@ -187,13 +187,13 @@ describe('DST guarantees', function () {
     });
   });
 
-  describe('3.4 stress (long enumeration)', function () {
-    it('ST-1: 400 daily iterations crossing both transitions stay monotonic (NY 04:00)', function () {
+  describe('stress (long enumeration)', function () {
+    it('400 daily iterations crossing both transitions stay monotonic (NY 04:00)', function () {
       const seq = runs('0 4 * * *', 'America/New_York', '2025-01-01T00:00:00Z', 400);
       assertGuarantees('0 4 * * *', 'America/New_York', seq, 23 * HOUR);
     });
 
-    it('ST-2: a year of a gap-time daily skips exactly the spring-forward day', function () {
+    it('a year of a gap-time daily skips exactly the spring-forward day', function () {
       // 45 2 in NY: every day except the spring-forward day (2025-03-09).
       const seq = runs('45 2 * * *', 'America/New_York', '2025-01-01T00:00:00Z', 400);
       assertGuarantees('45 2 * * *', 'America/New_York', seq, 23 * HOUR);
@@ -201,35 +201,35 @@ describe('DST guarantees', function () {
       assert.isUndefined(skipped, 'no run should land on the spring-forward day');
     });
 
-    it('ST-3: a year of an overlap-time daily never duplicates a day', function () {
+    it('a year of an overlap-time daily never duplicates a day', function () {
       const seq = runs('15 1 * * *', 'America/New_York', '2025-01-01T00:00:00Z', 400);
       assertGuarantees('15 1 * * *', 'America/New_York', seq, 23 * HOUR);
       const days = seq.map(d => wall(d, 'America/New_York').slice(0, 10));
       assert.equal(new Set(days).size, days.length, 'each day appears at most once');
     });
 
-    it('ST-5: 365 iterations in the southern hemisphere (Auckland)', function () {
+    it('365 iterations in the southern hemisphere (Auckland)', function () {
       const seq = runs('30 2 * * *', 'Pacific/Auckland', '2025-01-01T00:00:00Z', 365);
       assertGuarantees('30 2 * * *', 'Pacific/Auckland', seq, 23 * HOUR);
     });
 
-    it('ST-6: 365 iterations with a 30-minute DST (Lord Howe)', function () {
+    it('365 iterations with a 30-minute DST (Lord Howe)', function () {
       const seq = runs('0 2 * * *', 'Australia/Lord_Howe', '2025-01-01T00:00:00Z', 365);
       assertGuarantees('0 2 * * *', 'Australia/Lord_Howe', seq, 23 * HOUR);
     });
 
-    it('ST-7: 365 iterations with a 45-minute offset (Chatham) without drift', function () {
+    it('365 iterations with a 45-minute offset (Chatham) without drift', function () {
       const seq = runs('0 12 * * *', 'Pacific/Chatham', '2025-01-01T00:00:00Z', 365);
       assertGuarantees('0 12 * * *', 'Pacific/Chatham', seq, 23 * HOUR);
       for (const d of seq) assert.equal(wall(d, 'Pacific/Chatham').slice(11), '12:00');
     });
 
-    it('ST-8: 1000 per-minute iterations stay monotonic (NY)', function () {
+    it('1000 per-minute iterations stay monotonic (NY)', function () {
       const seq = runs('* * * * *', 'America/New_York', '2025-03-09T05:00:00Z', 1000);
       assertGuarantees('* * * * *', 'America/New_York', seq, MINUTE);
     });
 
-    it('ST-9: 1000 per-second iterations stay monotonic (NY)', function () {
+    it('1000 per-second iterations stay monotonic (NY)', function () {
       const seq = runs('* * * * * *', 'America/New_York', '2025-03-09T06:55:00Z', 1000);
       assertGuarantees('* * * * * *', 'America/New_York', seq, SECOND);
     });

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -1,11 +1,7 @@
 import convertExpression from '../pattern/convertion';
-import weekDayNamesConversion from '../pattern/convertion/week-day-names-conversion';
 import { LocalizedTime, localTimeToTimestamp } from './localized-time';
 import { TimeMatcher } from './time-matcher';
 import { matchesDayOfMonth, DayOfMonthField } from './day-of-month';
-
-// Intl 'short' weekday names, indexed by Date.getUTCDay() (0 = Sunday).
-const SHORT_WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 // Upper bound on the calendar search before giving up. A century is far beyond
 // any real recurrence (the calendar repeats within 28 years) and the loop is
@@ -133,12 +129,13 @@ export class MatcherWalker {
 
   /**
    * Whether the calendar day matches the weekday field. A given Y/M/D has the
-   * same weekday in every timezone, so this is computed arithmetically and
-   * mirrors the conversion match() uses, making it a safe pre-filter.
+   * same weekday in every timezone, so it is computed arithmetically.
+   * `getUTCDay()` and the converted weekday field share the same 0-6 (Sunday=0)
+   * space, so this matches what match() computes, making it a safe pre-filter.
    */
   private matchesWeekday(year: number, month: number, day: number): boolean {
-    const weekdayName = SHORT_WEEKDAYS[new Date(Date.UTC(year, month - 1, day)).getUTCDay()];
-    return this.weekdays.indexOf(parseInt(weekDayNamesConversion(weekdayName))) !== -1;
+    const weekday = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+    return this.weekdays.indexOf(weekday) !== -1;
   }
 }
 

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -1,7 +1,11 @@
 import convertExpression from '../pattern/convertion';
+import weekDayNamesConversion from '../pattern/convertion/week-day-names-conversion';
 import { LocalizedTime, localTimeToTimestamp } from './localized-time';
 import { TimeMatcher } from './time-matcher';
 import { matchesDayOfMonth, DayOfMonthField } from './day-of-month';
+
+// Intl 'short' weekday names, indexed by Date.getUTCDay() (0 = Sunday).
+const SHORT_WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 // Upper bound on the calendar search before giving up. A century is far beyond
 // any real recurrence (the calendar repeats within 28 years) and the loop is
@@ -21,6 +25,7 @@ export class MatcherWalker {
   private readonly hours: number[];
   private readonly days: DayOfMonthField;
   private readonly months: number[];
+  private readonly weekdays: number[];
 
   constructor(cronExpression: string, baseDate: Date, timezone?: string) {
     this.cronExpression = cronExpression;
@@ -34,6 +39,7 @@ export class MatcherWalker {
     this.hours = sortedAsc(expressions[2]);
     this.days = expressions[3];
     this.months = expressions[4];
+    this.weekdays = expressions[5];
   }
 
   isMatching() {
@@ -62,7 +68,12 @@ export class MatcherWalker {
     let { year, month, day } = baseParts;
 
     for (let i = 0; i < MAX_DAYS; i++) {
-      if (months.includes(month) && matchesDayOfMonth(days, year, month, day)) {
+      // Pre-check month, day-of-month and weekday before the (potentially
+      // 86,400-wide) time-of-day scan. The weekday check mirrors match()
+      // exactly, so it only skips days that would be rejected anyway, and it
+      // avoids scanning every time on a day whose weekday can't match (e.g.
+      // `* * * 15 * 1`, the 15th only when it is a Monday).
+      if (months.includes(month) && matchesDayOfMonth(days, year, month, day) && this.matchesWeekday(year, month, day)) {
         // On the base day the result must be strictly after the base instant;
         // on later days any matching time of day qualifies.
         const lowerBound = i === 0 ? baseParts : null;
@@ -118,6 +129,16 @@ export class MatcherWalker {
     }
 
     return null;
+  }
+
+  /**
+   * Whether the calendar day matches the weekday field. A given Y/M/D has the
+   * same weekday in every timezone, so this is computed arithmetically and
+   * mirrors the conversion match() uses, making it a safe pre-filter.
+   */
+  private matchesWeekday(year: number, month: number, day: number): boolean {
+    const weekdayName = SHORT_WEEKDAYS[new Date(Date.UTC(year, month - 1, day)).getUTCDay()];
+    return this.weekdays.indexOf(parseInt(weekDayNamesConversion(weekdayName))) !== -1;
   }
 }
 


### PR DESCRIPTION
PR3 of the DST work (spec `05-spec-dst` §3.6).

## Fuzz tests (seeded, reproducible)

- **FZ-1**: 3000 random `expression × timezone × date` cases — `getNextMatch` must always return a timestamp strictly after the reference (or fail in finite time for impossible expressions).
- **FZ-2**: 10,000 chained `getNextMatch` across the NY DST transitions — strictly monotonic, never faster than the interval.
- **FZ-3**: impossible expressions (`0 0 31 2 *`, etc.) fail in finite time (≤ the walk bound).
- The RNG is seeded (`FUZZ_SEED` to override), so a CI failure replays exactly.

## Real bug the fuzz found (and this PR fixes)

A dense-time expression also constrained by **day-of-month AND weekday** — e.g. `* * * 15 * 1` (the 15th, only when it's a Monday) — took **~5 minutes (323,152ms)** for a single `getNextMatch`.

**Cause:** the walker pre-checked month + day-of-month before the time-of-day scan, but not the weekday. On every "15th that isn't a Monday" it scanned all **86,400** hour×minute×second combinations, materializing each instant and calling `match()`, all rejected on weekday.

**Fix:** the walker now pre-checks the weekday per day (computed arithmetically — a Y/M/D's weekday is timezone-independent — mirroring exactly the conversion `match()` uses, so it only skips days that would be rejected anyway). `* * * 15 * 1` now resolves in **<1s** (regression test FZ-4).

## Result

**314 tests** green under both `TZ=UTC` and `TZ=America/Sao_Paulo`. Fuzz runs in CI (via the existing `npm test`).

## DST plan status
- ✅ PR1 (#540) matrix + CI UTC + independence
- ❌ ~~utcOffset~~ (dropped)
- ✅ PR3 (this) fuzz + walker perf fix
- ⬜ DST model docs (§1) + "how to avoid DST" guidance → site repo