### PR TITLE
feat: add onError and onSuccess callback options per task

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,16 @@ cron.schedule('0 3 * * *', task, {
   noOverlap: true,            // skip a run if the previous one is still going
   maxExecutions: 10,          // destroy the task after N runs
   maxRandomDelay: 30000,      // jitter (ms) added before each run
+  onError: (err, ctx) => {    // called when a run throws (alongside the event)
+    console.error(err);
+  },
 });
 ```
+
+`onError` fires in addition to the `execution:failed` event (it does not replace
+it) and receives the error plus the execution context. Errors thrown by the
+callback are swallowed so they cannot crash the scheduler. For background tasks
+the callback runs in the parent process, mirroring how `logger` is handled.
 
 See [Scheduling Options](https://nodecron.com/scheduling-options) for the full list.
 

--- a/README.md
+++ b/README.md
@@ -90,13 +90,18 @@ cron.schedule('0 3 * * *', task, {
   onError: (err, ctx) => {    // called when a run throws (alongside the event)
     console.error(err);
   },
+  onSuccess: (result, ctx) => { // called when a run completes (alongside the event)
+    console.log(result);
+  },
 });
 ```
 
-`onError` fires in addition to the `execution:failed` event (it does not replace
-it) and receives the error plus the execution context. Errors thrown by the
-callback are swallowed so they cannot crash the scheduler. For background tasks
-the callback runs in the parent process, mirroring how `logger` is handled.
+`onError` and `onSuccess` fire in addition to the `execution:failed` /
+`execution:finished` events (they do not replace them). `onError` receives the
+error plus the execution context; `onSuccess` receives the task's return value
+plus the context. Errors thrown by either callback are swallowed so they cannot
+crash the scheduler. For background tasks the callbacks run in the parent
+process, mirroring how `logger` is handled.
 
 See [Scheduling Options](https://nodecron.com/scheduling-options) for the full list.
 

--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -505,6 +505,75 @@ describe('BackgroundScheduledTask', function() {
     });
   });
 
