### PR TITLE
chore: improve npm description and keywords for discoverability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-cron",
   "version": "4.4.1",
-  "description": "A Lightweight Task Scheduler for Node.js",
+  "description": "A tiny, zero-dependency cron task scheduler for Node.js, written in TypeScript.",
   "author": "Lucas Merencia",
   "license": "ISC",
   "homepage": "https://nodecron.com",
@@ -37,10 +37,17 @@
   },
   "keywords": [
     "cron",
+    "crontab",
+    "cronjob",
+    "node-cron",
     "scheduler",
+    "task-scheduler",
+    "job-scheduler",
     "schedule",
+    "scheduled-tasks",
     "task",
-    "job"
+    "job",
+    "typescript"
   ],
   "bugs": {
     "url": "https://github.com/node-cron/node-cron/issues"


### PR DESCRIPTION
Metadata-only change to improve discoverability on the npm registry. No code or runtime behavior changes.

- **`description`**: `A Lightweight Task Scheduler for Node.js` → `A tiny, zero-dependency cron task scheduler for Node.js, written in TypeScript.` The previous description did not contain the word "cron"; npm search weights the description field.
- **`keywords`**: expanded from 5 to 12 with high-intent search terms (`crontab`, `cronjob`, `node-cron`, `task-scheduler`, `job-scheduler`, `scheduled-tasks`, `typescript`).

The GitHub repo's description and website field were aligned separately via repo settings.