### PR TITLE
feat: cron.parse and cron.validateDetailed (expression introspection)

### DIFF
--- a/src/node-cron.test.ts
+++ b/src/node-cron.test.ts
@@ -165,7 +165,28 @@ describe('node-cron', function() {
         });
         
         it('should fail with a invalid pattern', function() {
-            assert.isFalse(cron.validate('62 * * * * *')); 
+            assert.isFalse(cron.validate('62 * * * * *'));
+        });
+    });
+
+    describe('validateDetailed', function() {
+        it('returns a structured result', function() {
+            const ok = cron.validateDetailed('0 30 9 * * *');
+            assert.isTrue(ok.valid);
+            assert.deepEqual(ok.fields?.minute, [30]);
+
+            const bad = cron.validateDetailed('62 * * * * *');
+            assert.isFalse(bad.valid);
+            assert.equal(bad.errors[0].field, 'second');
+        });
+    });
+
+    describe('parse', function() {
+        it('returns decomposed fields', function() {
+            assert.deepEqual(cron.parse('0 30 9 * * *').hour, [9]);
+        });
+        it('throws on an invalid expression', function() {
+            assert.throws(() => cron.parse('62 * * * * *'));
         });
     });
 

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -13,7 +13,7 @@ import { ScheduledTask, TaskFn, TaskOptions } from "./tasks/scheduled-task";
 import { TaskRegistry } from "./task-registry";
 import logger from "./logger";
 
-import validation from "./pattern/validation/pattern-validation";
+import validation, { parse as parseExpression, validateDetailed as validateDetailedExpression } from "./pattern/validation/pattern-validation";
 import BackgroundScheduledTask from "./tasks/background-scheduled-task/background-scheduled-task";
 import { setLogger } from "./logger";
 
