### PR TITLE
feat: support extended day-of-week tokens (# nth weekday and L last weekday)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,14 @@ Need a task that doesn't start immediately? Use `cron.createTask(...)` and call 
 | hour         | 0-23                              |
 | day of month | 1-31 (or `L` for the last day)    |
 | month        | 1-12 (or names)                   |
-| day of week  | 0-7 (or names, 0 or 7 are sunday) |
+| day of week  | 0-7 (or names, 0 or 7 are sunday), and `<weekday>#<nth>` |
 
-See the [Cron Syntax guide](https://nodecron.com/cron-syntax) for ranges, steps, lists, named months/weekdays, and the `L` (last day of month) token.
+The day of week field also accepts the `<weekday>#<nth>` token, which matches the
+nth occurrence of a weekday in the month. For example `2#3` is the 3rd Tuesday and
+`0 0 12 * * 1#1` runs at 12:00 on the first Monday of every month. The weekday is
+0-7 (0 or 7 is Sunday) and the occurrence is 1-5.
+
+See the [Cron Syntax guide](https://nodecron.com/cron-syntax) for ranges, steps, lists, named months/weekdays, the `L` (last day of month) token, and the `#` (nth weekday) token.
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,13 @@ Need a task that doesn't start immediately? Use `cron.createTask(...)` and call 
 | second       | 0-59 (optional)                   |
 | minute       | 0-59                              |
 | hour         | 0-23                              |
-| day of month | 1-31 (or `L` for the last day)    |
-| month        | 1-12 (or names)                   |
-| day of week  | 0-7 (or names, 0 or 7 are sunday) |
+| day of month | 1-31 (or `L` for the last day)              |
+| month        | 1-12 (or names)                             |
+| day of week  | 0-7 (or names, 0 or 7 are sunday; `5L` = last Friday) |
 
-See the [Cron Syntax guide](https://nodecron.com/cron-syntax) for ranges, steps, lists, named months/weekdays, and the `L` (last day of month) token.
+In the day-of-week field, `<weekday>L` matches the last occurrence of that weekday in the month: `5L` is the last Friday, `0L` (or `7L`) the last Sunday.
+
+See the [Cron Syntax guide](https://nodecron.com/cron-syntax) for ranges, steps, lists, named months/weekdays, the `L` (last day of month) token, and the `<weekday>L` (last weekday of month) token.
 
 ## Options
 

--- a/src/pattern/conversion/index.ts
+++ b/src/pattern/conversion/index.ts
@@ -25,8 +25,19 @@ export default (() => {
                 // fixed numeric value. It is only meaningful in the day-of-month
                 // field, where validation accepts it; elsewhere it stays a token
                 // that no value matches and that validation rejects.
-                if (/^l$/i.test(String(numbers[j]).trim())) {
+                //
+                // Keep the `<weekday>#<nth>` token (e.g. `2#3`, "the 3rd Tuesday")
+                // as a literal too. It is only meaningful in the day-of-week
+                // field; the matcher resolves it against the actual date.
+                const value = String(numbers[j]).trim();
+                if (/^l$/i.test(value)) {
                     numbers[j] = 'L';
+                } else if (value.indexOf('#') !== -1) {
+                    // Any `#`-bearing entry is kept verbatim so the day-of-week
+                    // validator can accept the valid `<weekday>#<nth>` form and
+                    // reject malformed ones (rather than parseInt truncating
+                    // `2#6` to `2`).
+                    numbers[j] = value;
                 } else {
                     numbers[j] = parseInt(numbers[j]);
                 }

--- a/src/pattern/conversion/index.ts
+++ b/src/pattern/conversion/index.ts
@@ -21,12 +21,18 @@ export default (() => {
         for (let i=0; i < expressions.length; i++){
             const numbers = expressions[i].split(',');
             for (let j=0; j<numbers.length; j++){
+                const token = String(numbers[j]).trim();
                 // Keep the `L` (last day of month) token as a literal; it has no
                 // fixed numeric value. It is only meaningful in the day-of-month
                 // field, where validation accepts it; elsewhere it stays a token
                 // that no value matches and that validation rejects.
-                if (/^l$/i.test(String(numbers[j]).trim())) {
+                if (/^l$/i.test(token)) {
                     numbers[j] = 'L';
+                // Keep the `<weekday>L` (last weekday of month) token as a
+                // literal, e.g. `5L` for the last Friday. It is only meaningful
+                // in the day-of-week field; elsewhere validation rejects it.
+                } else if (/^[0-7]l$/i.test(token)) {
+                    numbers[j] = token.toUpperCase();
                 } else {
                     numbers[j] = parseInt(numbers[j]);
                 }

--- a/src/pattern/validation/pattern-validation.ts
+++ b/src/pattern/validation/pattern-validation.ts
@@ -73,7 +73,13 @@ function isInvalidMonth(expression) {
  * @returns {boolean}
  */
 function isInvalidWeekDay(expression) {
-    return !isValidExpression(expression, 0, 7);
+    // `<weekday>L` (last weekday of the month, e.g. `5L`) is a valid token in
+    // this field only; the `<weekday>` part has already been validated to be a
+    // single 0-7 digit by the conversion step. The remaining values must still
+    // be valid week-day numbers. Bare `L`, `L5`, `8L` and similar never reach
+    // here as a `<weekday>L` token, so they fall through and are rejected.
+    const days = expression.filter((value) => !/^[0-7]L$/.test(value));
+    return !isValidExpression(days, 0, 7);
 }
 
 /**
@@ -128,7 +134,7 @@ export interface ParsedFields {
     hour: number[];
     dayOfMonth: (number | string)[];
     month: number[];
-    dayOfWeek: number[];
+    dayOfWeek: (number | string)[];
 }
 
 export interface DetailedValidation {

--- a/src/pattern/validation/pattern-validation.ts
+++ b/src/pattern/validation/pattern-validation.ts
@@ -1,6 +1,11 @@
 import convertExpression from '../conversion/index';
+import { isNthWeekdayToken } from '../../time/day-of-week';
 
 const validationRegex = /^(?:\d+|\*|\*\/\d+)$/;
+
+// Characters allowed in a raw expression. `#` is permitted for the day-of-week
+// `<weekday>#<nth>` token; field-level validation rejects it elsewhere.
+const ALLOWED_CHARS_REGEX = /^[a-zA-Z0-9-*/,# ]+$/;
 
 /**
  * @param {string} expression The Cron-Job expression.
@@ -73,7 +78,11 @@ function isInvalidMonth(expression) {
  * @returns {boolean}
  */
 function isInvalidWeekDay(expression) {
-    return !isValidExpression(expression, 0, 7);
+    // `<weekday>#<nth>` (e.g. `2#3`, "the 3rd Tuesday of the month") is a valid
+    // token in this field only. The weekday is 0-7 (0 or 7 = Sunday) and the
+    // occurrence is 1-5. Any remaining entries must still be valid weekdays.
+    const days = expression.filter((value) => !isNthWeekdayToken(value));
+    return !isValidExpression(days, 0, 7);
 }
 
 /**
@@ -128,7 +137,7 @@ export interface ParsedFields {
     hour: number[];
     dayOfMonth: (number | string)[];
     month: number[];
-    dayOfWeek: number[];
+    dayOfWeek: (number | string)[];
 }
 
 export interface DetailedValidation {
@@ -147,7 +156,7 @@ export function validateDetailed(pattern: string): DetailedValidation {
     if (typeof pattern !== 'string')
         return { valid: false, errors: [{ field: 'expression', message: 'pattern must be a string' }] };
 
-    if (!/^[a-zA-Z0-9-*/, ]+$/.test(pattern))
+    if (!ALLOWED_CHARS_REGEX.test(pattern))
         return { valid: false, errors: [{ field: 'expression', value: pattern, message: 'pattern includes illegal characters' }] };
 
     const raw = pattern.replace(/\s{2,}/g, ' ').trim().split(' ');
@@ -198,8 +207,7 @@ export function parse(pattern: string): ParsedFields {
 function validate(pattern) {
     if (typeof pattern !== 'string')
         throw new TypeError('pattern must be a string!');
-    const charRegex = new RegExp('^[a-zA-Z0-9-*/, ]+$');
-    if (!charRegex.test(pattern))
+    if (!ALLOWED_CHARS_REGEX.test(pattern))
         throw new TypeError('pattern includes illegal characters!');
 
     const patterns = pattern.split(' ');

--- a/src/pattern/validation/validate-day.test.ts
+++ b/src/pattern/validation/validate-day.test.ts
@@ -58,4 +58,51 @@ describe('pattern-validation', function() {
             }).to.throw('LW is a invalid expression for day of month');
         });
     });
+
+    describe('validate week day', function() {
+        it('should not fail with <weekday>L (last weekday of month)', function() {
+            expect(() => {
+                validate('0 0 12 * * 5L');
+            }).to.not.throw();
+        });
+
+        it('should not fail with 0L / 7L (last Sunday)', function() {
+            expect(() => {
+                validate('0 0 12 * * 0L');
+            }).to.not.throw();
+            expect(() => {
+                validate('0 0 12 * * 7L');
+            }).to.not.throw();
+        });
+
+        it('should not fail with a lowercase weekday L', function() {
+            expect(() => {
+                validate('0 0 12 * * 5l');
+            }).to.not.throw();
+        });
+
+        it('should not fail with <weekday>L combined with explicit weekdays', function() {
+            expect(() => {
+                validate('0 0 12 * * 5L,1');
+            }).to.not.throw();
+        });
+
+        it('should fail with an out-of-range weekday L (8L)', function() {
+            expect(() => {
+                validate('0 0 12 * * 8L');
+            }).to.throw('8L is a invalid expression for week day');
+        });
+
+        it('should fail with a reversed token (L5)', function() {
+            expect(() => {
+                validate('0 0 12 * * L5');
+            }).to.throw('L5 is a invalid expression for week day');
+        });
+
+        it('should fail with a bare L in the week-day field', function() {
+            expect(() => {
+                validate('0 0 12 * * L');
+            }).to.throw('L is a invalid expression for week day');
+        });
+    });
 });

--- a/src/pattern/validation/validate-detailed.test.ts
+++ b/src/pattern/validation/validate-detailed.test.ts
@@ -25,6 +25,24 @@ describe('validateDetailed', function () {
     assert.include(result.fields?.dayOfMonth as any[], 'L');
   });
 
+  it('keeps the <weekday>L token in day-of-week', function () {
+    const result = validateDetailed('0 0 12 * * 5L');
+    assert.isTrue(result.valid);
+    assert.include(result.fields?.dayOfWeek as any[], '5L');
+  });
+
+  it('normalises 7L to 0L in day-of-week', function () {
+    const result = validateDetailed('0 0 12 * * 7L');
+    assert.isTrue(result.valid);
+    assert.include(result.fields?.dayOfWeek as any[], '0L');
+  });
+
+  it('reports an invalid <weekday>L token', function () {
+    const result = validateDetailed('0 0 12 * * 8L');
+    assert.isFalse(result.valid);
+    assert.equal(result.errors[0].field, 'dayOfWeek');
+  });
+
   it('reports an out-of-range field with its name and value', function () {
     const result = validateDetailed('0 0 99 * * *'); // 6 fields: hour = 99
     assert.isFalse(result.valid);

--- a/src/pattern/validation/validate-week-day.test.ts
+++ b/src/pattern/validation/validate-week-day.test.ts
@@ -51,5 +51,70 @@ describe('pattern-validation', function() {
                 validate('0 0 1 1 1-7');
             }).to.not.throw();
         });
+
+        describe('nth weekday (#) token', function() {
+            it('should not fail with a valid <weekday>#<nth> token', function() {
+                expect(() => {
+                    validate('0 0 12 * * 2#3');
+                }).to.not.throw();
+            });
+
+            it('should not fail with weekday 0 or 7 in a # token', function() {
+                expect(() => {
+                    validate('0 0 12 * * 0#1');
+                }).to.not.throw();
+                expect(() => {
+                    validate('0 0 12 * * 7#5');
+                }).to.not.throw();
+            });
+
+            it('should not fail with a weekday name in a # token', function() {
+                expect(() => {
+                    validate('0 0 12 * * Tuesday#3');
+                }).to.not.throw();
+            });
+
+            it('should not fail with a # token combined with a numeric weekday', function() {
+                expect(() => {
+                    validate('0 0 12 * * 5,2#3');
+                }).to.not.throw();
+            });
+
+            it('should fail when the weekday is out of range', function() {
+                expect(() => {
+                    validate('0 0 12 * * 8#1');
+                }).to.throw('8#1 is a invalid expression for week day');
+            });
+
+            it('should fail when the nth occurrence is above 5', function() {
+                expect(() => {
+                    validate('0 0 12 * * 2#6');
+                }).to.throw('2#6 is a invalid expression for week day');
+            });
+
+            it('should fail when the nth occurrence is 0', function() {
+                expect(() => {
+                    validate('0 0 12 * * 2#0');
+                }).to.throw('2#0 is a invalid expression for week day');
+            });
+
+            it('should fail when the weekday is missing', function() {
+                expect(() => {
+                    validate('0 0 12 * * #3');
+                }).to.throw('#3 is a invalid expression for week day');
+            });
+
+            it('should fail when the nth occurrence is missing', function() {
+                expect(() => {
+                    validate('0 0 12 * * 2#');
+                }).to.throw('2# is a invalid expression for week day');
+            });
+
+            it('should fail when # is used outside the day-of-week field', function() {
+                expect(() => {
+                    validate('0 0 12 2#3 * *');
+                }).to.throw('2#3 is a invalid expression for day of month');
+            });
+        });
     });
 });

--- a/src/time/day-of-week.test.ts
+++ b/src/time/day-of-week.test.ts
@@ -1,0 +1,105 @@
+import { assert } from 'chai';
+import {
+  isNthWeekdayToken,
+  parseNthWeekday,
+  occurrenceInMonth,
+  matchesNthWeekday,
+  matchesDayOfWeek,
+} from './day-of-week';
+
+describe('day-of-week', function () {
+  describe('isNthWeekdayToken', function () {
+    it('recognises valid <weekday>#<nth> tokens', function () {
+      assert.isTrue(isNthWeekdayToken('2#3'));
+      assert.isTrue(isNthWeekdayToken('0#1'));
+      assert.isTrue(isNthWeekdayToken('7#5'));
+    });
+
+    it('rejects non-tokens', function () {
+      assert.isFalse(isNthWeekdayToken(2));
+      assert.isFalse(isNthWeekdayToken('2'));
+      assert.isFalse(isNthWeekdayToken('8#1'));
+      assert.isFalse(isNthWeekdayToken('2#6'));
+      assert.isFalse(isNthWeekdayToken('2#0'));
+      assert.isFalse(isNthWeekdayToken('#3'));
+      assert.isFalse(isNthWeekdayToken('2#'));
+    });
+  });
+
+  describe('parseNthWeekday', function () {
+    it('parses weekday and nth', function () {
+      assert.deepEqual(parseNthWeekday('2#3'), { weekday: 2, nth: 3 });
+    });
+
+    it('normalises weekday 7 to 0 (Sunday)', function () {
+      assert.deepEqual(parseNthWeekday('7#1'), { weekday: 0, nth: 1 });
+    });
+
+    it('returns null for non-tokens', function () {
+      assert.isNull(parseNthWeekday(2));
+      assert.isNull(parseNthWeekday('2#6'));
+    });
+  });
+
+  describe('occurrenceInMonth', function () {
+    it('maps day numbers to their occurrence index', function () {
+      assert.equal(occurrenceInMonth(1), 1);
+      assert.equal(occurrenceInMonth(7), 1);
+      assert.equal(occurrenceInMonth(8), 2);
+      assert.equal(occurrenceInMonth(15), 3);
+      assert.equal(occurrenceInMonth(22), 4);
+      assert.equal(occurrenceInMonth(29), 5);
+    });
+  });
+
+  describe('matchesNthWeekday', function () {
+    // June 2026: Tuesdays fall on 2, 9, 16, 23, 30.
+    it('matches the nth occurrence of the weekday', function () {
+      assert.isTrue(matchesNthWeekday('2#3', 2026, 6, 16)); // 3rd Tuesday
+      assert.isTrue(matchesNthWeekday('2#1', 2026, 6, 2)); // 1st Tuesday
+      assert.isTrue(matchesNthWeekday('2#5', 2026, 6, 30)); // 5th Tuesday
+    });
+
+    it('does not match other occurrences of the weekday', function () {
+      assert.isFalse(matchesNthWeekday('2#3', 2026, 6, 9)); // 2nd Tuesday
+      assert.isFalse(matchesNthWeekday('2#3', 2026, 6, 23)); // 4th Tuesday
+    });
+
+    it('does not match a different weekday', function () {
+      assert.isFalse(matchesNthWeekday('2#3', 2026, 6, 15)); // a Monday
+    });
+
+    it('returns false for non-token input', function () {
+      assert.isFalse(matchesNthWeekday('2', 2026, 6, 16));
+    });
+  });
+
+  describe('matchesDayOfWeek', function () {
+    function weekdayOf(year: number, month: number, day: number): number {
+      return new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+    }
+
+    it('matches plain numeric weekdays', function () {
+      // June 16 2026 is a Tuesday (2).
+      assert.isTrue(matchesDayOfWeek([2], 2026, 6, 16, weekdayOf(2026, 6, 16)));
+      assert.isFalse(matchesDayOfWeek([1], 2026, 6, 16, weekdayOf(2026, 6, 16)));
+    });
+
+    it('matches nth-weekday tokens', function () {
+      assert.isTrue(matchesDayOfWeek(['2#3'], 2026, 6, 16, weekdayOf(2026, 6, 16)));
+      assert.isFalse(matchesDayOfWeek(['2#3'], 2026, 6, 9, weekdayOf(2026, 6, 9)));
+    });
+
+    it('supports tokens mixed with numeric weekdays', function () {
+      // 5 (Friday) or the 3rd Tuesday.
+      assert.isTrue(matchesDayOfWeek([5, '2#3'], 2026, 6, 16, weekdayOf(2026, 6, 16)));
+      assert.isTrue(matchesDayOfWeek([5, '2#3'], 2026, 6, 5, weekdayOf(2026, 6, 5))); // a Friday
+      assert.isFalse(matchesDayOfWeek([5, '2#3'], 2026, 6, 9, weekdayOf(2026, 6, 9))); // 2nd Tuesday
+    });
+
+    it('never matches #5 in a month with only four occurrences', function () {
+      // February 2026: Sundays fall on 1, 8, 15, 22 (only four).
+      assert.isFalse(matchesDayOfWeek(['0#5'], 2026, 2, 22, weekdayOf(2026, 2, 22)));
+    });
+  });
+});

--- a/src/time/day-of-week.test.ts
+++ b/src/time/day-of-week.test.ts
@@ -1,0 +1,83 @@
+import { assert } from 'chai';
+import {
+  isLastWeekdayOfMonth,
+  isLastWeekdayToken,
+  matchesDayOfWeek,
+  parseLastWeekdayToken,
+} from './day-of-week';
+
+describe('day-of-week', function () {
+  describe('parseLastWeekdayToken', function () {
+    it('parses a numeric weekday token', function () {
+      assert.equal(parseLastWeekdayToken('5L'), 5);
+      assert.equal(parseLastWeekdayToken('0L'), 0);
+    });
+
+    it('normalises 7L to Sunday (0)', function () {
+      assert.equal(parseLastWeekdayToken('7L'), 0);
+    });
+
+    it('accepts a lowercase l', function () {
+      assert.equal(parseLastWeekdayToken('5l'), 5);
+    });
+
+    it('returns null for non-tokens', function () {
+      assert.isNull(parseLastWeekdayToken(5));
+      assert.isNull(parseLastWeekdayToken('L'));
+      assert.isNull(parseLastWeekdayToken('L5'));
+      assert.isNull(parseLastWeekdayToken('8L'));
+    });
+  });
+
+  describe('isLastWeekdayToken', function () {
+    it('is true for a valid token and false otherwise', function () {
+      assert.isTrue(isLastWeekdayToken('5L'));
+      assert.isTrue(isLastWeekdayToken('7L'));
+      assert.isFalse(isLastWeekdayToken(5));
+      assert.isFalse(isLastWeekdayToken('L'));
+    });
+  });
+
+  describe('isLastWeekdayOfMonth', function () {
+    // June 2026: Fridays fall on 5, 12, 19, 26.
+    it('is true for the last occurrence of the weekday', function () {
+      assert.isTrue(isLastWeekdayOfMonth(2026, 6, 26)); // last Friday
+    });
+
+    it('is false for an earlier occurrence of the weekday', function () {
+      assert.isFalse(isLastWeekdayOfMonth(2026, 6, 19)); // 2nd-to-last Friday
+      assert.isFalse(isLastWeekdayOfMonth(2026, 6, 5));
+    });
+
+    it('handles a month-end weekday across a month boundary', function () {
+      // Jan 31 2025 is a Friday and the last Friday of January.
+      assert.isTrue(isLastWeekdayOfMonth(2025, 1, 31));
+    });
+  });
+
+  describe('matchesDayOfWeek', function () {
+    it('matches an explicit numeric weekday', function () {
+      // 2026-06-26 is a Friday (weekday 5).
+      assert.isTrue(matchesDayOfWeek([5], 2026, 6, 26, 5));
+      assert.isFalse(matchesDayOfWeek([5], 2026, 6, 25, 4));
+    });
+
+    it("matches only the last weekday for a '<weekday>L' token", function () {
+      assert.isTrue(matchesDayOfWeek(['5L'], 2026, 6, 26, 5));  // last Friday
+      assert.isFalse(matchesDayOfWeek(['5L'], 2026, 6, 19, 5)); // earlier Friday
+    });
+
+    it('matches the last Sunday for 0L / 7L (both normalise to 0)', function () {
+      // June 2026: Sundays fall on 7, 14, 21, 28. Last Sunday = 28.
+      assert.isTrue(matchesDayOfWeek(['0L'], 2026, 6, 28, 0));
+      assert.isFalse(matchesDayOfWeek(['0L'], 2026, 6, 21, 0));
+    });
+
+    it('supports a token combined with explicit weekdays', function () {
+      // last Friday or any Monday (weekday 1).
+      assert.isTrue(matchesDayOfWeek(['5L', 1], 2026, 6, 26, 5)); // last Friday
+      assert.isTrue(matchesDayOfWeek(['5L', 1], 2026, 6, 22, 1)); // a Monday
+      assert.isFalse(matchesDayOfWeek(['5L', 1], 2026, 6, 19, 5)); // non-last Friday, not Monday
+    });
+  });
+});

--- a/src/time/day-of-week.ts
+++ b/src/time/day-of-week.ts
@@ -1,0 +1,65 @@
+/**
+ * The `L` token in the day-of-week field means "the last <weekday> of the
+ * month": `5L` is the last Friday, `0L`/`7L` the last Sunday. Weekday numbering
+ * follows the existing convention (0 = Sunday, after 7 has been normalised to
+ * 0). The token is kept as a literal `<weekday>L` string through the pattern
+ * pipeline and resolved against the actual date here.
+ */
+const LAST_WEEKDAY_REGEX = /^([0-7])L$/i;
+
+export type DayOfWeekField = (number | string)[];
+
+/**
+ * Parses a `<weekday>L` token into its 0-6 weekday number (Sunday=0), or
+ * returns null when the value is not such a token. `7L` is treated as `0L`.
+ */
+export function parseLastWeekdayToken(value: number | string): number | null {
+  if (typeof value !== 'string') return null;
+  const match = LAST_WEEKDAY_REGEX.exec(value);
+  if (!match) return null;
+  const weekday = parseInt(match[1], 10);
+  return weekday === 7 ? 0 : weekday;
+}
+
+/** Whether `value` is a `<weekday>L` token (e.g. `5L`, `0L`, `7L`). */
+export function isLastWeekdayToken(value: number | string): boolean {
+  return parseLastWeekdayToken(value) !== null;
+}
+
+/**
+ * Whether the given date is the last occurrence of its weekday in its month.
+ * A weekday is the last of the month when adding 7 days moves into the next
+ * month.
+ */
+export function isLastWeekdayOfMonth(year: number, month: number, day: number): boolean {
+  const date = new Date(Date.UTC(year, month - 1, day));
+  const inSevenDays = new Date(date.getTime());
+  inSevenDays.setUTCDate(inSevenDays.getUTCDate() + 7);
+  return inSevenDays.getUTCMonth() + 1 !== month;
+}
+
+/**
+ * Whether the day-of-week field matches the given date, honouring the
+ * `<weekday>L` (last weekday of month) token alongside any explicit numeric
+ * weekdays. `weekday` is the date's 0-6 weekday (Sunday=0).
+ */
+export function matchesDayOfWeek(
+  field: DayOfWeekField,
+  year: number,
+  month: number,
+  day: number,
+  weekday: number,
+): boolean {
+  for (const value of field) {
+    if (value === weekday) return true;
+    const lastWeekday = parseLastWeekdayToken(value);
+    if (
+      lastWeekday !== null &&
+      lastWeekday === weekday &&
+      isLastWeekdayOfMonth(year, month, day)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/time/day-of-week.ts
+++ b/src/time/day-of-week.ts
@@ -1,0 +1,88 @@
+/**
+ * The `#` token in the day-of-week field selects the nth occurrence of a given
+ * weekday within the month. For example `2#3` means "the 3rd Tuesday of the
+ * month" (weekday numbering follows the cron convention where 0 = Sunday).
+ *
+ * Like the day-of-month `L` token, an `<weekday>#<n>` entry is kept as a literal
+ * string token (rather than a plain number) through the pattern pipeline and is
+ * resolved against the actual date here.
+ */
+
+/** Matches a `<weekday>#<nth>` token, e.g. `2#3`. */
+const NTH_WEEKDAY_REGEX = /^([0-7])#([1-5])$/;
+
+export type DayOfWeekField = (number | string)[];
+
+export interface NthWeekday {
+  /** The weekday, 0-6 (Sunday = 0). */
+  weekday: number;
+  /** Which occurrence in the month, 1-5. */
+  nth: number;
+}
+
+/** Whether the given field entry is an `<weekday>#<nth>` token. */
+export function isNthWeekdayToken(value: number | string): value is string {
+  return typeof value === 'string' && NTH_WEEKDAY_REGEX.test(value);
+}
+
+/**
+ * Parses an `<weekday>#<nth>` token into its parts, normalising weekday 7 to 0
+ * (both mean Sunday). Returns null when the value is not such a token.
+ */
+export function parseNthWeekday(value: number | string): NthWeekday | null {
+  if (typeof value !== 'string') return null;
+  const match = NTH_WEEKDAY_REGEX.exec(value);
+  if (!match) return null;
+  const weekday = parseInt(match[1], 10) % 7; // 7 -> 0 (Sunday)
+  const nth = parseInt(match[2], 10);
+  return { weekday, nth };
+}
+
+/**
+ * Which occurrence (1-based) of its weekday the given day is within its month.
+ * The 1st, 8th, 15th, 22nd and 29th of a month are the 1st..5th occurrence of
+ * whatever weekday they fall on.
+ */
+export function occurrenceInMonth(day: number): number {
+  return Math.floor((day - 1) / 7) + 1;
+}
+
+/**
+ * Whether a date matches an `<weekday>#<nth>` token: it must both fall on the
+ * requested weekday and be the nth such weekday in its month. A month with only
+ * four occurrences of a weekday never matches `#5`.
+ */
+export function matchesNthWeekday(
+  token: string,
+  year: number,
+  month: number,
+  day: number,
+): boolean {
+  const parsed = parseNthWeekday(token);
+  if (!parsed) return false;
+  const weekday = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+  if (weekday !== parsed.weekday) return false;
+  return occurrenceInMonth(day) === parsed.nth;
+}
+
+/**
+ * Whether the day-of-week field matches the given date. Plain numeric entries
+ * match on weekday alone; `<weekday>#<nth>` tokens additionally require the date
+ * to be the nth occurrence of that weekday in its month.
+ */
+export function matchesDayOfWeek(
+  field: DayOfWeekField,
+  year: number,
+  month: number,
+  day: number,
+  weekday: number,
+): boolean {
+  for (const entry of field) {
+    if (isNthWeekdayToken(entry)) {
+      if (matchesNthWeekday(entry, year, month, day)) return true;
+    } else if (entry === weekday) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/time/matcher-walker.test.ts
+++ b/src/time/matcher-walker.test.ts
@@ -93,11 +93,74 @@ describe('matcher-walker', function(){
   
   it('should match next Sunday in January or March from Aug 4th 2025 (crossing year boundary)', function(){
     const baseDate = new Date(Date.UTC(2025, 7, 4, 0, 0, 0));
-  
+
     const mw = new MatcherWalker("* * * January,March Sunday", baseDate, 'Etc/UTC');
-  
+
     assert.isFalse(mw.isMatching())
     const m = mw.matchNext();
     assert.equal(m.toISO(), '2026-01-04T00:00:00.000Z')
+  });
+
+  it('should find the 3rd Tuesday of the month with #', function(){
+    const baseDate = new Date(Date.UTC(2026, 5, 1, 0, 0, 0));
+
+    const mw = new MatcherWalker("0 0 9 * * 2#3", baseDate, 'Etc/UTC');
+
+    const m = mw.matchNext();
+    assert.equal(m.toISO(), '2026-06-16T09:00:00.000Z');
+  });
+
+  it('should skip months where the 5th occurrence does not exist', function(){
+    // Feb 2026 has only 4 Sundays (1, 8, 15, 22). The 5th Sunday
+    // does not exist, so the walker must advance to March (29th).
+    const baseDate = new Date(Date.UTC(2026, 1, 1, 0, 0, 0));
+
+    const mw = new MatcherWalker("0 0 0 * * 0#5", baseDate, 'Etc/UTC');
+
+    const m = mw.matchNext();
+    assert.equal(m.toISO(), '2026-03-29T00:00:00.000Z');
+  });
+
+  it('should enumerate multiple months correctly with #', function(){
+    // 2nd Friday at noon, starting Jan 2026.
+    // Jan: Fri 9 → 2nd is 9. Feb: Fri 6,13 → 2nd is 13. Mar: Fri 6,13 → 2nd is 13.
+    const baseDate = new Date(Date.UTC(2026, 0, 1, 0, 0, 0));
+
+    const mw = new MatcherWalker("0 0 12 * * 5#2", baseDate, 'Etc/UTC');
+
+    const m1 = mw.matchNext();
+    assert.equal(m1.toISO(), '2026-01-09T12:00:00.000Z');
+
+    const mw2 = new MatcherWalker("0 0 12 * * 5#2", m1.toDate(), 'Etc/UTC');
+    const m2 = mw2.matchNext();
+    assert.equal(m2.toISO(), '2026-02-13T12:00:00.000Z');
+
+    const mw3 = new MatcherWalker("0 0 12 * * 5#2", m2.toDate(), 'Etc/UTC');
+    const m3 = mw3.matchNext();
+    assert.equal(m3.toISO(), '2026-03-13T12:00:00.000Z');
+  });
+
+  it('should find the last Friday of the month with L', function(){
+    // June 2026: Fridays on 5, 12, 19, 26. Last = 26.
+    const baseDate = new Date(Date.UTC(2026, 5, 1, 0, 0, 0));
+
+    const mw = new MatcherWalker("0 0 18 * * 5L", baseDate, 'Etc/UTC');
+
+    const m = mw.matchNext();
+    assert.equal(m.toISO(), '2026-06-26T18:00:00.000Z');
+  });
+
+  it('should advance across months with L', function(){
+    // Last Monday at 8am. June 2026: last Mon = 29. July 2026: last Mon = 27.
+    const baseDate = new Date(Date.UTC(2026, 5, 1, 0, 0, 0));
+
+    const mw = new MatcherWalker("0 0 8 * * 1L", baseDate, 'Etc/UTC');
+
+    const m1 = mw.matchNext();
+    assert.equal(m1.toISO(), '2026-06-29T08:00:00.000Z');
+
+    const mw2 = new MatcherWalker("0 0 8 * * 1L", m1.toDate(), 'Etc/UTC');
+    const m2 = mw2.matchNext();
+    assert.equal(m2.toISO(), '2026-07-27T08:00:00.000Z');
   });
 });

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -2,6 +2,7 @@ import convertExpression from '../pattern/conversion';
 import { LocalizedTime, localTimeToTimestamp } from './localized-time';
 import { TimeMatcher } from './time-matcher';
 import { matchesDayOfMonth, DayOfMonthField } from './day-of-month';
+import { matchesDayOfWeek, DayOfWeekField } from './day-of-week';
 
 // Upper bound on the calendar search before giving up. A century is far beyond
 // any real recurrence (the calendar repeats within 28 years) and the loop is
@@ -21,7 +22,7 @@ export class MatcherWalker {
   private readonly hours: number[];
   private readonly days: DayOfMonthField;
   private readonly months: number[];
-  private readonly weekdays: number[];
+  private readonly weekdays: DayOfWeekField;
 
   constructor(cronExpression: string, baseDate: Date, timezone?: string) {
     this.cronExpression = cronExpression;
@@ -128,14 +129,15 @@ export class MatcherWalker {
   }
 
   /**
-   * Whether the calendar day matches the weekday field. A given Y/M/D has the
-   * same weekday in every timezone, so it is computed arithmetically.
-   * `getUTCDay()` and the converted weekday field share the same 0-6 (Sunday=0)
-   * space, so this matches what match() computes, making it a safe pre-filter.
+   * Whether the calendar day matches the weekday field, honouring the
+   * `<weekday>L` (last weekday of month) token. A given Y/M/D has the same
+   * weekday in every timezone, so it is computed arithmetically. `getUTCDay()`
+   * and the converted weekday field share the same 0-6 (Sunday=0) space, so this
+   * matches what match() computes, making it a safe pre-filter.
    */
   private matchesWeekday(year: number, month: number, day: number): boolean {
     const weekday = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
-    return this.weekdays.indexOf(weekday) !== -1;
+    return matchesDayOfWeek(this.weekdays, year, month, day, weekday);
   }
 }
 

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -2,6 +2,7 @@ import convertExpression from '../pattern/conversion';
 import { LocalizedTime, localTimeToTimestamp } from './localized-time';
 import { TimeMatcher } from './time-matcher';
 import { matchesDayOfMonth, DayOfMonthField } from './day-of-month';
+import { matchesDayOfWeek, DayOfWeekField } from './day-of-week';
 
 // Upper bound on the calendar search before giving up. A century is far beyond
 // any real recurrence (the calendar repeats within 28 years) and the loop is
@@ -21,7 +22,7 @@ export class MatcherWalker {
   private readonly hours: number[];
   private readonly days: DayOfMonthField;
   private readonly months: number[];
-  private readonly weekdays: number[];
+  private readonly weekdays: DayOfWeekField;
 
   constructor(cronExpression: string, baseDate: Date, timezone?: string) {
     this.cronExpression = cronExpression;
@@ -128,14 +129,15 @@ export class MatcherWalker {
   }
 
   /**
-   * Whether the calendar day matches the weekday field. A given Y/M/D has the
-   * same weekday in every timezone, so it is computed arithmetically.
-   * `getUTCDay()` and the converted weekday field share the same 0-6 (Sunday=0)
-   * space, so this matches what match() computes, making it a safe pre-filter.
+   * Whether the calendar day matches the weekday field, including any
+   * `<weekday>#<nth>` tokens. A given Y/M/D has the same weekday in every
+   * timezone, so it is computed arithmetically. `getUTCDay()` and the converted
+   * weekday field share the same 0-6 (Sunday=0) space, so this matches what
+   * match() computes, making it a safe pre-filter.
    */
   private matchesWeekday(year: number, month: number, day: number): boolean {
     const weekday = new Date(Date.UTC(year, month - 1, day)).getUTCDay();
-    return this.weekdays.indexOf(weekday) !== -1;
+    return matchesDayOfWeek(this.weekdays, year, month, day, weekday);
   }
 }
 

--- a/src/time/time-matcher.test.ts
+++ b/src/time/time-matcher.test.ts
@@ -383,4 +383,76 @@ describe('TimeMatcher', function() {
         assert.equal(next.toISOString(), '2024-02-29T12:00:00.000Z');
       });
     })
+
+    describe('nth weekday (#) token', function() {
+      // June 2026: Tuesdays fall on 2, 9, 16, 23, 30 (the 16th is the 3rd).
+      it('matches only the 3rd Tuesday at 12:00 for 2#3', function() {
+        const matcher = new TimeMatcher('0 0 12 * * 2#3', 'Etc/UTC');
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 16, 12, 0, 0))));
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 2, 12, 0, 0))));  // 1st Tuesday
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 9, 12, 0, 0))));  // 2nd Tuesday
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 23, 12, 0, 0)))); // 4th Tuesday
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 30, 12, 0, 0)))); // 5th Tuesday
+      });
+
+      it('does not match the right occurrence at the wrong time', function() {
+        const matcher = new TimeMatcher('0 0 12 * * 2#3', 'Etc/UTC');
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 16, 11, 0, 0))));
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 16, 13, 0, 0))));
+      });
+
+      it('matches the first Monday for 1#1', function() {
+        // Weekday numbering follows cron: 0/7 = Sunday, so 1 = Monday.
+        const matcher = new TimeMatcher('0 0 12 * * 1#1', 'Etc/UTC');
+        // June 2026: first Monday is the 1st.
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 1, 12, 0, 0))));
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 8, 12, 0, 0)))); // 2nd Monday
+      });
+
+      it('matches the first Sunday for 0#1', function() {
+        const matcher = new TimeMatcher('0 0 12 * * 0#1', 'Etc/UTC');
+        // June 2026: first Sunday is the 7th.
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 7, 12, 0, 0))));
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 14, 12, 0, 0)))); // 2nd Sunday
+      });
+
+      it('treats 7#1 as the first Sunday (7 = Sunday)', function() {
+        const matcher = new TimeMatcher('0 0 12 * * 7#1', 'Etc/UTC');
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 7, 12, 0, 0))));
+      });
+
+      it('never matches #5 in a month with only four occurrences', function() {
+        // February 2026: Sundays fall on 1, 8, 15, 22 (only four).
+        const matcher = new TimeMatcher('0 0 12 * * 0#5', 'Etc/UTC');
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 1, 22, 12, 0, 0)))); // 4th & last Sunday
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 1, 1, 12, 0, 0))));
+      });
+
+      it('getNextMatch advances across months', function() {
+        const matcher = new TimeMatcher('0 0 12 * * 2#3', 'Etc/UTC');
+        // Starting before the 3rd Tuesday of January 2026 (the 20th).
+        const jan = matcher.getNextMatch(new Date('2026-01-01T00:00:00Z'));
+        assert.equal(jan.toISOString(), '2026-01-20T12:00:00.000Z');
+        // From just after, it rolls to February's 3rd Tuesday (the 17th).
+        const feb = matcher.getNextMatch(jan);
+        assert.equal(feb.toISOString(), '2026-02-17T12:00:00.000Z');
+        const mar = matcher.getNextMatch(feb);
+        assert.equal(mar.toISOString(), '2026-03-17T12:00:00.000Z');
+      });
+
+      it('getNextMatch skips months without a 5th occurrence', function() {
+        const matcher = new TimeMatcher('0 0 12 * * 0#5', 'Etc/UTC');
+        // February 2026 has only four Sundays, so the next 5th Sunday is in March.
+        const next = matcher.getNextMatch(new Date('2026-02-01T00:00:00Z'));
+        assert.equal(next.toISOString(), '2026-03-29T12:00:00.000Z');
+      });
+
+      it('matches when combined with a plain weekday', function() {
+        // Either any Friday (5) or the 3rd Tuesday.
+        const matcher = new TimeMatcher('0 0 12 * * 5,2#3', 'Etc/UTC');
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 5, 12, 0, 0))));  // a Friday
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 16, 12, 0, 0)))); // 3rd Tuesday
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 9, 12, 0, 0))));  // 2nd Tuesday, not Friday
+      });
+    })
 });

