### PR TITLE
feat: support the # (nth weekday) token in the day-of-week field

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,14 @@ Need a task that doesn't start immediately? Use `cron.createTask(...)` and call 
 | hour         | 0-23                              |
 | day of month | 1-31 (or `L` for the last day)    |
 | month        | 1-12 (or names)                   |
-| day of week  | 0-7 (or names, 0 or 7 are sunday) |
+| day of week  | 0-7 (or names, 0 or 7 are sunday), and `<weekday>#<nth>` |
 
-See the [Cron Syntax guide](https://nodecron.com/cron-syntax) for ranges, steps, lists, named months/weekdays, and the `L` (last day of month) token.
+The day of week field also accepts the `<weekday>#<nth>` token, which matches the
+nth occurrence of a weekday in the month. For example `2#3` is the 3rd Tuesday and
+`0 0 12 * * 1#1` runs at 12:00 on the first Monday of every month. The weekday is
+0-7 (0 or 7 is Sunday) and the occurrence is 1-5.
+
+See the [Cron Syntax guide](https://nodecron.com/cron-syntax) for ranges, steps, lists, named months/weekdays, the `L` (last day of month) token, and the `#` (nth weekday) token.
 
 ## Options
 

--- a/src/pattern/conversion/index.ts
+++ b/src/pattern/conversion/index.ts
@@ -25,8 +25,19 @@ export default (() => {
                 // fixed numeric value. It is only meaningful in the day-of-month
                 // field, where validation accepts it; elsewhere it stays a token
                 // that no value matches and that validation rejects.
-                if (/^l$/i.test(String(numbers[j]).trim())) {
+                //
+                // Keep the `<weekday>#<nth>` token (e.g. `2#3`, "the 3rd Tuesday")
+                // as a literal too. It is only meaningful in the day-of-week
+                // field; the matcher resolves it against the actual date.
+                const value = String(numbers[j]).trim();
+                if (/^l$/i.test(value)) {
                     numbers[j] = 'L';
+                } else if (value.indexOf('#') !== -1) {
+                    // Any `#`-bearing entry is kept verbatim so the day-of-week
+                    // validator can accept the valid `<weekday>#<nth>` form and
+                    // reject malformed ones (rather than parseInt truncating
+                    // `2#6` to `2`).
+                    numbers[j] = value;
                 } else {
                     numbers[j] = parseInt(numbers[j]);
                 }

--- a/src/pattern/validation/pattern-validation.ts
+++ b/src/pattern/validation/pattern-validation.ts
@@ -1,6 +1,11 @@
 import convertExpression from '../conversion/index';
+import { isNthWeekdayToken } from '../../time/day-of-week';
 
 const validationRegex = /^(?:\d+|\*|\*\/\d+)$/;
+
+// Characters allowed in a raw expression. `#` is permitted for the day-of-week
+// `<weekday>#<nth>` token; field-level validation rejects it elsewhere.
+const ALLOWED_CHARS_REGEX = /^[a-zA-Z0-9-*/,# ]+$/;
 
 /**
  * @param {string} expression The Cron-Job expression.
@@ -73,7 +78,11 @@ function isInvalidMonth(expression) {
  * @returns {boolean}
  */
 function isInvalidWeekDay(expression) {
-    return !isValidExpression(expression, 0, 7);
+    // `<weekday>#<nth>` (e.g. `2#3`, "the 3rd Tuesday of the month") is a valid
+    // token in this field only. The weekday is 0-7 (0 or 7 = Sunday) and the
+    // occurrence is 1-5. Any remaining entries must still be valid weekdays.
+    const days = expression.filter((value) => !isNthWeekdayToken(value));
+    return !isValidExpression(days, 0, 7);
 }
 
 /**
@@ -128,7 +137,7 @@ export interface ParsedFields {
     hour: number[];
     dayOfMonth: (number | string)[];
     month: number[];
-    dayOfWeek: number[];
+    dayOfWeek: (number | string)[];
 }
 
 export interface DetailedValidation {
@@ -147,7 +156,7 @@ export function validateDetailed(pattern: string): DetailedValidation {
     if (typeof pattern !== 'string')
         return { valid: false, errors: [{ field: 'expression', message: 'pattern must be a string' }] };
 
-    if (!/^[a-zA-Z0-9-*/, ]+$/.test(pattern))
+    if (!ALLOWED_CHARS_REGEX.test(pattern))
         return { valid: false, errors: [{ field: 'expression', value: pattern, message: 'pattern includes illegal characters' }] };
 
     const raw = pattern.replace(/\s{2,}/g, ' ').trim().split(' ');
@@ -198,8 +207,7 @@ export function parse(pattern: string): ParsedFields {
 function validate(pattern) {
     if (typeof pattern !== 'string')
         throw new TypeError('pattern must be a string!');
-    const charRegex = new RegExp('^[a-zA-Z0-9-*/, ]+$');
-    if (!charRegex.test(pattern))
+    if (!ALLOWED_CHARS_REGEX.test(pattern))
         throw new TypeError('pattern includes illegal characters!');
 
     const patterns = pattern.split(' ');

--- a/src/pattern/validation/validate-week-day.test.ts
+++ b/src/pattern/validation/validate-week-day.test.ts
@@ -51,5 +51,70 @@ describe('pattern-validation', function() {
                 validate('0 0 1 1 1-7');
             }).to.not.throw();
         });
+
+        describe('nth weekday (#) token', function() {
+            it('should not fail with a valid <weekday>#<nth> token', function() {
+                expect(() => {
+                    validate('0 0 12 * * 2#3');
+                }).to.not.throw();
+            });
+
+            it('should not fail with weekday 0 or 7 in a # token', function() {
+                expect(() => {
+                    validate('0 0 12 * * 0#1');
+                }).to.not.throw();
+                expect(() => {
+                    validate('0 0 12 * * 7#5');
+                }).to.not.throw();
+            });
+
+            it('should not fail with a weekday name in a # token', function() {
+                expect(() => {
+                    validate('0 0 12 * * Tuesday#3');
+                }).to.not.throw();
+            });
+
+            it('should not fail with a # token combined with a numeric weekday', function() {
+                expect(() => {
+                    validate('0 0 12 * * 5,2#3');
+                }).to.not.throw();
+            });
+
+            it('should fail when the weekday is out of range', function() {
+                expect(() => {
+                    validate('0 0 12 * * 8#1');
+                }).to.throw('8#1 is a invalid expression for week day');
+            });
+
+            it('should fail when the nth occurrence is above 5', function() {
+                expect(() => {
+                    validate('0 0 12 * * 2#6');
+                }).to.throw('2#6 is a invalid expression for week day');
+            });
+
+            it('should fail when the nth occurrence is 0', function() {
+                expect(() => {
+                    validate('0 0 12 * * 2#0');
+                }).to.throw('2#0 is a invalid expression for week day');
+            });
+
+            it('should fail when the weekday is missing', function() {
+                expect(() => {
+                    validate('0 0 12 * * #3');
+                }).to.throw('#3 is a invalid expression for week day');
+            });
+
+            it('should fail when the nth occurrence is missing', function() {
+                expect(() => {
+                    validate('0 0 12 * * 2#');
+                }).to.throw('2# is a invalid expression for week day');
+            });
+
+            it('should fail when # is used outside the day-of-week field', function() {
+                expect(() => {
+                    validate('0 0 12 2#3 * *');
+                }).to.throw('2#3 is a invalid expression for day of month');
+            });
+        });
     });
 });

