### PR TITLE
chore: point package metadata to canonical URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ testing.js
 todo.txt
 
 /dist/
+
+# Local scratch / drafts (not for commit)
+/.local/
+/scratch/

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Lightweight Task Scheduler for Node.js",
   "author": "Lucas Merencia",
   "license": "ISC",
-  "homepage": "https://github.com/merencia/node-cron",
+  "homepage": "https://nodecron.com",
   "type": "module",
   "main": "./dist/node-cron.cjs",
   "module": "./dist/node-cron.js",
@@ -33,7 +33,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/merencia/node-cron.git"
+    "url": "git+https://github.com/node-cron/node-cron.git"
   },
   "keywords": [
     "cron",
@@ -43,7 +43,7 @@
     "job"
   ],
   "bugs": {
-    "url": "https://github.com/merencia/node-cron/issues"
+    "url": "https://github.com/node-cron/node-cron/issues"
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",


### PR DESCRIPTION
Aligns `package.json` metadata with the canonical project locations and ignores local scratch folders.

- **`homepage`**: `github.com/merencia/node-cron` → `https://nodecron.com`. The homepage link is the primary link on the npm page; pointing it at the docs site strengthens it as the canonical entry point.
- **`repository`** and **`bugs`**: now point at the `node-cron/node-cron` org repo instead of the personal fork path.
- **`.gitignore`**: ignore `/.local/` and `/scratch/` for local drafts and scratch work.

No code or runtime behavior changes.