+  describe('onSuccess callback', function () {
+    // The onSuccess option is a function and cannot cross the fork boundary, so
+    // it is stripped from the options sent to the daemon and invoked here in the
+    // parent, driven by the forwarded execution:finished message.
+    function finishedMessage(){
+      return {
+        event: 'execution:finished',
+        context: { date: new Date(), task: { state: 'idle' }, execution: { id: 'exec-1', result: 'bg result' } }
+      };
+    }
+
+    it('invokes onSuccess with the result and context on a successful execution', async function () {
+      let received: { result: unknown; context: any } | undefined;
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', {
+        onSuccess: (result, context) => { received = { result, context }; }
+      });
+      fakeChildProcess.send.callsFake(() => { task.emitter.emit('task:started'); });
+      await task.start();
+
+      fakeChildProcess.emit('message', finishedMessage());
+      await wait(10);
+
+      assert.isDefined(received, 'onSuccess should be invoked');
+      assert.equal(received?.result, 'bg result');
+      assert.equal(received?.context.execution?.id, 'exec-1');
+      assert.equal(received?.context.task, task);
+    });
+
+    it('does not send the onSuccess function to the daemon', async function () {
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', {
+        name: 'job', onSuccess: () => {}
+      });
+      fakeChildProcess.send.callsFake(() => { task.emitter.emit('task:started'); });
+      await task.start();
+
+      const startMsg = fakeChildProcess.send.getCalls().map(c => c.args[0]).find((a: any) => a?.command === 'task:start');
+      assert.isUndefined(startMsg.options.onSuccess, 'onSuccess must be stripped from the serialized options');
+    });
+
+    it('ignores a forwarded finished event when onSuccess is not set', async function () {
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      let finishedFired = false;
+      task.on('execution:finished', () => { finishedFired = true; });
+      fakeChildProcess.send.callsFake(() => { task.emitter.emit('task:started'); });
+      await task.start();
+
+      fakeChildProcess.emit('message', finishedMessage());
+      await wait(10);
+
+      assert.isTrue(finishedFired, 'execution:finished should still fire');
+    });
+
+    it('does not crash when onSuccess itself throws', async function () {
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', {
+        onSuccess: () => { throw new Error('callback exploded'); }
+      });
+      let finishedFired = false;
+      task.on('execution:finished', () => { finishedFired = true; });
+      fakeChildProcess.send.callsFake(() => { task.emitter.emit('task:started'); });
+      await task.start();
+
+      // Must not throw out of the message handler.
+      fakeChildProcess.emit('message', finishedMessage());
+      await wait(10);
+
+      assert.isTrue(finishedFired, 'execution:finished should still fire');
+    });
+  });
+
   describe('run coordination over IPC', function () {
     function makeCoordinator(behavior: { shouldRunReturns?: boolean; shouldRunThrows?: boolean } = {}) {
       const calls = { shouldRun: [] as { key: string; ttl: number }[], onComplete: [] as string[] };

--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -448,6 +448,63 @@ describe('BackgroundScheduledTask', function() {
     });
   });
 
+  describe('onError callback', function () {
+    // The onError option is a function and cannot cross the fork boundary, so it
+    // is stripped from the options sent to the daemon and invoked here in the
+    // parent, driven by the forwarded execution:failed message.
+    function failingMessage(){
+      return {
+        event: 'execution:failed',
+        context: { date: new Date(), task: { state: 'idle' }, execution: { id: 'exec-1' } },
+        jsonError: JSON.stringify({ name: 'Error', message: 'bg boom', stack: 'fake stack' })
+      };
+    }
+
+    it('invokes onError with the error and context on a failed execution', async function () {
+      let received: { error: Error; context: any } | undefined;
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', {
+        onError: (error, context) => { received = { error, context }; }
+      });
+      fakeChildProcess.send.callsFake(() => { task.emitter.emit('task:started'); });
+      await task.start();
+
+      fakeChildProcess.emit('message', failingMessage());
+      await wait(10);
+
+      assert.isDefined(received, 'onError should be invoked');
+      assert.equal(received?.error.message, 'bg boom');
+      assert.equal(received?.context.execution?.id, 'exec-1');
+      assert.equal(received?.context.task, task);
+    });
+
+    it('does not send the onError function to the daemon', async function () {
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', {
+        name: 'job', onError: () => {}
+      });
+      fakeChildProcess.send.callsFake(() => { task.emitter.emit('task:started'); });
+      await task.start();
+
+      const startMsg = fakeChildProcess.send.getCalls().map(c => c.args[0]).find((a: any) => a?.command === 'task:start');
+      assert.isUndefined(startMsg.options.onError, 'onError must be stripped from the serialized options');
+    });
+
+    it('does not crash when onError itself throws', async function () {
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', {
+        onError: () => { throw new Error('callback exploded'); }
+      });
+      let failedFired = false;
+      task.on('execution:failed', () => { failedFired = true; });
+      fakeChildProcess.send.callsFake(() => { task.emitter.emit('task:started'); });
+      await task.start();
+
+      // Must not throw out of the message handler.
+      fakeChildProcess.emit('message', failingMessage());
+      await wait(10);
+
+      assert.isTrue(failedFired, 'execution:failed should still fire');
+    });
+  });
+
   describe('run coordination over IPC', function () {
     function makeCoordinator(behavior: { shouldRunReturns?: boolean; shouldRunThrows?: boolean } = {}) {
       const calls = { shouldRun: [] as { key: string; ttl: number }[], onComplete: [] as string[] };

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -352,6 +352,18 @@ class BackgroundScheduledTask implements ScheduledTask{
           this.logger.warn('task still running, new execution blocked by overlap prevention!');
         }
         break;
+      case 'execution:finished':
+        // The onSuccess callback is a function and cannot cross the fork
+        // boundary, so it runs here in the parent (driven by the forwarded
+        // event), mirroring how `logger` is handled for background tasks.
+        if(this.options?.onSuccess){
+          try {
+            this.options.onSuccess(context.execution?.result, context);
+          } catch (err: any) {
+            this.logger.error('onSuccess callback threw', err);
+          }
+        }
+        break;
       case 'execution:failed':
         if(context.execution?.error){
           this.logger.error(context.execution.error);
@@ -388,15 +400,15 @@ class BackgroundScheduledTask implements ScheduledTask{
 
 /**
  * Strips options that cannot cross the process boundary (function-bearing
- * objects: a custom `logger`, the `runCoordinator`, and the `onError`
- * callback). The parent keeps the original options; it does the logging
- * itself, runs the coordinator on the daemon's behalf over IPC, and invokes
- * `onError` from the forwarded `execution:failed` event.
+ * objects: a custom `logger`, the `runCoordinator`, and the `onError` /
+ * `onSuccess` callbacks). The parent keeps the original options; it does the
+ * logging itself, runs the coordinator on the daemon's behalf over IPC, and
+ * invokes `onError` / `onSuccess` from the forwarded execution events.
  */
 function serializableOptions(options?: TaskOptions): TaskOptions | undefined {
   if(!options) return options;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { logger: _logger, runCoordinator: _runCoordinator, onError: _onError, ...rest } = options;
+  const { logger: _logger, runCoordinator: _runCoordinator, onError: _onError, onSuccess: _onSuccess, ...rest } = options;
   return rest;
 }
 

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -356,6 +356,16 @@ class BackgroundScheduledTask implements ScheduledTask{
         if(context.execution?.error){
           this.logger.error(context.execution.error);
         }
+        // The onError callback is a function and cannot cross the fork
+        // boundary, so it runs here in the parent (driven by the forwarded
+        // event), mirroring how `logger` is handled for background tasks.
+        if(this.options?.onError && context.execution?.error){
+          try {
+            this.options.onError(context.execution.error, context);
+          } catch (err: any) {
+            this.logger.error('onError callback threw', err);
+          }
+        }
         break;
     }
   }
@@ -378,14 +388,15 @@ class BackgroundScheduledTask implements ScheduledTask{
 
 /**
  * Strips options that cannot cross the process boundary (function-bearing
- * objects: a custom `logger` and the `runCoordinator`). The parent keeps the
- * original options; it does the logging itself and runs the coordinator on the
- * daemon's behalf over IPC.
+ * objects: a custom `logger`, the `runCoordinator`, and the `onError`
+ * callback). The parent keeps the original options; it does the logging
+ * itself, runs the coordinator on the daemon's behalf over IPC, and invokes
+ * `onError` from the forwarded `execution:failed` event.
  */
 function serializableOptions(options?: TaskOptions): TaskOptions | undefined {
   if(!options) return options;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { logger: _logger, runCoordinator: _runCoordinator, ...rest } = options;
+  const { logger: _logger, runCoordinator: _runCoordinator, onError: _onError, ...rest } = options;
   return rest;
 }
 

--- a/src/tasks/inline-scheduled-task.test.ts
+++ b/src/tasks/inline-scheduled-task.test.ts
@@ -258,6 +258,85 @@ describe('InlineScheduledTask', function() {
     assert.isFalse(captured.warnings.some(w => w.includes('missed execution')), 'warning should be suppressed by the flag');
     task.destroy();
   });
+
+  it('calls onError when the task throws synchronously', async function(){
+    let received: { error: Error; context: TaskContext } | undefined;
+    const task = new InlineScheduledTask('* * * * * *', () => { throw new Error('sync boom'); }, {
+      onError: (error, context) => { received = { error, context }; }
+    });
+    try { await task.execute(); } catch { /* execute() rejects on failure */ }
+    assert.isDefined(received, 'onError should be called');
+    assert.equal(received?.error.message, 'sync boom');
+    task.destroy();
+  });
+
+  it('calls onError when the task rejects asynchronously', async function(){
+    let received: { error: Error; context: TaskContext } | undefined;
+    const task = new InlineScheduledTask('* * * * * *', async () => { throw new Error('async boom'); }, {
+      onError: (error, context) => { received = { error, context }; }
+    });
+    try { await task.execute(); } catch { /* execute() rejects on failure */ }
+    assert.isDefined(received, 'onError should be called');
+    assert.equal(received?.error.message, 'async boom');
+    task.destroy();
+  });
+
+  it('passes the error and an execution context to onError', async function(){
+    let received: { error: Error; context: TaskContext } | undefined;
+    const task = new InlineScheduledTask('* * * * * *', async () => { throw new Error('ctx boom'); }, {
+      onError: (error, context) => { received = { error, context }; }
+    });
+    try { await task.execute(); } catch { /* expected */ }
+    assert.isDefined(received);
+    assert.instanceOf(received?.error, Error);
+    assert.isDefined(received?.context.date);
+    assert.isDefined(received?.context.triggeredAt);
+    assert.isDefined(received?.context.execution);
+    assert.isDefined(received?.context.execution?.id);
+    assert.equal(received?.context.execution?.error?.message, 'ctx boom');
+    assert.equal(received?.context.task, task);
+    task.destroy();
+  });
+
+  it('still emits execution:failed alongside onError', async function(){
+    let onErrorCalled = false;
+    let eventFired = false;
+    const task = new InlineScheduledTask('* * * * * *', async () => { throw new Error('both'); }, {
+      onError: () => { onErrorCalled = true; }
+    });
+    task.on('execution:failed', () => { eventFired = true; });
+    try { await task.execute(); } catch { /* expected */ }
+    assert.isTrue(onErrorCalled, 'onError should be called');
+    assert.isTrue(eventFired, 'execution:failed should still fire');
+    task.destroy();
+  });
+
+  it('keeps current behavior when onError is absent', async function(){
+    let eventFired = false;
+    const task = new InlineScheduledTask('* * * * * *', async () => { throw new Error('no callback'); });
+    task.on('execution:failed', () => { eventFired = true; });
+    try { await task.execute(); } catch { /* expected */ }
+    assert.isTrue(eventFired, 'execution:failed should still fire without onError');
+    task.destroy();
+  });
+
+  it('does not crash the scheduler when onError itself throws', async function(){
+    const captured = makeLogger();
+    let eventFired = false;
+    const task = new InlineScheduledTask('* * * * * *', async () => { throw new Error('original'); }, {
+      logger: captured,
+      onError: () => { throw new Error('callback exploded'); }
+    });
+    task.on('execution:failed', () => { eventFired = true; });
+    // execute() must still reject with the original error, not the callback error,
+    // and the throwing callback must not propagate.
+    let rejected: Error | undefined;
+    try { await task.execute(); } catch (e: any) { rejected = e; }
+    assert.equal(rejected?.message, 'original');
+    assert.isTrue(eventFired, 'execution:failed should still fire');
+    assert.isTrue(captured.errors.some(e => typeof e === 'string' && e.includes('onError callback threw')), 'the thrown callback error should be logged, not propagated');
+    task.destroy();
+  });
 });
 
 function makeLogger(){

--- a/src/tasks/inline-scheduled-task.test.ts
+++ b/src/tasks/inline-scheduled-task.test.ts
@@ -337,6 +337,71 @@ describe('InlineScheduledTask', function() {
     assert.isTrue(captured.errors.some(e => typeof e === 'string' && e.includes('onError callback threw')), 'the thrown callback error should be logged, not propagated');
     task.destroy();
   });
+
+  it('calls onSuccess with the result when the task completes', async function(){
+    let received: { result: unknown; context: TaskContext } | undefined;
+    const task = new InlineScheduledTask('* * * * * *', async () => 'the result', {
+      onSuccess: (result, context) => { received = { result, context }; }
+    });
+    await task.execute();
+    assert.isDefined(received, 'onSuccess should be called');
+    assert.equal(received?.result, 'the result');
+    task.destroy();
+  });
+
+  it('passes the result and an execution context to onSuccess', async function(){
+    let received: { result: unknown; context: TaskContext } | undefined;
+    const task = new InlineScheduledTask('* * * * * *', async () => 42, {
+      onSuccess: (result, context) => { received = { result, context }; }
+    });
+    await task.execute();
+    assert.isDefined(received);
+    assert.equal(received?.result, 42);
+    assert.isDefined(received?.context.date);
+    assert.isDefined(received?.context.triggeredAt);
+    assert.isDefined(received?.context.execution);
+    assert.isDefined(received?.context.execution?.id);
+    assert.equal(received?.context.execution?.result, 42);
+    assert.equal(received?.context.task, task);
+    task.destroy();
+  });
+
+  it('still emits execution:finished alongside onSuccess', async function(){
+    let onSuccessCalled = false;
+    let eventFired = false;
+    const task = new InlineScheduledTask('* * * * * *', async () => 'ok', {
+      onSuccess: () => { onSuccessCalled = true; }
+    });
+    task.on('execution:finished', () => { eventFired = true; });
+    await task.execute();
+    assert.isTrue(onSuccessCalled, 'onSuccess should be called');
+    assert.isTrue(eventFired, 'execution:finished should still fire');
+    task.destroy();
+  });
+
+  it('keeps current behavior when onSuccess is absent', async function(){
+    let eventFired = false;
+    const task = new InlineScheduledTask('* * * * * *', async () => 'ok');
+    task.on('execution:finished', () => { eventFired = true; });
+    await task.execute();
+    assert.isTrue(eventFired, 'execution:finished should still fire without onSuccess');
+    task.destroy();
+  });
+
+  it('does not crash the scheduler when onSuccess itself throws', async function(){
+    const captured = makeLogger();
+    let eventFired = false;
+    const task = new InlineScheduledTask('* * * * * *', async () => 'ok', {
+      logger: captured,
+      onSuccess: () => { throw new Error('callback exploded'); }
+    });
+    task.on('execution:finished', () => { eventFired = true; });
+    // execute() must still resolve and the throwing callback must not propagate.
+    await task.execute();
+    assert.isTrue(eventFired, 'execution:finished should still fire');
+    assert.isTrue(captured.errors.some(e => typeof e === 'string' && e.includes('onSuccess callback threw')), 'the thrown callback error should be logged, not propagated');
+    task.destroy();
+  });
 });
 
 function makeLogger(){

--- a/src/tasks/inline-scheduled-task.ts
+++ b/src/tasks/inline-scheduled-task.ts
@@ -21,6 +21,7 @@ export class InlineScheduledTask implements ScheduledTask {
   timezone?: string;
   logger: Logger;
   suppressMissedWarning: boolean;
+  private onErrorCallback?: (error: Error, context: TaskContext) => void;
 
   constructor(cronExpression: string, taskFn: TaskFn, options?: TaskOptions){
     this.emitter = new TaskEmitter();
@@ -31,6 +32,7 @@ export class InlineScheduledTask implements ScheduledTask {
     this.timezone = options?.timezone;
     this.logger = options?.logger || logger;
     this.suppressMissedWarning = options?.suppressMissedWarning || false;
+    this.onErrorCallback = options?.onError;
 
     this.timeMatcher = new TimeMatcher(cronExpression, options?.timezone)
     this.stateMachine = new StateMachine();
@@ -58,7 +60,9 @@ export class InlineScheduledTask implements ScheduledTask {
       },
       onError: (date: Date, error: Error, execution: Execution) => {
         this.logger.error(error);
-        this.emitter.emit('execution:failed', this.createContext(date, execution));
+        const context = this.createContext(date, execution);
+        this.emitter.emit('execution:failed', context);
+        this.runOnErrorCallback(error, context);
         this.changeState('idle');
       },
       onOverlap: (date: Date) => {
@@ -195,6 +199,17 @@ export class InlineScheduledTask implements ScheduledTask {
 
   once(event: TaskEvent, fun: (context: TaskContext) => Promise<void> | void): void {
     this.emitter.once(event, fun);
+  }
+
+  // Invoke the user-provided onError callback, guarding against a throwing
+  // callback so it can never crash the scheduler.
+  private runOnErrorCallback(error: Error, context: TaskContext): void {
+    if (!this.onErrorCallback) return;
+    try {
+      this.onErrorCallback(error, context);
+    } catch (err: any) {
+      this.logger.error('onError callback threw', err);
+    }
   }
 
   private createContext(executionDate: Date, execution?: Execution, reason?: SkipReason): TaskContext{

--- a/src/tasks/inline-scheduled-task.ts
+++ b/src/tasks/inline-scheduled-task.ts
@@ -22,6 +22,7 @@ export class InlineScheduledTask implements ScheduledTask {
   logger: Logger;
   suppressMissedWarning: boolean;
   private onErrorCallback?: (error: Error, context: TaskContext) => void;
+  private onSuccessCallback?: (result: unknown, context: TaskContext) => void;
 
   constructor(cronExpression: string, taskFn: TaskFn, options?: TaskOptions){
     this.emitter = new TaskEmitter();
@@ -33,6 +34,7 @@ export class InlineScheduledTask implements ScheduledTask {
     this.logger = options?.logger || logger;
     this.suppressMissedWarning = options?.suppressMissedWarning || false;
     this.onErrorCallback = options?.onError;
+    this.onSuccessCallback = options?.onSuccess;
 
     this.timeMatcher = new TimeMatcher(cronExpression, options?.timezone)
     this.stateMachine = new StateMachine();
@@ -55,7 +57,9 @@ export class InlineScheduledTask implements ScheduledTask {
         if(execution.reason === 'scheduled'){
           this.changeState('idle');
         }
-        this.emitter.emit('execution:finished', this.createContext(date, execution));
+        const context = this.createContext(date, execution);
+        this.emitter.emit('execution:finished', context);
+        this.runOnSuccessCallback(execution.result, context);
         return true;
       },
       onError: (date: Date, error: Error, execution: Execution) => {
@@ -209,6 +213,17 @@ export class InlineScheduledTask implements ScheduledTask {
       this.onErrorCallback(error, context);
     } catch (err: any) {
       this.logger.error('onError callback threw', err);
+    }
+  }
+
+  // Invoke the user-provided onSuccess callback, guarding against a throwing
+  // callback so it can never crash the scheduler.
+  private runOnSuccessCallback(result: unknown, context: TaskContext): void {
+    if (!this.onSuccessCallback) return;
+    try {
+      this.onSuccessCallback(result, context);
+    } catch (err: any) {
+      this.logger.error('onSuccess callback threw', err);
     }
   }
 

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -83,6 +83,15 @@ export type TaskOptions = {
    */
   onError?: (error: Error, context: TaskContext) => void,
   /**
+   * Called when a scheduled or invoked execution completes successfully. Fires
+   * in addition to the `execution:finished` event, not instead of it. Receives
+   * the value returned by the task function and the execution context. Errors
+   * thrown by this callback are swallowed so they cannot crash the scheduler.
+   * For background tasks it runs in the parent process (driven by the
+   * forwarded `execution:finished` event), mirroring how `logger` is handled.
+   */
+  onSuccess?: (result: unknown, context: TaskContext) => void,
+  /**
    * When true, suppresses the "missed execution" warning for this task.
    * The warning is also suppressed automatically when an `execution:missed`
    * listener is attached.

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -74,6 +74,15 @@ export type TaskOptions = {
    */
   logger?: Logger,
   /**
+   * Called when a scheduled or invoked execution throws (synchronously or via
+   * a rejected promise). Fires in addition to the `execution:failed` event,
+   * not instead of it. Receives the error and the execution context. Errors
+   * thrown by this callback are swallowed so they cannot crash the scheduler.
+   * For background tasks it runs in the parent process (driven by the
+   * forwarded `execution:failed` event), mirroring how `logger` is handled.
+   */
+  onError?: (error: Error, context: TaskContext) => void,
+  /**
    * When true, suppresses the "missed execution" warning for this task.
    * The warning is also suppressed automatically when an `execution:missed`
    * listener is attached.


### PR DESCRIPTION
Adds two symmetric per-task callback options so users can handle execution outcomes without subscribing to events:

- `onError?: (error, context) => void`
- `onSuccess?: (result, context) => void`

## Behavior
- Each fires **in addition to** the matching event (`execution:failed` / `execution:finished`), not instead of it.
- `onError` receives the error + context; `onSuccess` receives the task's return value + context.
- When a callback is absent, behavior is unchanged.
- A throwing callback is guarded: caught and logged (`'onError callback threw'` / `'onSuccess callback threw'`), never propagated, never crashes the scheduler.
- For background (forked) tasks the callbacks cannot cross the process boundary, so they are stripped from the serialized daemon options and invoked in the parent from the forwarded events. Documented in comments, mirroring how `logger` is handled.

## Tests
Inline and background coverage for: callback invoked with the right payload, the matching event still fires alongside, absence preserves behavior, a throwing callback does not break the scheduler, and (background) the function is stripped from the daemon options.

`npm run check` (eslint + vitest with coverage): lint clean, 392 tests passing.