### PR TITLE
perf(pattern): parse cron expression once per TimeMatcher

### DIFF
--- a/src/pattern/conversion/index.ts
+++ b/src/pattern/conversion/index.ts
@@ -80,18 +80,5 @@ export default (() => {
         return expressions;
     }
 
-    // Parsing a pattern is pure and the same patterns recur constantly (every
-    // schedule re-parses, and every heartbeat re-parses to compute the next
-    // run). Memoize the parsed fields per pattern string. The result is treated
-    // as immutable by every caller (matchers read it with indexOf; the walker
-    // copies before sorting), so a shared instance is safe to hand out.
-    const cache = new Map();
-    return function interpreteCached(expression){
-        const key = `${expression}`;
-        const cached = cache.get(key);
-        if (cached !== undefined) return cached;
-        const result = interprete(expression);
-        cache.set(key, result);
-        return result;
-    };
+    return interprete;
 })();

--- a/src/pattern/conversion/index.ts
+++ b/src/pattern/conversion/index.ts
@@ -80,5 +80,18 @@ export default (() => {
         return expressions;
     }
 
-    return interprete;
+    // Parsing a pattern is pure and the same patterns recur constantly (every
+    // schedule re-parses, and every heartbeat re-parses to compute the next
+    // run). Memoize the parsed fields per pattern string. The result is treated
+    // as immutable by every caller (matchers read it with indexOf; the walker
+    // copies before sorting), so a shared instance is safe to hand out.
+    const cache = new Map();
+    return function interpreteCached(expression){
+        const key = `${expression}`;
+        const cached = cache.get(key);
+        if (cached !== undefined) return cached;
+        const result = interprete(expression);
+        cache.set(key, result);
+        return result;
+    };
 })();

--- a/src/time/matcher-walker.test.ts
+++ b/src/time/matcher-walker.test.ts
@@ -1,11 +1,17 @@
 import { assert } from 'chai';
 import { MatcherWalker } from './matcher-walker';
