### PR TITLE
chore: add SECURITY, CONTRIBUTING and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug report
+description: Report something that isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! A minimal reproduction is the single most helpful
+        thing you can provide. Please do **not** report security issues here —
+        see [SECURITY.md](https://github.com/node-cron/node-cron/blob/main/SECURITY.md).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what happened instead?
+    validations:
+      required: true
+  - type: input
+    id: cron-version
+    attributes:
+      label: node-cron version
+      placeholder: e.g. 4.3.0
+    validations:
+      required: true
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      placeholder: e.g. 22.5.0
+    validations:
+      required: true
+  - type: dropdown
+    id: how-run
+    attributes:
+      label: How do you run your app?
+      description: This matters a lot for background tasks (the daemon is a forked plain-node process).
+      options:
+        - Plain node (.js)
+        - node with native TypeScript (Node >= 23.6, .ts)
+        - tsx
+        - ts-node
+        - A bundler (webpack, esbuild, Vite, etc.)
+        - Other (describe below)
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: e.g. Ubuntu 24.04, macOS 15, Windows 11, Docker (node:22-alpine)
+  - type: input
+    id: expression
+    attributes:
+      label: Cron expression and timezone
+      placeholder: e.g. "0 30 2 * * *", timezone "America/New_York"
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: The smallest snippet that reproduces the issue. A link to a repo is even better.
+      render: javascript
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / error output
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://nodecron.com
+    about: Full guides, API reference and the cookbook — check here before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Suggest an idea for node-cron
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        node-cron aims to stay small and focused (schedule functions with cron
+        expressions, zero dependencies). Distributed queues, persistence and
+        retry-with-dead-letter are intentionally out of scope — those belong to
+        tools like BullMQ.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case, not just the solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API
+      description: If you have one in mind, show the smallest API that would solve it.
+      render: javascript
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to node-cron
+
+Thanks for taking the time to contribute! This guide covers the basics.
+
+## Ground rules
+
+- **Zero runtime dependencies.** This is part of node-cron's identity. PRs that
+  add a runtime dependency will not be accepted; dev dependencies are fine.
+- **Keep the API small.** Prefer a one-line API. If a feature needs a paragraph
+  to explain, it probably needs redesigning.
+- **Tests are required.** New behavior comes with tests; bug fixes come with a
+  test that fails before the fix.
+- Only contribute code you wrote yourself, or that you have the legal right to
+  contribute under the project's ISC license.
+
+## Development setup
+
+Requires **Node.js >= 20**.
+
+```bash
+git clone https://github.com/node-cron/node-cron.git
+cd node-cron
+npm install
+```
+
+### Commands
+
+| Command          | What it does                                  |
+| ---------------- | --------------------------------------------- |
+| `npm test`       | Run the test suite (Vitest) with coverage     |
+| `npm run test:watch` | Run tests in watch mode                   |
+| `npm run lint`   | Lint `src` with ESLint                        |
+| `npm run build`  | Build the dual ESM/CJS bundle with Rollup     |
+| `npm run check`  | Lint + test (run this before opening a PR)    |
+
+Tests run against the TypeScript source. Background-task tests mock
+`child_process.fork`; the real fork path is exercised against the built output.
+
+## Workflow
+
+We follow the fork-and-pull model:
+
+1. Fork the repo and create a branch from `main`.
+2. Make your change with tests. Run `npm run check` and make sure it's green.
+3. Open a pull request against `main` with a clear description of the problem
+   and the fix. Reference any related issue.
+
+CI runs lint and the test suite on Node 20, 22 and 24 (and once under a non-UTC
+timezone to guard timezone independence). All checks must pass.
+
+## Reporting bugs
+
+Open an issue using the bug report template. A minimal reproduction, your
+Node.js version, and how you run your app (plain `node`, `tsx`, a bundler, etc.)
+make bugs far easier to fix — see [SECURITY.md](./SECURITY.md) for security
+issues, which should **not** be reported publicly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported versions
+
+node-cron follows semantic versioning. Security fixes are released for the
+latest `4.x` minor. Older majors (`3.x` and below) are not maintained.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 4.x     | :white_check_mark: |
+| < 4     | :x:                |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately through GitHub's [security advisories](https://github.com/node-cron/node-cron/security/advisories/new)
+("Report a vulnerability"). Include:
+
+- the affected version,
+- a description of the issue and its impact,
+- a minimal reproduction if you have one.
+
+You can expect an initial response within a few days. Once a fix is ready, a
+patched release is published and the advisory is disclosed with credit to the
+reporter (unless you prefer to stay anonymous).
+
+node-cron ships with **zero runtime dependencies**, so the attack surface is
+limited to the package's own code and the Node.js runtime it runs on.


### PR DESCRIPTION
Phase 0 (polish) — project governance / supply-chain files.

- **SECURITY.md** — private vulnerability reporting via GitHub advisories, supported versions (4.x), and a note that node-cron has zero runtime dependencies.
- **CONTRIBUTING.md** — dev setup (Node >= 20), the command table (`test`/`lint`/`build`/`check`), the fork-and-pull workflow, and the zero-dependency / small-API ground rules.
- **Issue templates** (`.github/ISSUE_TEMPLATE/`):
  - **Bug report** form capturing the info that recurrently blocks triage: node-cron + Node.js versions, **how the app is run** (plain node / native TS / tsx / bundler — key for background tasks), expression + timezone, and a minimal reproduction.
  - **Feature request** form that frames node-cron's scope up front.
  - `config.yml`: disables blank issues, links to the docs.

No code change. (Discussions isn't enabled on the repo, so the question link points to the docs site; enable Discussions later if you want a dedicated Q&A link.)