### PR TITLE
chore(release): 4.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.4.1] - 2026-06-18
+
 ### Changed
 - Renamed the `distributedTtl` option to **`distributedLease`** (same meaning:
   the safety lease, in ms, for lease-based coordinators). The old name was the
@@ -134,7 +136,8 @@ that start stopped, per-task `logger`, and a dual ESM/CJS build. The legacy
 `scheduled`/`runOnInit` options were removed and several event names changed.
 See the [migration guide](https://nodecron.com/migrating-from-v3).
 
-[Unreleased]: https://github.com/node-cron/node-cron/compare/v4.4.0...HEAD
+[Unreleased]: https://github.com/node-cron/node-cron/compare/v4.4.1...HEAD
+[4.4.1]: https://github.com/node-cron/node-cron/compare/v4.4.0...v4.4.1
 [4.4.0]: https://github.com/node-cron/node-cron/compare/v4.3.0...v4.4.0
 [4.3.0]: https://github.com/node-cron/node-cron/compare/v4.2.1...v4.3.0
 [4.2.1]: https://github.com/node-cron/node-cron/compare/v4.2.0...v4.2.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-cron",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-cron",
-      "version": "4.4.0",
+      "version": "4.4.1",
       "license": "ISC",
       "devDependencies": {
         "@eslint/js": "^9.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-cron",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "A Lightweight Task Scheduler for Node.js",
   "author": "Lucas Merencia",
   "license": "ISC",


### PR DESCRIPTION
Patch release: cuts **4.4.1**.

Promotes the `[Unreleased]` changelog entry and bumps the version. The only change since 4.4.0 is the option rename merged in #551:

### Changed
- Renamed the `distributedTtl` task option to **`distributedLease`** (same meaning: the safety lease in ms for lease-based run coordinators). `distributedTtl` shipped only in 4.4.0 and is removed without an alias.

Docs already updated (node-cron-site#21). Tag/publish after merge.