--- a/src/time/day-of-week.test.ts
+++ b/src/time/day-of-week.test.ts
@@ -1,0 +1,105 @@
+import { assert } from 'chai';
+import {
+  isNthWeekdayToken,
+  parseNthWeekday,
+  occurrenceInMonth,
+  matchesNthWeekday,
+  matchesDayOfWeek,
+} from './day-of-week';
+
+describe('day-of-week', function () {
+  describe('isNthWeekdayToken', function () {
+    it('recognises valid <weekday>#<nth> tokens', function () {
+      assert.isTrue(isNthWeekdayToken('2#3'));
+      assert.isTrue(isNthWeekdayToken('0#1'));
+      assert.isTrue(isNthWeekdayToken('7#5'));
+    });
+
+    it('rejects non-tokens', function () {
+      assert.isFalse(isNthWeekdayToken(2));
+      assert.isFalse(isNthWeekdayToken('2'));
+      assert.isFalse(isNthWeekdayToken('8#1'));
+      assert.isFalse(isNthWeekdayToken('2#6'));
+      assert.isFalse(isNthWeekdayToken('2#0'));
+      assert.isFalse(isNthWeekdayToken('#3'));
+      assert.isFalse(isNthWeekdayToken('2#'));
+    });
+  });
+
+  describe('parseNthWeekday', function () {
+    it('parses weekday and nth', function () {
+      assert.deepEqual(parseNthWeekday('2#3'), { weekday: 2, nth: 3 });
+    });
+
+    it('normalises weekday 7 to 0 (Sunday)', function () {
+      assert.deepEqual(parseNthWeekday('7#1'), { weekday: 0, nth: 1 });
+    });
+
+    it('returns null for non-tokens', function () {
+      assert.isNull(parseNthWeekday(2));
+      assert.isNull(parseNthWeekday('2#6'));
+    });
+  });
+
+  describe('occurrenceInMonth', function () {
+    it('maps day numbers to their occurrence index', function () {
+      assert.equal(occurrenceInMonth(1), 1);
+      assert.equal(occurrenceInMonth(7), 1);
+      assert.equal(occurrenceInMonth(8), 2);
+      assert.equal(occurrenceInMonth(15), 3);
+      assert.equal(occurrenceInMonth(22), 4);
+      assert.equal(occurrenceInMonth(29), 5);
+    });
+  });
+
+  describe('matchesNthWeekday', function () {
+    // June 2026: Tuesdays fall on 2, 9, 16, 23, 30.
+    it('matches the nth occurrence of the weekday', function () {
+      assert.isTrue(matchesNthWeekday('2#3', 2026, 6, 16)); // 3rd Tuesday
+      assert.isTrue(matchesNthWeekday('2#1', 2026, 6, 2)); // 1st Tuesday
+      assert.isTrue(matchesNthWeekday('2#5', 2026, 6, 30)); // 5th Tuesday
+    });
+
+    it('does not match other occurrences of the weekday', function () {
+      assert.isFalse(matchesNthWeekday('2#3', 2026, 6, 9)); // 2nd Tuesday
+      assert.isFalse(matchesNthWeekday('2#3', 2026, 6, 23)); // 4th Tuesday
+    });
+
+    it('does not match a different weekday', function () {
+      assert.isFalse(matchesNthWeekday('2#3', 2026, 6, 15)); // a Monday
+    });
+
+    it('returns false for non-token input', function () {
+      assert.isFalse(matchesNthWeekday('2', 2026, 6, 16));
+    });
+  });
+
+  describe('matchesDayOfWeek', function () {
+    function weekdayOf(year: number, month: number, day: number): number {
+      return new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+    }
+
+    it('matches plain numeric weekdays', function () {
+      // June 16 2026 is a Tuesday (2).
+      assert.isTrue(matchesDayOfWeek([2], 2026, 6, 16, weekdayOf(2026, 6, 16)));
+      assert.isFalse(matchesDayOfWeek([1], 2026, 6, 16, weekdayOf(2026, 6, 16)));
+    });
+
+    it('matches nth-weekday tokens', function () {
+      assert.isTrue(matchesDayOfWeek(['2#3'], 2026, 6, 16, weekdayOf(2026, 6, 16)));
+      assert.isFalse(matchesDayOfWeek(['2#3'], 2026, 6, 9, weekdayOf(2026, 6, 9)));
+    });
+
+    it('supports tokens mixed with numeric weekdays', function () {
+      // 5 (Friday) or the 3rd Tuesday.
+      assert.isTrue(matchesDayOfWeek([5, '2#3'], 2026, 6, 16, weekdayOf(2026, 6, 16)));
+      assert.isTrue(matchesDayOfWeek([5, '2#3'], 2026, 6, 5, weekdayOf(2026, 6, 5))); // a Friday
+      assert.isFalse(matchesDayOfWeek([5, '2#3'], 2026, 6, 9, weekdayOf(2026, 6, 9))); // 2nd Tuesday
+    });
+
+    it('never matches #5 in a month with only four occurrences', function () {
+      // February 2026: Sundays fall on 1, 8, 15, 22 (only four).
+      assert.isFalse(matchesDayOfWeek(['0#5'], 2026, 2, 22, weekdayOf(2026, 2, 22)));
+    });
+  });
+});

