### PR TITLE
feat: support the L token in the day-of-week field (last weekday of month)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,13 @@ Need a task that doesn't start immediately? Use `cron.createTask(...)` and call 
 | second       | 0-59 (optional)                   |
 | minute       | 0-59                              |
 | hour         | 0-23                              |
-| day of month | 1-31 (or `L` for the last day)    |
-| month        | 1-12 (or names)                   |
-| day of week  | 0-7 (or names, 0 or 7 are sunday) |
+| day of month | 1-31 (or `L` for the last day)              |
+| month        | 1-12 (or names)                             |
+| day of week  | 0-7 (or names, 0 or 7 are sunday; `5L` = last Friday) |
 
-See the [Cron Syntax guide](https://nodecron.com/cron-syntax) for ranges, steps, lists, named months/weekdays, and the `L` (last day of month) token.
+In the day-of-week field, `<weekday>L` matches the last occurrence of that weekday in the month: `5L` is the last Friday, `0L` (or `7L`) the last Sunday.
+
+See the [Cron Syntax guide](https://nodecron.com/cron-syntax) for ranges, steps, lists, named months/weekdays, the `L` (last day of month) token, and the `<weekday>L` (last weekday of month) token.
 
 ## Options
 

--- a/src/pattern/conversion/index.ts
+++ b/src/pattern/conversion/index.ts
@@ -21,12 +21,18 @@ export default (() => {
         for (let i=0; i < expressions.length; i++){
             const numbers = expressions[i].split(',');
             for (let j=0; j<numbers.length; j++){
+                const token = String(numbers[j]).trim();
                 // Keep the `L` (last day of month) token as a literal; it has no
                 // fixed numeric value. It is only meaningful in the day-of-month
                 // field, where validation accepts it; elsewhere it stays a token
                 // that no value matches and that validation rejects.
-                if (/^l$/i.test(String(numbers[j]).trim())) {
+                if (/^l$/i.test(token)) {
                     numbers[j] = 'L';
+                // Keep the `<weekday>L` (last weekday of month) token as a
+                // literal, e.g. `5L` for the last Friday. It is only meaningful
+                // in the day-of-week field; elsewhere validation rejects it.
+                } else if (/^[0-7]l$/i.test(token)) {
+                    numbers[j] = token.toUpperCase();
                 } else {
                     numbers[j] = parseInt(numbers[j]);
                 }

--- a/src/pattern/validation/pattern-validation.ts
+++ b/src/pattern/validation/pattern-validation.ts
@@ -73,7 +73,13 @@ function isInvalidMonth(expression) {
  * @returns {boolean}
  */
 function isInvalidWeekDay(expression) {
-    return !isValidExpression(expression, 0, 7);
+    // `<weekday>L` (last weekday of the month, e.g. `5L`) is a valid token in
+    // this field only; the `<weekday>` part has already been validated to be a
+    // single 0-7 digit by the conversion step. The remaining values must still
+    // be valid week-day numbers. Bare `L`, `L5`, `8L` and similar never reach
+    // here as a `<weekday>L` token, so they fall through and are rejected.
+    const days = expression.filter((value) => !/^[0-7]L$/.test(value));
+    return !isValidExpression(days, 0, 7);
 }
 
 /**
@@ -128,7 +134,7 @@ export interface ParsedFields {
     hour: number[];
     dayOfMonth: (number | string)[];
     month: number[];
-    dayOfWeek: number[];
+    dayOfWeek: (number | string)[];
 }
 
 export interface DetailedValidation {

--- a/src/pattern/validation/validate-day.test.ts
+++ b/src/pattern/validation/validate-day.test.ts
@@ -58,4 +58,51 @@ describe('pattern-validation', function() {
             }).to.throw('LW is a invalid expression for day of month');
         });
     });
+
+    describe('validate week day', function() {
+        it('should not fail with <weekday>L (last weekday of month)', function() {
+            expect(() => {
+                validate('0 0 12 * * 5L');
+            }).to.not.throw();
+        });
+
+        it('should not fail with 0L / 7L (last Sunday)', function() {
+            expect(() => {
+                validate('0 0 12 * * 0L');
+            }).to.not.throw();
+            expect(() => {
+                validate('0 0 12 * * 7L');
+            }).to.not.throw();
+        });
+
+        it('should not fail with a lowercase weekday L', function() {
+            expect(() => {
+                validate('0 0 12 * * 5l');
+            }).to.not.throw();
+        });
+
+        it('should not fail with <weekday>L combined with explicit weekdays', function() {
+            expect(() => {
+                validate('0 0 12 * * 5L,1');
+            }).to.not.throw();
+        });
+
+        it('should fail with an out-of-range weekday L (8L)', function() {
+            expect(() => {
+                validate('0 0 12 * * 8L');
+            }).to.throw('8L is a invalid expression for week day');
+        });
+
+        it('should fail with a reversed token (L5)', function() {
+            expect(() => {
+                validate('0 0 12 * * L5');
+            }).to.throw('L5 is a invalid expression for week day');
+        });
+
+        it('should fail with a bare L in the week-day field', function() {
+            expect(() => {
+                validate('0 0 12 * * L');
+            }).to.throw('L is a invalid expression for week day');
+        });
+    });
 });

--- a/src/pattern/validation/validate-detailed.test.ts
+++ b/src/pattern/validation/validate-detailed.test.ts
@@ -25,6 +25,24 @@ describe('validateDetailed', function () {
     assert.include(result.fields?.dayOfMonth as any[], 'L');
   });
 
+  it('keeps the <weekday>L token in day-of-week', function () {
+    const result = validateDetailed('0 0 12 * * 5L');
+    assert.isTrue(result.valid);
+    assert.include(result.fields?.dayOfWeek as any[], '5L');
+  });
+
+  it('normalises 7L to 0L in day-of-week', function () {
+    const result = validateDetailed('0 0 12 * * 7L');
+    assert.isTrue(result.valid);
+    assert.include(result.fields?.dayOfWeek as any[], '0L');
+  });
+
+  it('reports an invalid <weekday>L token', function () {
+    const result = validateDetailed('0 0 12 * * 8L');
+    assert.isFalse(result.valid);
+    assert.equal(result.errors[0].field, 'dayOfWeek');
+  });
+
   it('reports an out-of-range field with its name and value', function () {
     const result = validateDetailed('0 0 99 * * *'); // 6 fields: hour = 99
     assert.isFalse(result.valid);

--- a/src/time/day-of-week.test.ts
+++ b/src/time/day-of-week.test.ts
@@ -1,0 +1,83 @@
+import { assert } from 'chai';
+import {
+  isLastWeekdayOfMonth,
+  isLastWeekdayToken,
+  matchesDayOfWeek,
+  parseLastWeekdayToken,
+} from './day-of-week';
+
+describe('day-of-week', function () {
+  describe('parseLastWeekdayToken', function () {
+    it('parses a numeric weekday token', function () {
+      assert.equal(parseLastWeekdayToken('5L'), 5);
+      assert.equal(parseLastWeekdayToken('0L'), 0);
+    });
+
+    it('normalises 7L to Sunday (0)', function () {
+      assert.equal(parseLastWeekdayToken('7L'), 0);
+    });
+
+    it('accepts a lowercase l', function () {
+      assert.equal(parseLastWeekdayToken('5l'), 5);
+    });
+
+    it('returns null for non-tokens', function () {
+      assert.isNull(parseLastWeekdayToken(5));
+      assert.isNull(parseLastWeekdayToken('L'));
+      assert.isNull(parseLastWeekdayToken('L5'));
+      assert.isNull(parseLastWeekdayToken('8L'));
+    });
+  });
+
+  describe('isLastWeekdayToken', function () {
+    it('is true for a valid token and false otherwise', function () {
+      assert.isTrue(isLastWeekdayToken('5L'));
+      assert.isTrue(isLastWeekdayToken('7L'));
+      assert.isFalse(isLastWeekdayToken(5));
+      assert.isFalse(isLastWeekdayToken('L'));
+    });
+  });
+
+  describe('isLastWeekdayOfMonth', function () {
+    // June 2026: Fridays fall on 5, 12, 19, 26.
+    it('is true for the last occurrence of the weekday', function () {
+      assert.isTrue(isLastWeekdayOfMonth(2026, 6, 26)); // last Friday
+    });
+
+    it('is false for an earlier occurrence of the weekday', function () {
+      assert.isFalse(isLastWeekdayOfMonth(2026, 6, 19)); // 2nd-to-last Friday
+      assert.isFalse(isLastWeekdayOfMonth(2026, 6, 5));
+    });
+
+    it('handles a month-end weekday across a month boundary', function () {
+      // Jan 31 2025 is a Friday and the last Friday of January.
+      assert.isTrue(isLastWeekdayOfMonth(2025, 1, 31));
+    });
+  });
+
+  describe('matchesDayOfWeek', function () {
+    it('matches an explicit numeric weekday', function () {
+      // 2026-06-26 is a Friday (weekday 5).
+      assert.isTrue(matchesDayOfWeek([5], 2026, 6, 26, 5));
+      assert.isFalse(matchesDayOfWeek([5], 2026, 6, 25, 4));
+    });
+
+    it("matches only the last weekday for a '<weekday>L' token", function () {
+      assert.isTrue(matchesDayOfWeek(['5L'], 2026, 6, 26, 5));  // last Friday
+      assert.isFalse(matchesDayOfWeek(['5L'], 2026, 6, 19, 5)); // earlier Friday
+    });
+
+    it('matches the last Sunday for 0L / 7L (both normalise to 0)', function () {
+      // June 2026: Sundays fall on 7, 14, 21, 28. Last Sunday = 28.
+      assert.isTrue(matchesDayOfWeek(['0L'], 2026, 6, 28, 0));
+      assert.isFalse(matchesDayOfWeek(['0L'], 2026, 6, 21, 0));
+    });
+
+    it('supports a token combined with explicit weekdays', function () {
+      // last Friday or any Monday (weekday 1).
+      assert.isTrue(matchesDayOfWeek(['5L', 1], 2026, 6, 26, 5)); // last Friday
+      assert.isTrue(matchesDayOfWeek(['5L', 1], 2026, 6, 22, 1)); // a Monday
+      assert.isFalse(matchesDayOfWeek(['5L', 1], 2026, 6, 19, 5)); // non-last Friday, not Monday
+    });
+  });
+});

--- a/src/time/day-of-week.ts
+++ b/src/time/day-of-week.ts
@@ -1,0 +1,65 @@
+/**
+ * The `L` token in the day-of-week field means "the last <weekday> of the
+ * month": `5L` is the last Friday, `0L`/`7L` the last Sunday. Weekday numbering
+ * follows the existing convention (0 = Sunday, after 7 has been normalised to
+ * 0). The token is kept as a literal `<weekday>L` string through the pattern
+ * pipeline and resolved against the actual date here.
+ */
+const LAST_WEEKDAY_REGEX = /^([0-7])L$/i;
+
+export type DayOfWeekField = (number | string)[];
+
+/**
+ * Parses a `<weekday>L` token into its 0-6 weekday number (Sunday=0), or
+ * returns null when the value is not such a token. `7L` is treated as `0L`.
+ */
+export function parseLastWeekdayToken(value: number | string): number | null {
+  if (typeof value !== 'string') return null;
+  const match = LAST_WEEKDAY_REGEX.exec(value);
+  if (!match) return null;
+  const weekday = parseInt(match[1], 10);
+  return weekday === 7 ? 0 : weekday;
+}
+
+/** Whether `value` is a `<weekday>L` token (e.g. `5L`, `0L`, `7L`). */
+export function isLastWeekdayToken(value: number | string): boolean {
+  return parseLastWeekdayToken(value) !== null;
+}
+
+/**
+ * Whether the given date is the last occurrence of its weekday in its month.
+ * A weekday is the last of the month when adding 7 days moves into the next
+ * month.
+ */
+export function isLastWeekdayOfMonth(year: number, month: number, day: number): boolean {
+  const date = new Date(Date.UTC(year, month - 1, day));
+  const inSevenDays = new Date(date.getTime());
+  inSevenDays.setUTCDate(inSevenDays.getUTCDate() + 7);
+  return inSevenDays.getUTCMonth() + 1 !== month;
+}
+
+/**
+ * Whether the day-of-week field matches the given date, honouring the
+ * `<weekday>L` (last weekday of month) token alongside any explicit numeric
+ * weekdays. `weekday` is the date's 0-6 weekday (Sunday=0).
+ */
+export function matchesDayOfWeek(
+  field: DayOfWeekField,
+  year: number,
+  month: number,
+  day: number,
+  weekday: number,
+): boolean {
+  for (const value of field) {
+    if (value === weekday) return true;
+    const lastWeekday = parseLastWeekdayToken(value);
+    if (
+      lastWeekday !== null &&
+      lastWeekday === weekday &&
+      isLastWeekdayOfMonth(year, month, day)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -2,6 +2,7 @@ import convertExpression from '../pattern/conversion';
 import { LocalizedTime, localTimeToTimestamp } from './localized-time';
 import { TimeMatcher } from './time-matcher';
 import { matchesDayOfMonth, DayOfMonthField } from './day-of-month';
+import { matchesDayOfWeek, DayOfWeekField } from './day-of-week';
 
 // Upper bound on the calendar search before giving up. A century is far beyond
 // any real recurrence (the calendar repeats within 28 years) and the loop is
@@ -21,7 +22,7 @@ export class MatcherWalker {
   private readonly hours: number[];
   private readonly days: DayOfMonthField;
   private readonly months: number[];
-  private readonly weekdays: number[];
+  private readonly weekdays: DayOfWeekField;
 
   constructor(cronExpression: string, baseDate: Date, timezone?: string) {
     this.cronExpression = cronExpression;
@@ -128,14 +129,15 @@ export class MatcherWalker {
   }
 
   /**
-   * Whether the calendar day matches the weekday field. A given Y/M/D has the
-   * same weekday in every timezone, so it is computed arithmetically.
-   * `getUTCDay()` and the converted weekday field share the same 0-6 (Sunday=0)
-   * space, so this matches what match() computes, making it a safe pre-filter.
+   * Whether the calendar day matches the weekday field, honouring the
+   * `<weekday>L` (last weekday of month) token. A given Y/M/D has the same
+   * weekday in every timezone, so it is computed arithmetically. `getUTCDay()`
+   * and the converted weekday field share the same 0-6 (Sunday=0) space, so this
+   * matches what match() computes, making it a safe pre-filter.
    */
   private matchesWeekday(year: number, month: number, day: number): boolean {
     const weekday = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
-    return this.weekdays.indexOf(weekday) !== -1;
+    return matchesDayOfWeek(this.weekdays, year, month, day, weekday);
   }
 }
 

--- a/src/time/time-matcher.test.ts
+++ b/src/time/time-matcher.test.ts
@@ -383,4 +383,62 @@ describe('TimeMatcher', function() {
         assert.equal(next.toISOString(), '2024-02-29T12:00:00.000Z');
       });
     })
+
+    describe('last weekday of month (<weekday>L)', function() {
+      // June 2026: Fridays fall on 5, 12, 19, 26; Sundays on 7, 14, 21, 28.
+      it('matches only the last Friday of the month', function () {
+        const matcher = new TimeMatcher('0 0 12 * * 5L', 'Etc/UTC');
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 5, 12, 0, 0))));
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 12, 12, 0, 0))));
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 19, 12, 0, 0))));
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 26, 12, 0, 0))));
+      });
+
+      it('does not match a Friday that is not the last Friday', function () {
+        const matcher = new TimeMatcher('0 0 12 * * 5L', 'Etc/UTC');
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 19, 12, 0, 0))));
+      });
+
+      it('does not match the last Friday at the wrong time', function () {
+        const matcher = new TimeMatcher('0 0 12 * * 5L', 'Etc/UTC');
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 26, 13, 0, 0))));
+      });
+
+      it('matches the last Sunday for both 0L and 7L', function () {
+        for (const expr of ['0 0 12 * * 0L', '0 0 12 * * 7L']) {
+          const matcher = new TimeMatcher(expr, 'Etc/UTC');
+          assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 21, 12, 0, 0))), expr);
+          assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 28, 12, 0, 0))), expr);
+        }
+      });
+
+      it('accepts a lowercase l', function () {
+        const matcher = new TimeMatcher('0 0 12 * * 5l', 'Etc/UTC');
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 26, 12, 0, 0))));
+      });
+
+      it('supports a token combined with explicit weekdays', function () {
+        // last Friday or any Monday (June 2026 Mondays: 1, 8, 15, 22, 29).
+        const matcher = new TimeMatcher('0 0 12 * * 5L,1', 'Etc/UTC');
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 26, 12, 0, 0))));  // last Friday
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 22, 12, 0, 0))));  // a Monday
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 19, 12, 0, 0)))); // non-last Friday
+      });
+
+      it('getNextMatch finds the last Friday of the current month', function () {
+        const next = new TimeMatcher('0 0 12 * * 5L', 'Etc/UTC').getNextMatch(new Date('2026-06-20T00:00:00Z'));
+        assert.equal(next.toISOString(), '2026-06-26T12:00:00.000Z');
+      });
+
+      it('getNextMatch advances across the month boundary', function () {
+        // After the last Friday of June, the next is the last Friday of July (31).
+        const next = new TimeMatcher('0 0 12 * * 5L', 'Etc/UTC').getNextMatch(new Date('2026-06-27T00:00:00Z'));
+        assert.equal(next.toISOString(), '2026-07-31T12:00:00.000Z');
+      });
+
+      it('getNextMatch finds the last Sunday for 7L', function () {
+        const next = new TimeMatcher('0 0 12 * * 7L', 'Etc/UTC').getNextMatch(new Date('2026-06-01T00:00:00Z'));
+        assert.equal(next.toISOString(), '2026-06-28T12:00:00.000Z');
+      });
+    })
 });