--- a/src/time/time-matcher.test.ts
+++ b/src/time/time-matcher.test.ts
@@ -383,4 +383,62 @@ describe('TimeMatcher', function() {
         assert.equal(next.toISOString(), '2024-02-29T12:00:00.000Z');
       });
     })
+
+    describe('last weekday of month (<weekday>L)', function() {
+      // June 2026: Fridays fall on 5, 12, 19, 26; Sundays on 7, 14, 21, 28.
+      it('matches only the last Friday of the month', function () {
+        const matcher = new TimeMatcher('0 0 12 * * 5L', 'Etc/UTC');
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 5, 12, 0, 0))));
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 12, 12, 0, 0))));
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 19, 12, 0, 0))));
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 26, 12, 0, 0))));
+      });
+
+      it('does not match a Friday that is not the last Friday', function () {
+        const matcher = new TimeMatcher('0 0 12 * * 5L', 'Etc/UTC');
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 19, 12, 0, 0))));
+      });
+
+      it('does not match the last Friday at the wrong time', function () {
+        const matcher = new TimeMatcher('0 0 12 * * 5L', 'Etc/UTC');
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 26, 13, 0, 0))));
+      });
+
+      it('matches the last Sunday for both 0L and 7L', function () {
+        for (const expr of ['0 0 12 * * 0L', '0 0 12 * * 7L']) {
+          const matcher = new TimeMatcher(expr, 'Etc/UTC');
+          assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 21, 12, 0, 0))), expr);
+          assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 28, 12, 0, 0))), expr);
+        }
+      });
+
+      it('accepts a lowercase l', function () {
+        const matcher = new TimeMatcher('0 0 12 * * 5l', 'Etc/UTC');
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 26, 12, 0, 0))));
+      });
+
+      it('supports a token combined with explicit weekdays', function () {
+        // last Friday or any Monday (June 2026 Mondays: 1, 8, 15, 22, 29).
+        const matcher = new TimeMatcher('0 0 12 * * 5L,1', 'Etc/UTC');
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 26, 12, 0, 0))));  // last Friday
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 22, 12, 0, 0))));  // a Monday
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 5, 19, 12, 0, 0)))); // non-last Friday
+      });
+
+      it('getNextMatch finds the last Friday of the current month', function () {
+        const next = new TimeMatcher('0 0 12 * * 5L', 'Etc/UTC').getNextMatch(new Date('2026-06-20T00:00:00Z'));
+        assert.equal(next.toISOString(), '2026-06-26T12:00:00.000Z');
+      });
+
+      it('getNextMatch advances across the month boundary', function () {
+        // After the last Friday of June, the next is the last Friday of July (31).
+        const next = new TimeMatcher('0 0 12 * * 5L', 'Etc/UTC').getNextMatch(new Date('2026-06-27T00:00:00Z'));
+        assert.equal(next.toISOString(), '2026-07-31T12:00:00.000Z');
+      });
+
+      it('getNextMatch finds the last Sunday for 7L', function () {
+        const next = new TimeMatcher('0 0 12 * * 7L', 'Etc/UTC').getNextMatch(new Date('2026-06-01T00:00:00Z'));
+        assert.equal(next.toISOString(), '2026-06-28T12:00:00.000Z');
+      });
+    })
 });