--- a/src/time/day-of-week.ts
+++ b/src/time/day-of-week.ts
@@ -1,0 +1,88 @@
+/**
+ * The `#` token in the day-of-week field selects the nth occurrence of a given
+ * weekday within the month. For example `2#3` means "the 3rd Tuesday of the
+ * month" (weekday numbering follows the cron convention where 0 = Sunday).
+ *
+ * Like the day-of-month `L` token, an `<weekday>#<n>` entry is kept as a literal
+ * string token (rather than a plain number) through the pattern pipeline and is
+ * resolved against the actual date here.
+ */
+
+/** Matches a `<weekday>#<nth>` token, e.g. `2#3`. */
+const NTH_WEEKDAY_REGEX = /^([0-7])#([1-5])$/;
+
+export type DayOfWeekField = (number | string)[];
+
+export interface NthWeekday {
+  /** The weekday, 0-6 (Sunday = 0). */
+  weekday: number;
+  /** Which occurrence in the month, 1-5. */
+  nth: number;
+}
+
+/** Whether the given field entry is an `<weekday>#<nth>` token. */
+export function isNthWeekdayToken(value: number | string): value is string {
+  return typeof value === 'string' && NTH_WEEKDAY_REGEX.test(value);
+}
+
+/**
+ * Parses an `<weekday>#<nth>` token into its parts, normalising weekday 7 to 0
+ * (both mean Sunday). Returns null when the value is not such a token.
+ */
+export function parseNthWeekday(value: number | string): NthWeekday | null {
+  if (typeof value !== 'string') return null;
+  const match = NTH_WEEKDAY_REGEX.exec(value);
+  if (!match) return null;
+  const weekday = parseInt(match[1], 10) % 7; // 7 -> 0 (Sunday)
+  const nth = parseInt(match[2], 10);
+  return { weekday, nth };
+}
+
+/**
+ * Which occurrence (1-based) of its weekday the given day is within its month.
+ * The 1st, 8th, 15th, 22nd and 29th of a month are the 1st..5th occurrence of
+ * whatever weekday they fall on.
+ */
+export function occurrenceInMonth(day: number): number {
+  return Math.floor((day - 1) / 7) + 1;
+}
+
+/**
+ * Whether a date matches an `<weekday>#<nth>` token: it must both fall on the
+ * requested weekday and be the nth such weekday in its month. A month with only
+ * four occurrences of a weekday never matches `#5`.
+ */
+export function matchesNthWeekday(
+  token: string,
+  year: number,
+  month: number,
+  day: number,
+): boolean {
+  const parsed = parseNthWeekday(token);
+  if (!parsed) return false;
+  const weekday = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+  if (weekday !== parsed.weekday) return false;
+  return occurrenceInMonth(day) === parsed.nth;
+}
+
+/**
+ * Whether the day-of-week field matches the given date. Plain numeric entries
+ * match on weekday alone; `<weekday>#<nth>` tokens additionally require the date
+ * to be the nth occurrence of that weekday in its month.
+ */
+export function matchesDayOfWeek(
+  field: DayOfWeekField,
+  year: number,
+  month: number,
+  day: number,
+  weekday: number,
+): boolean {
+  for (const entry of field) {
+    if (isNthWeekdayToken(entry)) {
+      if (matchesNthWeekday(entry, year, month, day)) return true;
+    } else if (entry === weekday) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -2,6 +2,7 @@ import convertExpression from '../pattern/conversion';
 import { LocalizedTime, localTimeToTimestamp } from './localized-time';
 import { TimeMatcher } from './time-matcher';
 import { matchesDayOfMonth, DayOfMonthField } from './day-of-month';
+import { matchesDayOfWeek, DayOfWeekField } from './day-of-week';
 
 // Upper bound on the calendar search before giving up. A century is far beyond
 // any real recurrence (the calendar repeats within 28 years) and the loop is
@@ -21,7 +22,7 @@ export class MatcherWalker {
   private readonly hours: number[];
   private readonly days: DayOfMonthField;
   private readonly months: number[];
-  private readonly weekdays: number[];
+  private readonly weekdays: DayOfWeekField;
 
   constructor(cronExpression: string, baseDate: Date, timezone?: string) {
     this.cronExpression = cronExpression;
@@ -128,14 +129,15 @@ export class MatcherWalker {
   }
 
   /**
-   * Whether the calendar day matches the weekday field. A given Y/M/D has the
-   * same weekday in every timezone, so it is computed arithmetically.
-   * `getUTCDay()` and the converted weekday field share the same 0-6 (Sunday=0)
-   * space, so this matches what match() computes, making it a safe pre-filter.
+   * Whether the calendar day matches the weekday field, including any
+   * `<weekday>#<nth>` tokens. A given Y/M/D has the same weekday in every
+   * timezone, so it is computed arithmetically. `getUTCDay()` and the converted
+   * weekday field share the same 0-6 (Sunday=0) space, so this matches what
+   * match() computes, making it a safe pre-filter.
    */
   private matchesWeekday(year: number, month: number, day: number): boolean {
     const weekday = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
-    return this.weekdays.indexOf(weekday) !== -1;
+    return matchesDayOfWeek(this.weekdays, year, month, day, weekday);
   }
 }
 

--- a/src/time/time-matcher.test.ts
+++ b/src/time/time-matcher.test.ts
@@ -383,4 +383,76 @@ describe('TimeMatcher', function() {
         assert.equal(next.toISOString(), '2024-02-29T12:00:00.000Z');
       });
     })
+
+    describe('nth weekday (#) token', function() {
+      // June 2026: Tuesdays fall on 2, 9, 16, 23, 30 (the 16th is the 3rd).
+      it('matches only the 3rd Tuesday at 12:00 for 2#3', function() {
+        const matcher = new TimeMatcher('0 0 12 * * 2#3', 'Etc/UTC');
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 16, 12, 0, 0))));
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 2, 12, 0, 0))));  // 1st Tuesday
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 9, 12, 0, 0))));  // 2nd Tuesday
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 23, 12, 0, 0)))); // 4th Tuesday
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 30, 12, 0, 0)))); // 5th Tuesday
+      });
+
+      it('does not match the right occurrence at the wrong time', function() {
+        const matcher = new TimeMatcher('0 0 12 * * 2#3', 'Etc/UTC');
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 16, 11, 0, 0))));
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 16, 13, 0, 0))));
+      });
+
+      it('matches the first Monday for 1#1', function() {
+        // Weekday numbering follows cron: 0/7 = Sunday, so 1 = Monday.
+        const matcher = new TimeMatcher('0 0 12 * * 1#1', 'Etc/UTC');
+        // June 2026: first Monday is the 1st.
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 1, 12, 0, 0))));
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 8, 12, 0, 0)))); // 2nd Monday
+      });
+
+      it('matches the first Sunday for 0#1', function() {
+        const matcher = new TimeMatcher('0 0 12 * * 0#1', 'Etc/UTC');
+        // June 2026: first Sunday is the 7th.
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 7, 12, 0, 0))));
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 14, 12, 0, 0)))); // 2nd Sunday
+      });
+
+      it('treats 7#1 as the first Sunday (7 = Sunday)', function() {
+        const matcher = new TimeMatcher('0 0 12 * * 7#1', 'Etc/UTC');
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 7, 12, 0, 0))));
+      });
+
+      it('never matches #5 in a month with only four occurrences', function() {
+        // February 2026: Sundays fall on 1, 8, 15, 22 (only four).
+        const matcher = new TimeMatcher('0 0 12 * * 0#5', 'Etc/UTC');
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 1, 22, 12, 0, 0)))); // 4th & last Sunday
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 1, 1, 12, 0, 0))));
+      });
+
+      it('getNextMatch advances across months', function() {
+        const matcher = new TimeMatcher('0 0 12 * * 2#3', 'Etc/UTC');
+        // Starting before the 3rd Tuesday of January 2026 (the 20th).
+        const jan = matcher.getNextMatch(new Date('2026-01-01T00:00:00Z'));
+        assert.equal(jan.toISOString(), '2026-01-20T12:00:00.000Z');
+        // From just after, it rolls to February's 3rd Tuesday (the 17th).
+        const feb = matcher.getNextMatch(jan);
+        assert.equal(feb.toISOString(), '2026-02-17T12:00:00.000Z');
+        const mar = matcher.getNextMatch(feb);
+        assert.equal(mar.toISOString(), '2026-03-17T12:00:00.000Z');
+      });
+
+      it('getNextMatch skips months without a 5th occurrence', function() {
+        const matcher = new TimeMatcher('0 0 12 * * 0#5', 'Etc/UTC');
+        // February 2026 has only four Sundays, so the next 5th Sunday is in March.
+        const next = matcher.getNextMatch(new Date('2026-02-01T00:00:00Z'));
+        assert.equal(next.toISOString(), '2026-03-29T12:00:00.000Z');
+      });
+
+      it('matches when combined with a plain weekday', function() {
+        // Either any Friday (5) or the 3rd Tuesday.
+        const matcher = new TimeMatcher('0 0 12 * * 5,2#3', 'Etc/UTC');
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 5, 12, 0, 0))));  // a Friday
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 16, 12, 0, 0)))); // 3rd Tuesday
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 9, 12, 0, 0))));  // 2nd Tuesday, not Friday
+      });
+    })
 });