@@ -132,6 +132,23 @@ export function validate(expression: string): boolean {
 }
 
 /**
+ * Validates a cron expression and returns a structured result with every
+ * problem (field name, offending value and reason), instead of a plain boolean.
+ * Useful for tooling, editors and richer error messages.
+ *
+ * @param expression - The cron expression to validate
+ */
+export const validateDetailed = validateDetailedExpression;
+
+/**
+ * Parses a cron expression into its decomposed fields, or throws an Error with
+ * a useful message (which field, which value) for the first problem found.
+ *
+ * @param expression - The cron expression to parse
+ */
+export const parse = parseExpression;
+
+/**
  * Retrieves all scheduled tasks from the registry.
  * 
  * @returns A map of scheduled tasks
@@ -150,11 +167,14 @@ export { setLogger } from './logger';
 
 export type { ScheduledTask, TaskFn, TaskContext, TaskOptions } from './tasks/scheduled-task';
 export type { Logger } from './logger';
+export type { ParsedFields, DetailedValidation, CronFieldError } from './pattern/validation/pattern-validation';
 
 export interface NodeCron {
   schedule: typeof schedule;
   createTask: typeof createTask;
   validate: typeof validate;
+  validateDetailed: typeof validateDetailed;
+  parse: typeof parse;
   getTasks: typeof getTasks;
   getTask: typeof getTask;
   setLogger: typeof setLogger;
@@ -164,6 +184,8 @@ export const nodeCron: NodeCron = {
   schedule,
   createTask,
   validate,
+  validateDetailed,
+  parse,
   getTasks,
   getTask,
   setLogger,

--- a/src/pattern/validation/pattern-validation.ts
+++ b/src/pattern/validation/pattern-validation.ts
@@ -104,6 +104,91 @@ function validateFields(patterns, executablePatterns) {
         throw new Error(`${patterns[5]} is a invalid expression for week day`);
 }
 
+// Field metadata reused by the detailed (non-throwing) API below. Order matches
+// the 6-field expression: second minute hour day-of-month month day-of-week.
+const FIELDS = [
+    { key: 'second', label: 'second', invalid: isInvalidSecond },
+    { key: 'minute', label: 'minute', invalid: isInvalidMinute },
+    { key: 'hour', label: 'hour', invalid: isInvalidHour },
+    { key: 'dayOfMonth', label: 'day of month', invalid: isInvalidDayOfMonth },
+    { key: 'month', label: 'month', invalid: isInvalidMonth },
+    { key: 'dayOfWeek', label: 'week day', invalid: isInvalidWeekDay },
+];
+
+export interface CronFieldError {
+    /** The field name, or `'expression'` for whole-expression problems. */
+    field: string;
+    value?: string;
+    message: string;
+}
+
+export interface ParsedFields {
+    second: number[];
+    minute: number[];
+    hour: number[];
+    dayOfMonth: (number | string)[];
+    month: number[];
+    dayOfWeek: number[];
+}
+
+export interface DetailedValidation {
+    valid: boolean;
+    /** Present only when `valid` is true. */
+    fields?: ParsedFields;
+    errors: CronFieldError[];
+}
+
+/**
+ * Validates an expression and returns a structured result with every error
+ * (field name, offending value, reason) instead of throwing on the first.
+ * Useful for tooling, editors and DX.
+ */
+export function validateDetailed(pattern: string): DetailedValidation {
+    if (typeof pattern !== 'string')
+        return { valid: false, errors: [{ field: 'expression', message: 'pattern must be a string' }] };
+
+    if (!/^[a-zA-Z0-9-*/, ]+$/.test(pattern))
+        return { valid: false, errors: [{ field: 'expression', value: pattern, message: 'pattern includes illegal characters' }] };
+
+    const raw = pattern.replace(/\s{2,}/g, ' ').trim().split(' ');
+    if (raw.length !== 5 && raw.length !== 6)
+        return { valid: false, errors: [{ field: 'expression', value: pattern, message: `expected 5 or 6 fields but got ${raw.length}` }] };
+
+    const patterns = raw.length === 5 ? ['0', ...raw] : raw;
+    const executable = convertExpression(pattern);
+
+    const errors: CronFieldError[] = [];
+    FIELDS.forEach((f, i) => {
+        if (f.invalid(executable[i]))
+            errors.push({ field: f.key, value: patterns[i], message: `${patterns[i]} is a invalid expression for ${f.label}` });
+    });
+
+    if (errors.length) return { valid: false, errors };
+
+    return {
+        valid: true,
+        errors: [],
+        fields: {
+            second: executable[0],
+            minute: executable[1],
+            hour: executable[2],
+            dayOfMonth: executable[3],
+            month: executable[4],
+            dayOfWeek: executable[5],
+        },
+    };
+}
+
+/**
+ * Parses an expression into its decomposed fields, or throws an Error with a
+ * useful message (which field, which value) for the first problem found.
+ */
+export function parse(pattern: string): ParsedFields {
+    const result = validateDetailed(pattern);
+    if (!result.valid) throw new Error(result.errors[0].message);
+    return result.fields as ParsedFields;
+}
+
 /**
  * Validates a Cron-Job expression pattern.
  *

--- a/src/pattern/validation/validate-detailed.test.ts
+++ b/src/pattern/validation/validate-detailed.test.ts
@@ -1,0 +1,75 @@
+import { assert } from 'chai';
+import { parse, validateDetailed } from './pattern-validation';
+
+describe('validateDetailed', function () {
+  it('returns valid with the decomposed fields for a valid expression', function () {
+    const result = validateDetailed('0 30 9 * * 1-5');
+    assert.isTrue(result.valid);
+    assert.deepEqual(result.errors, []);
+    assert.deepEqual(result.fields?.second, [0]);
+    assert.deepEqual(result.fields?.minute, [30]);
+    assert.deepEqual(result.fields?.hour, [9]);
+    assert.deepEqual(result.fields?.dayOfWeek, [1, 2, 3, 4, 5]);
+  });
+
+  it('defaults the seconds field for a 5-field expression', function () {
+    const result = validateDetailed('30 9 * * *');
+    assert.isTrue(result.valid);
+    assert.deepEqual(result.fields?.second, [0]);
+    assert.deepEqual(result.fields?.minute, [30]);
+  });
+
+  it('keeps the L token in day-of-month', function () {
+    const result = validateDetailed('0 0 12 L * *');
+    assert.isTrue(result.valid);
+    assert.include(result.fields?.dayOfMonth as any[], 'L');
+  });
+
+  it('reports an out-of-range field with its name and value', function () {
+    const result = validateDetailed('0 0 99 * * *'); // 6 fields: hour = 99
+    assert.isFalse(result.valid);
+    assert.isUndefined(result.fields);
+    assert.lengthOf(result.errors, 1);
+    assert.equal(result.errors[0].field, 'hour');
+    assert.equal(result.errors[0].value, '99');
+    assert.match(result.errors[0].message, /99/);
+  });
+
+  it('collects errors from multiple invalid fields', function () {
+    const result = validateDetailed('99 0 99 * * *'); // bad second and bad hour
+    assert.isFalse(result.valid);
+    const fields = result.errors.map(e => e.field);
+    assert.includeMembers(fields, ['second', 'hour']);
+  });
+
+  it('rejects illegal characters', function () {
+    const result = validateDetailed('0 0 12 * * $');
+    assert.isFalse(result.valid);
+    assert.equal(result.errors[0].field, 'expression');
+  });
+
+  it('rejects a wrong number of fields', function () {
+    const result = validateDetailed('* * *');
+    assert.isFalse(result.valid);
+    assert.equal(result.errors[0].field, 'expression');
+    assert.match(result.errors[0].message, /5 or 6 fields/);
+  });
+
+  it('rejects a non-string', function () {
+    const result = validateDetailed(123 as any);
+    assert.isFalse(result.valid);
+    assert.equal(result.errors[0].field, 'expression');
+  });
+});
+
+describe('parse', function () {
+  it('returns the decomposed fields for a valid expression', function () {
+    const fields = parse('0 30 9 * * *');
+    assert.deepEqual(fields.minute, [30]);
+    assert.deepEqual(fields.hour, [9]);
+  });
+
+  it('throws with a useful message for an invalid expression', function () {
+    assert.throws(() => parse('0 0 99 * * *'), /99 is a invalid expression for hour/);
+  });
+});


### PR DESCRIPTION
Phase 1 — expression introspection (DX / tooling).

- **`cron.validateDetailed(expression)`** → `{ valid, fields?, errors }`. Unlike `validate()` (boolean), it collects **every** problem with `{ field, value, message }`, and returns the **decomposed fields** when valid.
- **`cron.parse(expression)`** → the decomposed fields (`{ second, minute, hour, dayOfMonth, month, dayOfWeek }`), or **throws** with a useful message (which field, which value) for the first problem.

Both reuse the existing per-field validators — `validate()` (boolean) is untouched, so no behavior change there. Handles 5/6-field forms, the `L` token in day-of-month, illegal characters, wrong field count, and non-string input.

```js
cron.validateDetailed('0 30 9 * * 1-5');
// { valid: true, fields: { ..., dayOfWeek: [1,2,3,4,5] }, errors: [] }

cron.validateDetailed('99 * * * * *');
// { valid: false, errors: [{ field: 'second', value: '99', message: '99 is a invalid expression for second' }] }

cron.parse('0 30 9 * * *'); // { second:[0], minute:[30], hour:[9], ... }
```

New exported types: `ParsedFields`, `DetailedValidation`, `CronFieldError`. Full suite green (327 tests).