--- a/src/time/time-matcher.ts
+++ b/src/time/time-matcher.ts
@@ -4,6 +4,7 @@ import weekDayNamesConversion from '../pattern/conversion/week-day-names-convers
 import { LocalizedTime } from './localized-time';
 import { MatcherWalker } from './matcher-walker';
 import { matchesDayOfMonth } from './day-of-month';
+import { matchesDayOfWeek } from './day-of-week';
 
 function matchValue(allowedValues: number[], value: number){
   return allowedValues.indexOf(value) !== -1;
@@ -28,7 +29,8 @@ export class TimeMatcher{
         const runOnHour = matchValue(this.expressions[2], parts.hour);
         const runOnDay = matchesDayOfMonth(this.expressions[3], parts.year, parts.month, parts.day);
         const runOnMonth = matchValue(this.expressions[4], parts.month);
-        const runOnWeekDay = matchValue(this.expressions[5], parseInt(weekDayNamesConversion(parts.weekday)));
+        const weekday = parseInt(weekDayNamesConversion(parts.weekday));
+        const runOnWeekDay = matchesDayOfWeek(this.expressions[5], parts.year, parts.month, parts.day, weekday);
 
         return runOnSecond && runOnMinute && runOnHour && runOnDay && runOnMonth && runOnWeekDay;
     }


### PR DESCRIPTION
## Summary

Adds support for the `L` token in the **day-of-week** field, mirroring the existing `L` (last day of month) support in the day-of-month field.

`<weekday>L` matches the **last occurrence of that weekday in the month**:

- `0 0 12 * * 5L` runs at 12:00 on the last Friday of every month.
- `0L` / `7L` match the last Sunday (weekday numbering follows the existing convention where 0 or 7 is Sunday).
- Works with `match(date)` and `getNextRuns` / `getNextMatch`, including across month boundaries.

Previously `L` was valid only in the day-of-month field.

## Changes

- **Conversion** (`pattern/conversion/index.ts`): preserve `<weekday>L` as a literal token through the pipeline instead of `parseInt`-ing it away. `7L` is normalised to `0L` (the existing weekday-name conversion already maps 7 to 0) and the suffix is uppercased.
- **Validation** (`pattern/validation/pattern-validation.ts`): accept `<weekday>L` only in the day-of-week field; widen `dayOfWeek` in `ParsedFields` to `(number | string)[]`. Invalid forms still throw a clear error:
  - `8L` -> `8L is a invalid expression for week day`
  - `L5` -> `L5 is a invalid expression for week day`
  - bare `L` in dow -> `L is a invalid expression for week day`
- **Matching**: new `time/day-of-week.ts` module (mirrors `day-of-month.ts`) with `matchesDayOfWeek` / `isLastWeekdayOfMonth`. Wired into `TimeMatcher.match` and the `MatcherWalker` weekday pre-filter, so both direct matching and next-run search honour the token.
- **Docs**: README cron-syntax section documents the `<weekday>L` token.

## Tests

- `time/day-of-week.test.ts`: unit tests for token parsing, normalisation, last-weekday detection, and matching (including combined with explicit weekdays).
- `time/time-matcher.test.ts`: `0 0 12 * * 5L` matches only the last Friday at 12:00; `0L`/`7L` match the last Sunday; a non-last Friday does not match; lowercase `l`; wrong-time rejection; `getNextMatch` advances correctly across the month boundary (last Friday of June to last Friday of July) and resolves `7L`.
- `pattern/validation/validate-day.test.ts`: valid `5L`/`0L`/`7L`/`5l`/`5L,1`; invalid `8L`/`L5`/bare `L` throw clear errors.
- `pattern/validation/validate-detailed.test.ts`: token preservation, `7L` -> `0L` normalisation, and structured error reporting.

`npm run check` (lint + vitest with coverage) passes fully: 405 tests, lint clean. The new modules are fully covered.
