### PR TITLE
Fix typos in internal function names

### DIFF
--- a/src/pattern/conversion/index.ts
+++ b/src/pattern/conversion/index.ts
@@ -5,7 +5,7 @@ import convertRanges from './range-conversion';
 
 export default (() => {
 
-    function appendSeccondExpression(expressions){
+    function appendSecondExpression(expressions){
         if(expressions.length === 5){
             return ['0'].concat(expressions);
         }
@@ -67,9 +67,9 @@ export default (() => {
    *  - expression 1-5 * * * *
    *  - Will be translated to 1,2,3,4,5 * * * *
    */
-    function interprete(expression){
+    function interpret(expression){
         let expressions = removeSpaces(`${expression}`).split(' ');
-        expressions = appendSeccondExpression(expressions);
+        expressions = appendSecondExpression(expressions);
         expressions[4] = monthNamesConversion(expressions[4]);
         expressions[5] = weekDayNamesConversion(expressions[5]);
         expressions = convertAsterisksToRanges(expressions);
@@ -80,5 +80,5 @@ export default (() => {
         return expressions;
     }
 
-    return interprete;
+    return interpret;
 })();

--- a/src/pattern/conversion/month-names-conversion.ts
+++ b/src/pattern/conversion/month-names-conversion.ts
@@ -11,11 +11,11 @@ export default (() => {
         return expression;
     }
 
-    function interprete(monthExpression){
+    function interpret(monthExpression){
         monthExpression = convertMonthName(monthExpression, months);
         monthExpression = convertMonthName(monthExpression, shortMonths);
         return monthExpression;
     }
 
-    return interprete;
+    return interpret;
 })();


### PR DESCRIPTION
## Summary

- Rename `interprete` to `interpret` in `src/pattern/conversion/index.ts` and `src/pattern/conversion/month-names-conversion.ts`
- Rename `appendSeccondExpression` to `appendSecondExpression` in `src/pattern/conversion/index.ts`

All internal functions, no public API changes.