--- a/src/time/time-matcher.ts
+++ b/src/time/time-matcher.ts
@@ -4,6 +4,7 @@ import weekDayNamesConversion from '../pattern/conversion/week-day-names-convers
 import { LocalizedTime } from './localized-time';
 import { MatcherWalker } from './matcher-walker';
 import { matchesDayOfMonth } from './day-of-month';
+import { matchesDayOfWeek } from './day-of-week';
 
 function matchValue(allowedValues: number[], value: number){
   return allowedValues.indexOf(value) !== -1;
@@ -28,7 +29,8 @@ export class TimeMatcher{
         const runOnHour = matchValue(this.expressions[2], parts.hour);
         const runOnDay = matchesDayOfMonth(this.expressions[3], parts.year, parts.month, parts.day);
         const runOnMonth = matchValue(this.expressions[4], parts.month);
-        const runOnWeekDay = matchValue(this.expressions[5], parseInt(weekDayNamesConversion(parts.weekday)));
+        const weekday = parseInt(weekDayNamesConversion(parts.weekday));
+        const runOnWeekDay = matchesDayOfWeek(this.expressions[5], parts.year, parts.month, parts.day, weekday);
 
         return runOnSecond && runOnMinute && runOnHour && runOnDay && runOnMonth && runOnWeekDay;
     }


### PR DESCRIPTION
Adds two extended tokens to the **day-of-week** field, consolidated into a single coherent `src/time/day-of-week.ts` module. This supersedes #558 and #559, which each implemented one token and collided on the same new file.

## Tokens
- **`<weekday>#<nth>`** matches the nth occurrence of a weekday in the month. `2#3` is the 3rd Tuesday, so `0 0 12 * * 1#1` runs at 12:00 on the first Monday of every month (occurrence is 1-5).
- **`<weekday>L`** matches the last occurrence of a weekday in the month. `5L` is the last Friday, `0L`/`7L` the last Sunday.

Both are honored by `match(date)` and `getNextMatch()`/`getNextRuns()`, across month boundaries. Invalid forms (`8#1`, `2#6`, `2#0`, `8L`, `L5`, bare `L` in the weekday field, ...) are rejected with a clear validation error.

## Implementation
- New `src/time/day-of-week.ts` with parsing, validation helpers and matching for both tokens.
- Token preservation through `pattern/conversion`, acceptance in `pattern/validation`, and matching wired into `time-matcher.ts` and the `matcher-walker.ts` pre-filter.
- README cron-syntax section documents both tokens.

`npm run check` (eslint + vitest with coverage): lint clean, 437 tests passing.

Closes #558. Closes #559.