### PR TITLE
feat: task introspection (getNextRuns, match, msToNext, isBusy, runsLeft, getPattern)

### DIFF
--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -426,6 +426,26 @@ describe('BackgroundScheduledTask', function() {
       const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
       assert.isUndefined(task.runsLeft());
     });
+
+    it('isBusy is false when not executing', function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      assert.isFalse(task.isBusy());
+    });
+
+    it('msToNext is null when stopped and a positive number once started', async function(){
+      const task = new BackgroundScheduledTask('* * * * *', './test-assets/dummy-task.js', { timezone: 'Etc/UTC' });
+      assert.isNull(task.msToNext());
+
+      fakeChildProcess.send.callsFake((msg: any)=>{
+        if (msg.command === 'task:destroy') task.emitter.emit('task:destroyed');
+        else task.emitter.emit('task:started');
+      });
+      await task.start();
+      const ms = task.msToNext();
+      assert.isNotNull(ms);
+      assert.isAbove(ms as number, 0);
+      await task.destroy();
+    });
   });
 });
 

--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -398,6 +398,35 @@ describe('BackgroundScheduledTask', function() {
       assert.equal(result, 'late result');
     });
   });
+
+  describe('introspection', function(){
+    it('getPattern returns the expression', function(){
+      const task = new BackgroundScheduledTask('0 0 12 * * *', './test-assets/dummy-task.js');
+      assert.equal(task.getPattern(), '0 0 12 * * *');
+    });
+
+    it('match and getNextRuns compute locally (no daemon needed)', function(){
+      const task = new BackgroundScheduledTask('0 0 12 * * *', './test-assets/dummy-task.js', { timezone: 'Etc/UTC' });
+      assert.isTrue(task.match(new Date('2025-06-15T12:00:00Z')));
+      assert.isFalse(task.match(new Date('2025-06-15T12:00:01Z')));
+      const runs = task.getNextRuns(3);
+      assert.lengthOf(runs, 3);
+      assert.isAbove(runs[1].getTime(), runs[0].getTime());
+    });
+
+    it('runsLeft tracks executions reported by the daemon', function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', { maxExecutions: 3 });
+      assert.equal(task.runsLeft(), 3);
+      task.emitter.emit('execution:started', {} as any);
+      task.emitter.emit('execution:started', {} as any);
+      assert.equal(task.runsLeft(), 1);
+    });
+
+    it('runsLeft is undefined without maxExecutions', function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      assert.isUndefined(task.runsLeft());
+    });
+  });
 });
 
 

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -28,6 +28,8 @@ class BackgroundScheduledTask implements ScheduledTask{
   stateMachine: StateMachine;
   logger: Logger;
   suppressMissedWarning: boolean;
+  timeMatcher: TimeMatcher;
+  runCount: number;
 
   constructor(cronExpression: string, taskPath: string, options?: TaskOptions){
     this.cronExpression = cronExpression;
@@ -37,6 +39,11 @@ class BackgroundScheduledTask implements ScheduledTask{
     this.name = options?.name || this.id;
     this.emitter = new TaskEmitter();
     this.stateMachine = new StateMachine('stopped');
+    // The execution count lives in the daemon; mirror it here from the forwarded
+    // events so runsLeft() works across the process boundary.
+    this.timeMatcher = new TimeMatcher(cronExpression, options?.timezone);
+    this.runCount = 0;
+    this.on('execution:started', () => { this.runCount++; });
     // The logger lives in the parent process: it cannot cross the fork
     // boundary. The daemon runs with a no-op logger and forwards events, and
     // this process logs from those events using the configured logger.
@@ -58,10 +65,41 @@ class BackgroundScheduledTask implements ScheduledTask{
 
   getNextRun(): Date | null {
     if ( this.stateMachine.state !== 'stopped'){
-      const timeMatcher = new TimeMatcher(this.cronExpression, this.options?.timezone);
-      return timeMatcher.getNextMatch(new Date());
+      return this.timeMatcher.getNextMatch(new Date());
     }
     return null;
+  }
+
+  getNextRuns(count: number): Date[] {
+    const runs: Date[] = [];
+    let from = new Date();
+    for (let i = 0; i < count; i++) {
+      from = this.timeMatcher.getNextMatch(from);
+      runs.push(from);
+    }
+    return runs;
+  }
+
+  match(date: Date): boolean {
+    return this.timeMatcher.match(date);
+  }
+
+  msToNext(): number | null {
+    const next = this.getNextRun();
+    return next ? next.getTime() - Date.now() : null;
+  }
+
+  isBusy(): boolean {
+    return this.getStatus() === 'running';
+  }
+
+  runsLeft(): number | undefined {
+    if (this.options?.maxExecutions == null) return undefined;
+    return Math.max(0, this.options.maxExecutions - this.runCount);
+  }
+
+  getPattern(): string {
+    return this.cronExpression;
   }
 
   start(): Promise<void> {

--- a/src/tasks/inline-scheduled-task.ts
+++ b/src/tasks/inline-scheduled-task.ts
@@ -90,6 +90,38 @@ export class InlineScheduledTask implements ScheduledTask {
     return null;
   }
 
+  getNextRuns(count: number): Date[] {
+    const runs: Date[] = [];
+    let from = new Date();
+    for (let i = 0; i < count; i++) {
+      from = this.timeMatcher.getNextMatch(from);
+      runs.push(from);
+    }
+    return runs;
+  }
+
+  match(date: Date): boolean {
+    return this.timeMatcher.match(date);
+  }
+
+  msToNext(): number | null {
+    const next = this.getNextRun();
+    return next ? next.getTime() - Date.now() : null;
+  }
+
+  isBusy(): boolean {
+    return this.getStatus() === 'running';
+  }
+
+  runsLeft(): number | undefined {
+    if (this.runner.maxExecutions == null) return undefined;
+    return Math.max(0, this.runner.maxExecutions - this.runner.runCount);
+  }
+
+  getPattern(): string {
+    return this.cronExpression;
+  }
+
   private changeState(state){
     if(this.runner.isStarted()){
       this.stateMachine.changeState(state);

--- a/src/tasks/introspection.test.ts
+++ b/src/tasks/introspection.test.ts
@@ -1,0 +1,82 @@
+import { assert } from 'chai';
+import { InlineScheduledTask } from './inline-scheduled-task';
+
+const wait = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+describe('task introspection', function () {
+  describe('getPattern', function () {
+    it('returns the original cron expression', function () {
+      const task = new InlineScheduledTask('0 0 12 * * *', () => {});
+      assert.equal(task.getPattern(), '0 0 12 * * *');
+    });
+  });
+
+  describe('match', function () {
+    it('reports whether a date matches the expression', function () {
+      const task = new InlineScheduledTask('0 0 12 * * *', () => {}, { timezone: 'Etc/UTC' });
+      assert.isTrue(task.match(new Date('2025-06-15T12:00:00Z')));
+      assert.isFalse(task.match(new Date('2025-06-15T12:00:01Z')));
+    });
+  });
+
+  describe('getNextRuns', function () {
+    it('returns the next N runs, strictly increasing, each matching', function () {
+      const task = new InlineScheduledTask('0 0 12 * * *', () => {}, { timezone: 'Etc/UTC' });
+      const runs = task.getNextRuns(3);
+      assert.lengthOf(runs, 3);
+      for (let i = 0; i < runs.length; i++) {
+        assert.isTrue(task.match(runs[i]), `run ${i} should match`);
+        if (i > 0) assert.isAbove(runs[i].getTime(), runs[i - 1].getTime());
+      }
+    });
+
+    it('returns an empty array for a non-positive count', function () {
+      const task = new InlineScheduledTask('0 0 12 * * *', () => {});
+      assert.deepEqual(task.getNextRuns(0), []);
+    });
+  });
+
+  describe('msToNext', function () {
+    it('returns the milliseconds until the next run when started', function () {
+      const task = new InlineScheduledTask('0 0 12 * * *', () => {}, { timezone: 'Etc/UTC' });
+      task.start();
+      const ms = task.msToNext();
+      assert.isNotNull(ms);
+      assert.isAbove(ms as number, 0);
+      assert.closeTo((ms as number), (task.getNextRun() as Date).getTime() - Date.now(), 1000);
+      task.stop();
+    });
+
+    it('returns null when the task is stopped', function () {
+      const task = new InlineScheduledTask('0 0 12 * * *', () => {});
+      assert.isNull(task.msToNext());
+    });
+  });
+
+  describe('isBusy', function () {
+    it('is false when the task is not executing', function () {
+      const task = new InlineScheduledTask('0 0 12 * * *', () => {});
+      assert.isFalse(task.isBusy());
+    });
+
+    it('is true while an execution is in progress', async function () {
+      const task = new InlineScheduledTask('* * * * * *', async () => { await wait(700); });
+      task.start();
+      await wait(1100); // let one run start
+      assert.isTrue(task.isBusy());
+      task.stop();
+    });
+  });
+
+  describe('runsLeft', function () {
+    it('returns the remaining executions when maxExecutions is set', function () {
+      const task = new InlineScheduledTask('* * * * * *', () => {}, { maxExecutions: 3 });
+      assert.equal(task.runsLeft(), 3);
+    });
+
+    it('returns undefined when maxExecutions is not set', function () {
+      const task = new InlineScheduledTask('* * * * * *', () => {});
+      assert.isUndefined(task.runsLeft());
+    });
+  });
+});

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -96,6 +96,19 @@ export interface ScheduledTask {
   execute(): Promise<any>;
   getNextRun(): Date | null;
 
+  /** The next `count` instants this task's expression matches, from now. */
+  getNextRuns(count: number): Date[];
+  /** Whether the given date matches this task's expression. */
+  match(date: Date): boolean;
+  /** Milliseconds until the next run, or `null` when the task is stopped. */
+  msToNext(): number | null;
+  /** Whether an execution is currently in progress. */
+  isBusy(): boolean;
+  /** Remaining executions when `maxExecutions` is set, otherwise `undefined`. */
+  runsLeft(): number | undefined;
+  /** The original cron expression. */
+  getPattern(): string;
+
   on(event: TaskEvent, fun: (context: TaskContext) => Promise<void> | void): void
   off(event: TaskEvent, fun: (context: TaskContext) => Promise<void> | void): void
   once(event: TaskEvent, fun: (context: TaskContext) => Promise<void> | void): void 


### PR DESCRIPTION
Phase 1 — task introspection. Six small methods on the public `ScheduledTask` interface, implemented for both inline and background tasks.

| Method | Returns | Notes |
|---|---|---|
| `getNextRuns(n)` | `Date[]` | the next `n` matches from now (pure; closes the FI-7 scenario skipped in the DST work) |
| `match(date)` | `boolean` | whether a date matches the expression |
| `msToNext()` | `number \| null` | ms until the next run; `null` when stopped |
| `isBusy()` | `boolean` | whether an execution is in progress |
| `runsLeft()` | `number \| undefined` | remaining runs when `maxExecutions` is set |
| `getPattern()` | `string` | the original cron expression |

- `getNextRuns` / `match` / `getPattern` are **pure** (computed from the expression + timezone), so they work on a stopped task and on a background task **without** querying the daemon.
- `runsLeft` for background tasks: the real count lives in the forked daemon, so the parent mirrors it from the `execution:started` events it already receives.

Tests cover both implementations (inline directly; background for the local-compute methods and the event-tracked `runsLeft`). Full suite green.

## Next in Phase 1
- `cron.parse()` + `cron.validateDetailed()` (expression introspection — separate PR).
- Observability (`getStats`/history/`previousRun(s)`) after the `EventStore` provider.