### PR TITLE
refactor!: rename distributedTtl option to distributedLease

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- Renamed the `distributedTtl` option to **`distributedLease`** (same meaning:
+  the safety lease, in ms, for lease-based coordinators). The old name was the
+  only abbreviation in the options API; the new one groups with `distributed`.
+  `distributedTtl` was introduced in 4.4.0 and is removed without an alias.
+
 ## [4.4.0] - 2026-06-17
 
 ### Added

--- a/src/coordinator/run-coordinator.test.ts
+++ b/src/coordinator/run-coordinator.test.ts
@@ -92,10 +92,10 @@ describe('run coordinator', function () {
     assert.isAbove(ran, 0);
   });
 
-  it('honours a custom distributedTtl', async function () {
+  it('honours a custom distributedLease', async function () {
     const coordinator = makeCoordinator();
     setRunCoordinator(coordinator as any);
-    const task = new InlineScheduledTask('* * * * * *', () => {}, { name: 'job', distributed: true, distributedTtl: 5000 });
+    const task = new InlineScheduledTask('* * * * * *', () => {}, { name: 'job', distributed: true, distributedLease: 5000 });
 
     task.start();
     await wait(1200);

--- a/src/tasks/inline-scheduled-task.ts
+++ b/src/tasks/inline-scheduled-task.ts
@@ -82,7 +82,7 @@ export class InlineScheduledTask implements ScheduledTask {
       // then the env-var default (in a daemon this is the IPC bridge to the parent).
       runCoordinator: options?.distributed ? resolveRunCoordinator(options?.runCoordinator) : undefined,
       coordinatorKeyPrefix: this.name,
-      coordinatorTtl: options?.distributedTtl,
+      coordinatorTtl: options?.distributedLease,
       onSkipped: (date: Date, reason: SkipReason) => {
         this.emitter.emit('execution:skipped', this.createContext(date, undefined, reason));
       }

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -53,11 +53,11 @@ export type TaskOptions = {
    */
   runCoordinator?: RunCoordinator,
   /**
-   * Safety lease expiry (ms) passed to lease-based coordinators (e.g. a Redis
-   * lock), in case the holder crashes without releasing. Must be larger than
-   * the task's run time. Ignored by config-based coordinators. Defaults to 30000.
+   * Safety lease (ms) passed to lease-based coordinators (e.g. a Redis lock),
+   * in case the holder crashes without releasing. Must be larger than the
+   * task's run time. Ignored by config-based coordinators. Defaults to 30000.
    */
-  distributedTtl?: number,
+  distributedLease?: number,
   /**
    * Stop the task after this many executions. Counted per instance: combined
    * with `distributed` and a per-fire coordinator (e.g. a Redis lock), each


### PR DESCRIPTION
Renames the `distributedTtl` task option to **`distributedLease`** (same meaning: the safety lease, in ms, for lease-based run coordinators).

`distributedTtl` was the only abbreviation in the options API (the rest are spelled out: `maxExecutions`, `executeTimeout`, `missedExecutionTolerance`, …) and `Ttl` read poorly. `distributedLease` drops the abbreviation and groups with `distributed` in autocomplete; a "lease" is inherently a bounded duration.

It was introduced in **4.4.0** (days ago), so it's removed **without an alias**.

- `TaskOptions.distributedTtl` → `distributedTtl` becomes `distributedLease`
- inline + background wiring updated
- test + CHANGELOG (`[Unreleased]`) updated

Docs updated in node-cron-site#20.

Build, lint, and the full suite (374 tests) pass.