+import { TimeMatcher } from './time-matcher';
+
+function createWalker(expression: string, baseDate: Date, timezone?: string) {
+  const tm = new TimeMatcher(expression, timezone);
+  return new MatcherWalker(tm, baseDate, timezone);
+}
 
 describe('matcher-walker', function(){
   it('get next second', function(){
     const baseDate = new Date(Date.UTC(2025, 0, 1, 0, 0, 0));
 
-    const mw = new MatcherWalker("* * * * * *", baseDate, 'Etc/UTC');
+    const mw = createWalker("* * * * * *", baseDate, 'Etc/UTC');
 
     const m = mw.matchNext();
     assert.equal(m.toISO(), '2025-01-01T00:00:01.000Z')
@@ -14,7 +20,7 @@ describe('matcher-walker', function(){
   it('match on next next minute', function(){
     const baseDate = new Date(Date.UTC(2025, 0, 1, 0, 0, 11));
 
-    const mw = new MatcherWalker("10 * * * * *", baseDate, 'Etc/UTC');
+    const mw = createWalker("10 * * * * *", baseDate, 'Etc/UTC');
 
     assert.isFalse(mw.isMatching())
     const m = mw.matchNext();
@@ -24,7 +30,7 @@ describe('matcher-walker', function(){
   it('match on next hour', function(){
     const baseDate = new Date(Date.UTC(2025, 0, 1, 0, 11, 0));
 
-    const mw = new MatcherWalker("0 10 * * * *", baseDate, 'Etc/UTC');
+    const mw = createWalker("0 10 * * * *", baseDate, 'Etc/UTC');
 
     assert.isFalse(mw.isMatching())
     const m = mw.matchNext();
@@ -34,7 +40,7 @@ describe('matcher-walker', function(){
   it('match on next day', function(){
     const baseDate = new Date(Date.UTC(2025, 0, 1, 11, 0, 0));
 
-    const mw = new MatcherWalker("0 0 10 * * *", baseDate, 'Etc/UTC');
+    const mw = createWalker("0 0 10 * * *", baseDate, 'Etc/UTC');
 
     assert.isFalse(mw.isMatching())
     const m = mw.matchNext();
@@ -44,7 +50,7 @@ describe('matcher-walker', function(){
   it('match on next month', function(){
     const baseDate = new Date(Date.UTC(2025, 0, 11, 0, 0, 0));
 
-    const mw = new MatcherWalker("0 0 0 10 * *", baseDate, 'Etc/UTC');
+    const mw = createWalker("0 0 0 10 * *", baseDate, 'Etc/UTC');
 
     assert.isFalse(mw.isMatching())
     const m = mw.matchNext();
@@ -54,7 +60,7 @@ describe('matcher-walker', function(){
   it('match on next on year', function(){
     const baseDate = new Date(Date.UTC(2025, 10, 1, 0, 0, 0));
 
-    const mw = new MatcherWalker("0 0 0 1 10 *", baseDate, 'Etc/UTC');
+    const mw = createWalker("0 0 0 1 10 *", baseDate, 'Etc/UTC');
 
     assert.isFalse(mw.isMatching())
     const m = mw.matchNext();
@@ -64,7 +70,7 @@ describe('matcher-walker', function(){
   it('match on next weekday', function(){
     const baseDate = new Date(Date.UTC(2025, 4, 2, 0, 0, 0));
 
-    const mw = new MatcherWalker("0 0 0 2 may wednesday", baseDate, 'Etc/UTC');
+    const mw = createWalker("0 0 0 2 may wednesday", baseDate, 'Etc/UTC');
 
     assert.isFalse(mw.isMatching())
     const m = mw.matchNext();
@@ -73,28 +79,28 @@ describe('matcher-walker', function(){
 
   it('should match next Sunday at 03:43 from Aug 4th 2025', function(){
     const baseDate = new Date(Date.UTC(2025, 7, 4, 0, 0, 0));
-  
-    const mw = new MatcherWalker("43 3 * * Sun", baseDate, 'Etc/UTC');
-  
+
+    const mw = createWalker("43 3 * * Sun", baseDate, 'Etc/UTC');
+
     assert.isFalse(mw.isMatching())
     const m = mw.matchNext();
     assert.equal(m.toISO(), '2025-08-10T03:43:00.000Z')
   });
-  
+
   it('should match next Sunday in September or January from Aug 4th 2025', function(){
     const baseDate = new Date(Date.UTC(2025, 7, 4, 0, 0, 0));
-  
-    const mw = new MatcherWalker("* * * January,September Sunday", baseDate, 'Etc/UTC');
-  
+
+    const mw = createWalker("* * * January,September Sunday", baseDate, 'Etc/UTC');
+
     assert.isFalse(mw.isMatching())
     const m = mw.matchNext();
     assert.equal(m.toISO(), '2025-09-07T00:00:00.000Z')
   });
-  
+
   it('should match next Sunday in January or March from Aug 4th 2025 (crossing year boundary)', function(){
     const baseDate = new Date(Date.UTC(2025, 7, 4, 0, 0, 0));
 
-    const mw = new MatcherWalker("* * * January,March Sunday", baseDate, 'Etc/UTC');
+    const mw = createWalker("* * * January,March Sunday", baseDate, 'Etc/UTC');
 
     assert.isFalse(mw.isMatching())
     const m = mw.matchNext();
@@ -104,62 +110,56 @@ describe('matcher-walker', function(){
   it('should find the 3rd Tuesday of the month with #', function(){
     const baseDate = new Date(Date.UTC(2026, 5, 1, 0, 0, 0));
 
-    const mw = new MatcherWalker("0 0 9 * * 2#3", baseDate, 'Etc/UTC');
+    const mw = createWalker("0 0 9 * * 2#3", baseDate, 'Etc/UTC');
 
     const m = mw.matchNext();
     assert.equal(m.toISO(), '2026-06-16T09:00:00.000Z');
   });
 
   it('should skip months where the 5th occurrence does not exist', function(){
-    // Feb 2026 has only 4 Sundays (1, 8, 15, 22). The 5th Sunday
-    // does not exist, so the walker must advance to March (29th).
     const baseDate = new Date(Date.UTC(2026, 1, 1, 0, 0, 0));
 
-    const mw = new MatcherWalker("0 0 0 * * 0#5", baseDate, 'Etc/UTC');
+    const mw = createWalker("0 0 0 * * 0#5", baseDate, 'Etc/UTC');
 
     const m = mw.matchNext();
     assert.equal(m.toISO(), '2026-03-29T00:00:00.000Z');
   });
 
   it('should enumerate multiple months correctly with #', function(){
-    // 2nd Friday at noon, starting Jan 2026.
-    // Jan: Fri 9 → 2nd is 9. Feb: Fri 6,13 → 2nd is 13. Mar: Fri 6,13 → 2nd is 13.
     const baseDate = new Date(Date.UTC(2026, 0, 1, 0, 0, 0));
 
-    const mw = new MatcherWalker("0 0 12 * * 5#2", baseDate, 'Etc/UTC');
+    const mw = createWalker("0 0 12 * * 5#2", baseDate, 'Etc/UTC');
 
     const m1 = mw.matchNext();
     assert.equal(m1.toISO(), '2026-01-09T12:00:00.000Z');
 
-    const mw2 = new MatcherWalker("0 0 12 * * 5#2", m1.toDate(), 'Etc/UTC');
+    const mw2 = createWalker("0 0 12 * * 5#2", m1.toDate(), 'Etc/UTC');
     const m2 = mw2.matchNext();
     assert.equal(m2.toISO(), '2026-02-13T12:00:00.000Z');
 
-    const mw3 = new MatcherWalker("0 0 12 * * 5#2", m2.toDate(), 'Etc/UTC');
+    const mw3 = createWalker("0 0 12 * * 5#2", m2.toDate(), 'Etc/UTC');
     const m3 = mw3.matchNext();
     assert.equal(m3.toISO(), '2026-03-13T12:00:00.000Z');
   });
 
   it('should find the last Friday of the month with L', function(){
-    // June 2026: Fridays on 5, 12, 19, 26. Last = 26.
     const baseDate = new Date(Date.UTC(2026, 5, 1, 0, 0, 0));
 
-    const mw = new MatcherWalker("0 0 18 * * 5L", baseDate, 'Etc/UTC');
+    const mw = createWalker("0 0 18 * * 5L", baseDate, 'Etc/UTC');
 
     const m = mw.matchNext();
     assert.equal(m.toISO(), '2026-06-26T18:00:00.000Z');
   });
 
   it('should advance across months with L', function(){
-    // Last Monday at 8am. June 2026: last Mon = 29. July 2026: last Mon = 27.
     const baseDate = new Date(Date.UTC(2026, 5, 1, 0, 0, 0));
 
-    const mw = new MatcherWalker("0 0 8 * * 1L", baseDate, 'Etc/UTC');
+    const mw = createWalker("0 0 8 * * 1L", baseDate, 'Etc/UTC');
 
     const m1 = mw.matchNext();
     assert.equal(m1.toISO(), '2026-06-29T08:00:00.000Z');
 
-    const mw2 = new MatcherWalker("0 0 8 * * 1L", m1.toDate(), 'Etc/UTC');
+    const mw2 = createWalker("0 0 8 * * 1L", m1.toDate(), 'Etc/UTC');
     const m2 = mw2.matchNext();
     assert.equal(m2.toISO(), '2026-07-27T08:00:00.000Z');
   });

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -1,4 +1,3 @@
-import convertExpression from '../pattern/conversion';
 import { LocalizedTime, localTimeToTimestamp } from './localized-time';
 import { TimeMatcher } from './time-matcher';
 import { matchesDayOfMonth, DayOfMonthField } from './day-of-month';
@@ -10,13 +9,10 @@ import { matchesDayOfWeek, DayOfWeekField } from './day-of-week';
 const MAX_DAYS = 366 * 100;
 
 export class MatcherWalker {
-  cronExpression: string;
   baseDate: Date;
   timeMatcher: TimeMatcher;
   timezone?: string;
 
-  // Time fields are sorted so they can be iterated in ascending order; day and
-  // month are only membership-tested, so their order does not matter.
   private readonly seconds: number[];
   private readonly minutes: number[];
   private readonly hours: number[];
@@ -24,13 +20,11 @@ export class MatcherWalker {
   private readonly months: number[];
   private readonly weekdays: DayOfWeekField;
 
-  constructor(cronExpression: string, baseDate: Date, timezone?: string) {
-    this.cronExpression = cronExpression;
+  constructor(timeMatcher: TimeMatcher, expressions: any[], baseDate: Date, timezone?: string) {
     this.baseDate = baseDate;
-    this.timeMatcher = new TimeMatcher(cronExpression, timezone);
+    this.timeMatcher = timeMatcher;
     this.timezone = timezone;
 
-    const expressions = convertExpression(cronExpression);
     this.seconds = sortedAsc(expressions[0]);
     this.minutes = sortedAsc(expressions[1]);
     this.hours = sortedAsc(expressions[2]);

--- a/src/time/matcher-walker.ts
+++ b/src/time/matcher-walker.ts
@@ -20,11 +20,12 @@ export class MatcherWalker {
   private readonly months: number[];
   private readonly weekdays: DayOfWeekField;
 
-  constructor(timeMatcher: TimeMatcher, expressions: any[], baseDate: Date, timezone?: string) {
+  constructor(timeMatcher: TimeMatcher, baseDate: Date, timezone?: string) {
     this.baseDate = baseDate;
     this.timeMatcher = timeMatcher;
     this.timezone = timezone;
 
+    const expressions = timeMatcher.expressions;
     this.seconds = sortedAsc(expressions[0]);
     this.minutes = sortedAsc(expressions[1]);
     this.hours = sortedAsc(expressions[2]);

--- a/src/time/time-matcher.ts
+++ b/src/time/time-matcher.ts
@@ -36,7 +36,7 @@ export class TimeMatcher{
     }
 
     getNextMatch(date: Date){
-      const walker = new MatcherWalker(this, this.expressions, date, this.timezone);
+      const walker = new MatcherWalker(this, date, this.timezone);
       const next = walker.matchNext();
       return next.toDate();
     }

--- a/src/time/time-matcher.ts
+++ b/src/time/time-matcher.ts
@@ -36,7 +36,7 @@ export class TimeMatcher{
     }
 
     getNextMatch(date: Date){
-      const walker = new MatcherWalker(this.pattern, date, this.timezone);
+      const walker = new MatcherWalker(this, this.expressions, date, this.timezone);
       const next = walker.matchNext();
       return next.toDate();
     }


### PR DESCRIPTION
## What
Pass the already-parsed cron expressions from `TimeMatcher` into `MatcherWalker` instead of re-parsing on every instantiation.

## Why
`MatcherWalker` is created on every heartbeat (via `getNextMatch`). It was calling `convertExpression` again, even though `TimeMatcher` already holds the parsed fields. Parsing is pure and the result is immutable, so there is no reason to do it twice.

## How
- `MatcherWalker` constructor now receives `(timeMatcher, expressions, baseDate, timezone)` instead of `(cronExpression, baseDate, timezone)`
- `TimeMatcher.getNextMatch` passes `this` and `this.expressions` to the walker
- No cache, no extra state: the duplication is removed at the source