--- a/src/time/time-matcher.ts
+++ b/src/time/time-matcher.ts
@@ -4,6 +4,7 @@ import weekDayNamesConversion from '../pattern/conversion/week-day-names-convers
 import { LocalizedTime } from './localized-time';
 import { MatcherWalker } from './matcher-walker';
 import { matchesDayOfMonth } from './day-of-month';
+import { matchesDayOfWeek } from './day-of-week';
 
 function matchValue(allowedValues: number[], value: number){
   return allowedValues.indexOf(value) !== -1;
@@ -28,7 +29,8 @@ export class TimeMatcher{
         const runOnHour = matchValue(this.expressions[2], parts.hour);
         const runOnDay = matchesDayOfMonth(this.expressions[3], parts.year, parts.month, parts.day);
         const runOnMonth = matchValue(this.expressions[4], parts.month);
-        const runOnWeekDay = matchValue(this.expressions[5], parseInt(weekDayNamesConversion(parts.weekday)));
+        const weekday = parseInt(weekDayNamesConversion(parts.weekday));
+        const runOnWeekDay = matchesDayOfWeek(this.expressions[5], parts.year, parts.month, parts.day, weekday);
 
         return runOnSecond && runOnMinute && runOnHour && runOnDay && runOnMonth && runOnWeekDay;
     }


### PR DESCRIPTION
## Summary

Adds support for the `<weekday>#<nth>` token in the day-of-week field, a standard cron extension. `2#3` means "the 3rd Tuesday of the month". Weekday numbering follows the existing convention (0 or 7 = Sunday) and the occurrence is 1-5.

Examples:
- `0 0 12 * * 2#3` runs at 12:00 on the 3rd Tuesday of every month.
- `0 0 12 * * 1#1` runs at 12:00 on the first Monday of every month.
- A month with only four occurrences of a weekday never matches `#5` (the walker skips it and finds the next month that has a 5th).

## Changes

- **New model `src/time/day-of-week.ts`** mirroring the day-of-month `L` token: parses/validates `<weekday>#<nth>` tokens and resolves them against an actual date (`occurrenceInMonth`, `matchesNthWeekday`, `matchesDayOfWeek`).
- **Conversion** (`pattern/conversion/index.ts`): any `#`-bearing entry is kept as a literal token through the pipeline, so the validator can accept the valid form and reject malformed ones instead of `parseInt` silently truncating `2#6` to `2`.
- **Validation** (`pattern/validation/pattern-validation.ts`): `#` is added to the allowed-characters set; `<weekday>#<nth>` is accepted in the day-of-week field only and rejected everywhere else. Invalid forms (`8#1`, `2#6`, `2#0`, `#3`, `2#`) throw a clear field error.
- **Matcher**: `TimeMatcher.match` and the `MatcherWalker` weekday pre-filter both honor the token, so `match(date)` and `getNextRuns` work consistently (including across month boundaries).
- **README**: documents the new token in the cron-syntax section.

## Tests

- `src/time/day-of-week.test.ts`: token recognition, parsing (incl. 7 -> Sunday), occurrence math, and matching (incl. mixed numeric + token, and `#5` in a 4-occurrence month). 100% coverage of the new file.
- `src/pattern/validation/validate-week-day.test.ts`: valid forms (numeric, names, combined), all invalid forms, and `#` rejected outside day-of-week.
- `src/time/time-matcher.test.ts`: `2#3` matches only the 3rd Tuesday at 12:00; `1#1`/`0#1`/`7#1` first weekday; `#5` never matches a 4-occurrence month; `getNextMatch` advances correctly across months and skips months without a 5th occurrence; combined with a plain weekday.

`npm run check` (eslint + vitest with coverage): all 407 tests pass, lint clean.

## Notes

Kept changes minimal and localized to the day-of-week parsing/matching path to reduce conflicts with the parallel `feat/last-weekday-token` work.
