### PR TITLE
feat(day-of-month): Quartz-style W, L-n and ? modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,15 @@ All events: `task:started`, `task:stopped`, `task:destroyed`, `execution:started
 | second       | 0-59 (optional)                   |
 | minute       | 0-59                              |
 | hour         | 0-23                              |
-| day of month | 1-31 (or `L` for the last day)    |
+| day of month | 1-31 (or `L` for the last day; `L-3` offset from last; `15W`, `LW` for nearest weekday) |
 | month        | 1-12 (or names)                   |
 | day of week  | 0-7 (or names, 0 or 7 are Sunday; `2#3`, `5L`) |
 
-Supports ranges (`1-5`), steps (`*/2`), lists (`1,15`), named months/weekdays, `L` (last day of month), `#` (nth weekday), and `<weekday>L` (last weekday of month). See the [Cron Syntax guide](https://nodecron.com/cron-syntax).
+Supports ranges (`1-5`), steps (`*/2`), lists (`1,15`), named months/weekdays, `L` (last day of month), `L-n` (offset from the last day), `#` (nth weekday), `<weekday>L` (last weekday of month), `W` (nearest weekday), and `?` (alias for `*` in the day fields, for Quartz-style expressions). See the [Cron Syntax guide](https://nodecron.com/cron-syntax).
+
+The `W` modifier in the day-of-month field fires on the nearest weekday (Monday-Friday) to a given day, without crossing the month boundary: `15W` is the nearest weekday to the 15th, `1W` the first weekday of the month, and `LW` the last weekday of the month. Only weekends are adjusted for; **there is no holiday awareness**.
+
+The `L-n` form fires `n` days before the last day of the month (`L-3` is the third-to-last day). In months where the offset reaches before the 1st (e.g. `L-29` in February), it simply does not fire that month.
 
 ## When to Use node-cron
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ The `W` modifier in the day-of-month field fires on the nearest weekday (Monday-
 
 The `L-n` form fires `n` days before the last day of the month (`L-3` is the third-to-last day). In months where the offset reaches before the 1st (e.g. `L-29` in February), it simply does not fire that month.
 
+> **Note on Quartz:** `L`, `L-n`, `W`, `LW`, `#`, `<weekday>L` and `?` are borrowed from [Quartz](https://www.quartz-scheduler.org/), but node-cron is **not** Quartz-compatible. Two differences matter:
+> - **Day-of-week numbering** is standard cron, not Quartz: `0-7` with `0`/`7` = Sunday and `1` = Monday. In Quartz `1` = Sunday, so the same numeric weekday fires on a different day.
+> - **day-of-month and day-of-week** are combined with **AND** (both must match), and may both be set; Quartz instead treats them as mutually exclusive and requires `?` in one of them.
+>
+> `?` is accepted purely as an alias for `*` in the day fields so Quartz-style expressions parse, not as a semantic compatibility guarantee.
+
 ## When to Use node-cron
 
 - Recurring jobs on a schedule (cron expressions with second-level precision)

--- a/src/pattern/conversion/index.ts
+++ b/src/pattern/conversion/index.ts
@@ -33,7 +33,17 @@ export default (() => {
                 // matcher resolves them against the actual date.
                 if (/^l$/i.test(token)) {
                     numbers[j] = 'L';
+                } else if (/^l-\d{1,2}$/i.test(token)) {
+                    // `L-n` (n days before the last day of the month) is kept as a
+                    // literal token, like `L`; only meaningful in day-of-month.
+                    numbers[j] = token.toUpperCase();
                 } else if (/^[0-7]l$/i.test(token)) {
+                    numbers[j] = token.toUpperCase();
+                } else if (/w/i.test(token)) {
+                    // Keep any `W`-bearing entry (e.g. `15W`, `LW`) as a literal
+                    // uppercase token so the day-of-month validator can accept the
+                    // valid forms and reject malformed ones, rather than parseInt
+                    // truncating `15W` to `15`. Only meaningful in day-of-month.
                     numbers[j] = token.toUpperCase();
                 } else if (token.indexOf('#') !== -1) {
                     // Any `#`-bearing entry is kept verbatim so the day-of-week
@@ -67,9 +77,19 @@ export default (() => {
    *  - expression 1-5 * * * *
    *  - Will be translated to 1,2,3,4,5 * * * *
    */
+    // The Quartz `?` ("no specific value") is accepted only as a whole-field
+    // token in the day-of-month and day-of-week fields, where it is an alias for
+    // `*`. Anywhere else it is left untouched so field validation rejects it.
+    function convertQuestionMarks(expressions) {
+        if (expressions[3] === '?') expressions[3] = '*';
+        if (expressions[5] === '?') expressions[5] = '*';
+        return expressions;
+    }
+
     function interpret(expression){
         let expressions = removeSpaces(`${expression}`).split(' ');
         expressions = appendSecondExpression(expressions);
+        expressions = convertQuestionMarks(expressions);
         expressions[4] = monthNamesConversion(expressions[4]);
         expressions[5] = weekDayNamesConversion(expressions[5]);
         expressions = convertAsterisksToRanges(expressions);

--- a/src/pattern/conversion/index.ts
+++ b/src/pattern/conversion/index.ts
@@ -51,8 +51,14 @@ export default (() => {
                     // reject malformed ones (rather than parseInt truncating
                     // `2#6` to `2`).
                     numbers[j] = token;
+                } else if (/^\d+$/.test(token)) {
+                    numbers[j] = parseInt(token, 10);
                 } else {
-                    numbers[j] = parseInt(numbers[j]);
+                    // Not a plain integer or a recognised token. Keep it verbatim
+                    // so field validation rejects it, instead of `parseInt`
+                    // silently truncating garbage (`15abc` -> 15, `0x1f` -> 31,
+                    // `1e2` -> 1, `15-L` -> 15).
+                    numbers[j] = token;
                 }
             }
             expressions[i] = numbers;

--- a/src/pattern/conversion/index.ts
+++ b/src/pattern/conversion/index.ts
@@ -80,6 +80,13 @@ export default (() => {
     // The Quartz `?` ("no specific value") is accepted only as a whole-field
     // token in the day-of-month and day-of-week fields, where it is an alias for
     // `*`. Anywhere else it is left untouched so field validation rejects it.
+    //
+    // NOTE: this (and the `L`, `L-n`, `W`, `LW`, `#`, `<weekday>L` tokens) is
+    // borrowed from Quartz but node-cron is NOT Quartz-compatible. Day-of-week
+    // numbering is standard cron (0-7, 0/7 = Sunday, 1 = Monday), not Quartz
+    // (1 = Sunday); and day-of-month/day-of-week are combined with AND and may
+    // both be set, whereas Quartz treats them as mutually exclusive. `?` is thus
+    // a parse-time convenience, not a semantic compatibility guarantee.
     function convertQuestionMarks(expressions) {
         if (expressions[3] === '?') expressions[3] = '*';
         if (expressions[5] === '?') expressions[5] = '*';

--- a/src/pattern/conversion/range-conversion.test.ts
+++ b/src/pattern/conversion/range-conversion.test.ts
@@ -20,4 +20,20 @@ describe('range-conversion', function() {
       const expression = conversion(expressions).join(' ');
       expect(expression).to.equal('0,2,4,6,8,10 11,13,15,17,19,21');
   });
+
+    it('should expand a reversed range', function() {
+        expect(conversion(['5-3']).join(' ')).to.equal('3,4,5');
+    });
+
+    it('should leave malformed multi-dash forms untouched', function() {
+        // Only whole `n-n` / `n-n/step` tokens expand; mangling these into
+        // valid-looking numbers is what let `1-2-3` slip past validation.
+        expect(conversion(['1-2-3'])[0]).to.equal('1-2-3');
+        expect(conversion(['1-2-3-4'])[0]).to.equal('1-2-3-4');
+        expect(conversion(['L-3-5'])[0]).to.equal('L-3-5');
+    });
+
+    it('should leave a non-positive step untouched (no infinite loop)', function() {
+        expect(conversion(['1-5/0'])[0]).to.equal('1-5/0');
+    });
 });

--- a/src/pattern/conversion/range-conversion.ts
+++ b/src/pattern/conversion/range-conversion.ts
@@ -1,30 +1,41 @@
 export default ( () => {
-    function replaceWithRange(expression, text, init, end, stepTxt) {
-        const step = parseInt(stepTxt);
-        const numbers: number[] = [];
-        let last = parseInt(end);
-        let first = parseInt(init);
+    // A range is only expanded when a whole comma-separated token is exactly
+    // `n-n` or `n-n/step`. Matching per token (rather than anywhere in the
+    // field) stops malformed forms like `1-2-3` or `L-3-5` from being mangled
+    // into something that looks valid; they are left untouched so validation
+    // rejects them. By this stage names and `*` have already been converted, so
+    // every legitimate range is numeric.
+    const rangeRegEx = /^(\d+)-(\d+)(?:\/(\d+))?$/;
 
-        if(first > last){
-            last = parseInt(init);
-            first = parseInt(end);
+    function expandRange(initTxt, endTxt, stepTxt) {
+        const step = parseInt(stepTxt, 10);
+        // A non-positive step would never terminate; leave the token for
+        // validation to reject.
+        if (!(step >= 1)) return `${initTxt}-${endTxt}/${stepTxt}`;
+
+        let first = parseInt(initTxt, 10);
+        let last = parseInt(endTxt, 10);
+        if (first > last) {
+            const swap = first;
+            first = last;
+            last = swap;
         }
 
-        for(let i = first; i <= last; i += step) {
+        const numbers: number[] = [];
+        for (let i = first; i <= last; i += step) {
             numbers.push(i);
         }
-
-        return expression.replace(new RegExp(text, 'i'), numbers.join());
+        return numbers.join();
     }
 
     function convertRange(expression){
-        const rangeRegEx = /(\d+)-(\d+)(\/(\d+)|)/;
-        let match = rangeRegEx.exec(expression);
-        while(match !== null && match.length > 0){
-            expression = replaceWithRange(expression, match[0], match[1], match[2], match[4] || '1');
-            match = rangeRegEx.exec(expression);
-        }
-        return expression;
+        return expression
+            .split(',')
+            .map((token) => {
+                const match = rangeRegEx.exec(token.trim());
+                return match ? expandRange(match[1], match[2], match[3] || '1') : token;
+            })
+            .join();
     }
 
     function convertAllRanges(expressions){

--- a/src/pattern/validation/pattern-validation.ts
+++ b/src/pattern/validation/pattern-validation.ts
@@ -4,8 +4,9 @@ import { isNthWeekdayToken } from '../../time/day-of-week';
 const validationRegex = /^(?:\d+|\*|\*\/\d+)$/;
 
 // Characters allowed in a raw expression. `#` is permitted for the day-of-week
-// `<weekday>#<nth>` token; field-level validation rejects it elsewhere.
-const ALLOWED_CHARS_REGEX = /^[a-zA-Z0-9-*/,# ]+$/;
+// `<weekday>#<nth>` token and `?` for the Quartz no-specific-value alias in the
+// day fields; field-level validation rejects either elsewhere.
+const ALLOWED_CHARS_REGEX = /^[a-zA-Z0-9-*/,#? ]+$/;
 
 /**
  * @param {string} expression The Cron-Job expression.
@@ -58,11 +59,58 @@ function isInvalidHour(expression) {
  * @param {string} expression The Cron-Job expression.
  * @returns {boolean}
  */
+// `nW` / `LW` (nearest weekday) tokens, valid in the day-of-month field only.
+const DAY_OF_MONTH_W_TOKEN = /^(\d{1,2}|L)W$/i;
+// `L-n` (n days before the last day of the month), valid in day-of-month only.
+const DAY_OF_MONTH_OFFSET_TOKEN = /^L-(\d{1,2})$/i;
+
 function isInvalidDayOfMonth(expression) {
-    // 'L' (last day of the month) is a valid token in this field only; the
-    // remaining values must still be valid day numbers.
-    const days = expression.filter((value) => value !== 'L');
+    // 'L' (last day of the month), the `nW` / `LW` (nearest weekday) tokens and
+    // the `L-n` (offset from the last day) form are valid in this field only;
+    // the remaining values must still be valid day numbers. Out-of-range forms
+    // (e.g. `0W`, `32W`, `L-0`, `L-40`) are left in so the numeric check below
+    // rejects them. The largest meaningful offset is 30 (`L-30` is day 1 of a
+    // 31-day month); anything larger can never resolve to a real day.
+    const days = expression.filter((value) => {
+        if (value === 'L') return false;
+        const weekday = DAY_OF_MONTH_W_TOKEN.exec(String(value));
+        if (weekday) {
+            if (weekday[1] === 'L') return false;
+            const target = parseInt(weekday[1], 10);
+            return target < 1 || target > 31;
+        }
+        const offset = DAY_OF_MONTH_OFFSET_TOKEN.exec(String(value));
+        if (offset) {
+            const n = parseInt(offset[1], 10);
+            return n < 1 || n > 30;
+        }
+        return true;
+    });
     return !isValidExpression(days, 1, 31);
+}
+
+/**
+ * Detects misuse of the `W` (nearest weekday) modifier in the RAW day-of-month
+ * field, before range expansion destroys the information: `W` is only valid on a
+ * single day number (`15W`) or on `L` (`LW`), optionally in a comma list
+ * (`1W,15W`). Ranges and steps (`1-15W`, `15W/2`) and malformed forms are
+ * rejected. Runs on the unexpanded string because `convertRanges` turns
+ * `1-15W` into `1,2,...,15W`, which would otherwise look valid.
+ *
+ * @param {string} rawDayOfMonth The raw day-of-month field.
+ * @returns {boolean}
+ */
+function hasInvalidWModifier(rawDayOfMonth) {
+    if (!/w/i.test(rawDayOfMonth)) return false;
+    return rawDayOfMonth.split(',').some((token) => {
+        const value = token.trim();
+        if (!/w/i.test(value)) return false; // non-W entries handled elsewhere
+        const match = DAY_OF_MONTH_W_TOKEN.exec(value);
+        if (!match) return true; // range/step/malformed `W` usage
+        if (match[1] === 'L' || match[1] === 'l') return false;
+        const target = parseInt(match[1], 10);
+        return target < 1 || target > 31;
+    });
 }
 
 /**
@@ -104,7 +152,7 @@ function validateFields(patterns, executablePatterns) {
     if (isInvalidHour(executablePatterns[2]))
         throw new Error(`${patterns[2]} is a invalid expression for hour`);
 
-    if (isInvalidDayOfMonth(executablePatterns[3]))
+    if (isInvalidDayOfMonth(executablePatterns[3]) || hasInvalidWModifier(patterns[3]))
         throw new Error(
             `${patterns[3]} is a invalid expression for day of month`
         );
@@ -171,7 +219,8 @@ export function validateDetailed(pattern: string): DetailedValidation {
 
     const errors: CronFieldError[] = [];
     FIELDS.forEach((f, i) => {
-        if (f.invalid(executable[i]))
+        const rawWMisuse = f.key === 'dayOfMonth' && hasInvalidWModifier(patterns[i]);
+        if (f.invalid(executable[i]) || rawWMisuse)
             errors.push({ field: f.key, value: patterns[i], message: `${patterns[i]} is a invalid expression for ${f.label}` });
     });
 

--- a/src/pattern/validation/pattern-validation.ts
+++ b/src/pattern/validation/pattern-validation.ts
@@ -55,15 +55,15 @@ function isInvalidHour(expression) {
     return !isValidExpression(expression, 0, 23);
 }
 
-/**
- * @param {string} expression The Cron-Job expression.
- * @returns {boolean}
- */
 // `nW` / `LW` (nearest weekday) tokens, valid in the day-of-month field only.
 const DAY_OF_MONTH_W_TOKEN = /^(\d{1,2}|L)W$/i;
 // `L-n` (n days before the last day of the month), valid in day-of-month only.
 const DAY_OF_MONTH_OFFSET_TOKEN = /^L-(\d{1,2})$/i;
 
+/**
+ * @param {string} expression The Cron-Job expression.
+ * @returns {boolean}
+ */
 function isInvalidDayOfMonth(expression) {
     // 'L' (last day of the month), the `nW` / `LW` (nearest weekday) tokens and
     // the `L-n` (offset from the last day) form are valid in this field only;
@@ -90,12 +90,13 @@ function isInvalidDayOfMonth(expression) {
 }
 
 /**
- * Detects misuse of the `W` (nearest weekday) modifier in the RAW day-of-month
- * field, before range expansion destroys the information: `W` is only valid on a
- * single day number (`15W`) or on `L` (`LW`), optionally in a comma list
- * (`1W,15W`). Ranges and steps (`1-15W`, `15W/2`) and malformed forms are
- * rejected. Runs on the unexpanded string because `convertRanges` turns
- * `1-15W` into `1,2,...,15W`, which would otherwise look valid.
+ * Detects structural misuse of the `W` (nearest weekday) modifier in the RAW
+ * day-of-month field, before range expansion destroys the information: `W` is
+ * only valid on a single day number (`15W`) or on `L` (`LW`), optionally in a
+ * comma list (`1W,15W`). Ranges and steps (`1-15W`, `15W/2`) and malformed forms
+ * are rejected. Runs on the unexpanded string because `convertRanges` turns
+ * `1-15W` into `1,2,...,15W`, which would otherwise look valid. The numeric
+ * range of a well-formed `nW` token (`0W`, `32W`) is left to isInvalidDayOfMonth.
  *
  * @param {string} rawDayOfMonth The raw day-of-month field.
  * @returns {boolean}
@@ -105,11 +106,7 @@ function hasInvalidWModifier(rawDayOfMonth) {
     return rawDayOfMonth.split(',').some((token) => {
         const value = token.trim();
         if (!/w/i.test(value)) return false; // non-W entries handled elsewhere
-        const match = DAY_OF_MONTH_W_TOKEN.exec(value);
-        if (!match) return true; // range/step/malformed `W` usage
-        if (match[1] === 'L' || match[1] === 'l') return false;
-        const target = parseInt(match[1], 10);
-        return target < 1 || target > 31;
+        return !DAY_OF_MONTH_W_TOKEN.test(value); // range/step/malformed `W` usage
     });
 }
 

--- a/src/pattern/validation/validate-day.test.ts
+++ b/src/pattern/validation/validate-day.test.ts
@@ -52,10 +52,144 @@ describe('pattern-validation', function() {
             }).to.throw('L is a invalid expression for minute');
         });
 
-        it('should fail with an unsupported L variant (LW)', function() {
+        it('should not fail with nW (nearest weekday)', function() {
+            expect(() => {
+                validate('0 0 12 15W * *');
+            }).to.not.throw();
+            expect(() => {
+                validate('0 0 12 1W * *');
+            }).to.not.throw();
+        });
+
+        it('should not fail with LW (last weekday of month)', function() {
             expect(() => {
                 validate('0 0 12 LW * *');
-            }).to.throw('LW is a invalid expression for day of month');
+            }).to.not.throw();
+        });
+
+        it('should not fail with lowercase nW / lw', function() {
+            expect(() => {
+                validate('0 0 12 15w * *');
+            }).to.not.throw();
+            expect(() => {
+                validate('0 0 12 lw * *');
+            }).to.not.throw();
+        });
+
+        it('should not fail with a list of W tokens', function() {
+            expect(() => {
+                validate('0 0 12 1W,LW * *');
+            }).to.not.throw();
+        });
+
+        it('should fail with W in a range', function() {
+            expect(() => {
+                validate('0 0 12 1-15W * *');
+            }).to.throw('1-15W is a invalid expression for day of month');
+        });
+
+        it('should fail with W combined with a step', function() {
+            expect(() => {
+                validate('0 0 12 15W/2 * *');
+            }).to.throw('15W/2 is a invalid expression for day of month');
+        });
+
+        it('should fail with an out-of-range nW (0W / 32W)', function() {
+            expect(() => {
+                validate('0 0 12 0W * *');
+            }).to.throw('0W is a invalid expression for day of month');
+            expect(() => {
+                validate('0 0 12 32W * *');
+            }).to.throw('32W is a invalid expression for day of month');
+        });
+
+        it('should fail with a malformed W token (bare W / WL / 15WW)', function() {
+            expect(() => {
+                validate('0 0 12 W * *');
+            }).to.throw('W is a invalid expression for day of month');
+            expect(() => {
+                validate('0 0 12 WL * *');
+            }).to.throw('WL is a invalid expression for day of month');
+            expect(() => {
+                validate('0 0 12 15WW * *');
+            }).to.throw('15WW is a invalid expression for day of month');
+        });
+
+        it('should fail with W outside the day-of-month field', function() {
+            expect(() => {
+                validate('0 0 12 * * 5W');
+            }).to.throw('5W is a invalid expression for week day');
+        });
+
+        it('should not fail with L-n (offset from the last day)', function() {
+            expect(() => {
+                validate('0 0 12 L-3 * *');
+            }).to.not.throw();
+            expect(() => {
+                validate('0 0 12 L-30 * *');
+            }).to.not.throw();
+            expect(() => {
+                validate('0 0 12 l-1 * *');
+            }).to.not.throw();
+        });
+
+        it('should not fail with L-n combined with explicit days', function() {
+            expect(() => {
+                validate('0 0 12 1,L-3 * *');
+            }).to.not.throw();
+        });
+
+        it('should fail with an out-of-range L-n (L-0 / L-31 / L-40)', function() {
+            expect(() => {
+                validate('0 0 12 L-0 * *');
+            }).to.throw('L-0 is a invalid expression for day of month');
+            expect(() => {
+                validate('0 0 12 L-31 * *');
+            }).to.throw('L-31 is a invalid expression for day of month');
+            expect(() => {
+                validate('0 0 12 L-40 * *');
+            }).to.throw('L-40 is a invalid expression for day of month');
+        });
+
+        it('should fail with L-n outside the day-of-month field', function() {
+            expect(() => {
+                validate('0 0 12 * * L-3');
+            }).to.throw('L-3 is a invalid expression for week day');
+        });
+    });
+
+    describe('validate ? (no-specific-value alias)', function() {
+        it('should accept ? in the day-of-month field', function() {
+            expect(() => {
+                validate('0 0 12 ? * 1');
+            }).to.not.throw();
+        });
+
+        it('should accept ? in the day-of-week field', function() {
+            expect(() => {
+                validate('0 0 12 15 * ?');
+            }).to.not.throw();
+        });
+
+        it('should accept ? in both day fields', function() {
+            expect(() => {
+                validate('0 0 12 ? * ?');
+            }).to.not.throw();
+        });
+
+        it('should fail with ? combined in a list', function() {
+            expect(() => {
+                validate('0 0 12 1,? * *');
+            }).to.throw('1,? is a invalid expression for day of month');
+        });
+
+        it('should fail with ? outside the day fields', function() {
+            expect(() => {
+                validate('0 ? * * * *');
+            }).to.throw('? is a invalid expression for minute');
+            expect(() => {
+                validate('0 0 12 * ? *');
+            }).to.throw('? is a invalid expression for month');
         });
     });
 

--- a/src/pattern/validation/validate-detailed.test.ts
+++ b/src/pattern/validation/validate-detailed.test.ts
@@ -37,6 +37,32 @@ describe('validateDetailed', function () {
     assert.include(result.fields?.dayOfWeek as any[], '0L');
   });
 
+  it('keeps the nW / LW tokens in day-of-month', function () {
+    const result = validateDetailed('0 0 12 15W,LW * *');
+    assert.isTrue(result.valid);
+    assert.includeMembers(result.fields?.dayOfMonth as any[], ['15W', 'LW']);
+  });
+
+  it('reports W used in a range as invalid day-of-month', function () {
+    const result = validateDetailed('0 0 12 1-15W * *');
+    assert.isFalse(result.valid);
+    assert.equal(result.errors[0].field, 'dayOfMonth');
+    assert.equal(result.errors[0].value, '1-15W');
+  });
+
+  it('keeps the L-n token in day-of-month', function () {
+    const result = validateDetailed('0 0 12 L-3 * *');
+    assert.isTrue(result.valid);
+    assert.include(result.fields?.dayOfMonth as any[], 'L-3');
+  });
+
+  it('reports an out-of-range L-n token', function () {
+    const result = validateDetailed('0 0 12 L-40 * *');
+    assert.isFalse(result.valid);
+    assert.equal(result.errors[0].field, 'dayOfMonth');
+    assert.equal(result.errors[0].value, 'L-40');
+  });
+
   it('reports an invalid <weekday>L token', function () {
     const result = validateDetailed('0 0 12 * * 8L');
     assert.isFalse(result.valid);

--- a/src/pattern/validation/validate.test.ts
+++ b/src/pattern/validation/validate.test.ts
@@ -32,4 +32,33 @@ describe('pattern-validation', function() {
             validate(50);
         }).to.throw('pattern must be a string!');
     });
+
+    describe('rejects malformed tokens instead of silently truncating', function() {
+        // Previously these slipped through because the parser fell back to a
+        // lenient parseInt (`15abc` -> 15, `0x1f` -> 31) or because range
+        // expansion mangled multi-dash forms (`1-2-3` -> 1,2,3).
+        const garbage = [
+            '15abc', '0x1f', '1e2', '15/x', '5/2', '1-', '15--3',
+            '1-2-3', '1-2-3-4', '15-L', '1-L', '15L-3', '1-5/0',
+        ];
+
+        garbage.forEach((token) => {
+            it(`rejects "${token}" in the day-of-month field`, function() {
+                expect(() => {
+                    validate(`0 0 0 ${token} * *`);
+                }).to.throw(/invalid expression|illegal characters/);
+            });
+        });
+
+        it('rejects garbage in a non-day field too', function() {
+            expect(() => {
+                validate('0 5min * * * *');
+            }).to.throw('5min is a invalid expression for minute');
+        });
+
+        it('still accepts the valid forms it resembles', function() {
+            ['0 0 0 1-5 * *', '0 0 0 */2 * *', '0 0 0 5-3 * *', '0 0 0 1,15,L * *', '0 0 0 1-10/2 * *']
+                .forEach((expr) => expect(() => validate(expr), expr).to.not.throw());
+        });
+    });
 });

--- a/src/time/day-of-month.test.ts
+++ b/src/time/day-of-month.test.ts
@@ -41,5 +41,90 @@ describe('day-of-month', function () {
       assert.isTrue(matchesDayOfMonth([15, 'L'], 2025, 1, 31));
       assert.isFalse(matchesDayOfMonth([15, 'L'], 2025, 1, 20));
     });
+
+    describe("the 'nW' / 'LW' (nearest weekday) tokens", function () {
+      // Anchor months (2025): Mar 1 = Sat, Mar 15 = Sat, Mar 31 = Mon;
+      // Jun 1 = Sun, Jun 15 = Sun; May 31 = Sat; Aug 31 = Sun.
+
+      it('fires on the same day when the target is a weekday', function () {
+        // Jan 15 2025 is a Wednesday.
+        assert.isTrue(matchesDayOfMonth(['15W'], 2025, 1, 15));
+        assert.isFalse(matchesDayOfMonth(['15W'], 2025, 1, 14));
+        assert.isFalse(matchesDayOfMonth(['15W'], 2025, 1, 16));
+      });
+
+      it('shifts a Saturday target to the previous Friday', function () {
+        // Mar 15 2025 is a Saturday -> Fri 14.
+        assert.isTrue(matchesDayOfMonth(['15W'], 2025, 3, 14));
+        assert.isFalse(matchesDayOfMonth(['15W'], 2025, 3, 15));
+      });
+
+      it('shifts a Sunday target to the following Monday', function () {
+        // Jun 15 2025 is a Sunday -> Mon 16.
+        assert.isTrue(matchesDayOfMonth(['15W'], 2025, 6, 16));
+        assert.isFalse(matchesDayOfMonth(['15W'], 2025, 6, 15));
+      });
+
+      it('keeps 1W inside the month when the 1st is a Saturday', function () {
+        // Mar 1 2025 is a Saturday -> Mon 3 (not Feb 28).
+        assert.isTrue(matchesDayOfMonth(['1W'], 2025, 3, 3));
+        assert.isFalse(matchesDayOfMonth(['1W'], 2025, 3, 1));
+      });
+
+      it('keeps 1W inside the month when the 1st is a Sunday', function () {
+        // Jun 1 2025 is a Sunday -> Mon 2.
+        assert.isTrue(matchesDayOfMonth(['1W'], 2025, 6, 2));
+        assert.isFalse(matchesDayOfMonth(['1W'], 2025, 6, 1));
+      });
+
+      it('resolves LW to the last weekday of the month', function () {
+        // Mar 31 2025 = Mon (weekday) -> 31.
+        assert.isTrue(matchesDayOfMonth(['LW'], 2025, 3, 31));
+        // May 31 2025 = Sat -> Fri 30.
+        assert.isTrue(matchesDayOfMonth(['LW'], 2025, 5, 30));
+        assert.isFalse(matchesDayOfMonth(['LW'], 2025, 5, 31));
+        // Aug 31 2025 = Sun -> Fri 29.
+        assert.isTrue(matchesDayOfMonth(['LW'], 2025, 8, 29));
+        assert.isFalse(matchesDayOfMonth(['LW'], 2025, 8, 31));
+      });
+
+      it('never fires for a target day that does not exist in the month', function () {
+        // 31W in April (30 days) -> no day matches.
+        for (let day = 1; day <= 30; day++) {
+          assert.isFalse(matchesDayOfMonth(['31W'], 2025, 4, day));
+        }
+      });
+
+      it('supports a list of W tokens', function () {
+        // Mar 2025: 1W -> Mon 3, LW -> Mon 31.
+        assert.isTrue(matchesDayOfMonth(['1W', 'LW'], 2025, 3, 3));
+        assert.isTrue(matchesDayOfMonth(['1W', 'LW'], 2025, 3, 31));
+        assert.isFalse(matchesDayOfMonth(['1W', 'LW'], 2025, 3, 15));
+      });
+    });
+
+    describe("the 'L-n' (offset from last day) token", function () {
+      it('resolves L-n relative to the last day of the month', function () {
+        assert.isTrue(matchesDayOfMonth(['L-3'], 2025, 1, 28));  // Jan (31) -> 28
+        assert.isFalse(matchesDayOfMonth(['L-3'], 2025, 1, 27));
+        assert.isFalse(matchesDayOfMonth(['L-3'], 2025, 1, 29));
+        assert.isTrue(matchesDayOfMonth(['L-3'], 2025, 2, 25));  // Feb (28) -> 25
+        assert.isTrue(matchesDayOfMonth(['L-3'], 2025, 4, 27));  // Apr (30) -> 27
+      });
+
+      it('resolves L-30 to the 1st only in 31-day months', function () {
+        assert.isTrue(matchesDayOfMonth(['L-30'], 2025, 1, 1)); // Jan (31) -> 1
+        for (let day = 1; day <= 30; day++) {
+          assert.isFalse(matchesDayOfMonth(['L-30'], 2025, 4, day)); // Apr (30) -> 0, no day
+        }
+      });
+
+      it('never fires when the offset reaches before the 1st', function () {
+        // Feb 2025 (28 days): L-29 -> -1, no day matches.
+        for (let day = 1; day <= 28; day++) {
+          assert.isFalse(matchesDayOfMonth(['L-29'], 2025, 2, day));
+        }
+      });
+    });
   });
 });

--- a/src/time/day-of-month.ts
+++ b/src/time/day-of-month.ts
@@ -6,6 +6,24 @@
  */
 export const LAST_DAY_TOKEN = 'L';
 
+/**
+ * The `W` modifier in the day-of-month field means "the nearest weekday
+ * (Monday-Friday) to the given day, without crossing the month boundary".
+ * It suffixes either a day number (`15W`) or the `L` token (`LW`, the last
+ * weekday of the month). Like `L`, it is kept as a literal token through the
+ * pipeline and resolved against the actual date here. Weekends are the only
+ * adjustment; there is no holiday awareness.
+ */
+const WEEKDAY_TOKEN = /^(\d{1,2}|L)W$/;
+
+/**
+ * The `L-n` form in the day-of-month field means "the day `n` days before the
+ * last day of the month" (e.g. `L-3` is the third-to-last day). Kept as a
+ * literal token and resolved here. When the offset reaches past the start of a
+ * particular month (e.g. `L-29` in February) no day matches that month.
+ */
+const LAST_DAY_OFFSET_TOKEN = /^L-(\d{1,2})$/;
+
 export type DayOfMonthField = (number | string)[];
 
 /** The last calendar day (28-31) of the given 1-based month. */
@@ -15,8 +33,28 @@ export function lastDayOfMonth(year: number, month: number): number {
 }
 
 /**
+ * The nearest weekday (Mon-Fri) to `target` within the given 1-based month,
+ * never crossing into an adjacent month:
+ *  - a weekday target resolves to itself;
+ *  - a Saturday shifts to the previous Friday, unless that would leave the
+ *    month (target is the 1st), in which case it shifts to the following Monday;
+ *  - a Sunday shifts to the following Monday, unless that would leave the month
+ *    (target is the last day), in which case it shifts to the previous Friday.
+ * Returns -1 when `target` does not exist in the month (e.g. 31W in April).
+ */
+function nearestWeekday(year: number, month: number, target: number): number {
+  const last = lastDayOfMonth(year, month);
+  if (target < 1 || target > last) return -1;
+  const weekday = new Date(Date.UTC(year, month - 1, target)).getUTCDay(); // 0=Sun..6=Sat
+  if (weekday === 6) return target === 1 ? target + 2 : target - 1; // Saturday
+  if (weekday === 0) return target === last ? target - 2 : target + 1; // Sunday
+  return target;
+}
+
+/**
  * Whether the day-of-month field matches the given date, honouring the `L`
- * (last day of month) token alongside any explicit numeric days.
+ * (last day of month) and `nW` / `LW` (nearest weekday) tokens alongside any
+ * explicit numeric days.
  */
 export function matchesDayOfMonth(
   field: DayOfMonthField,
@@ -24,7 +62,21 @@ export function matchesDayOfMonth(
   month: number,
   day: number,
 ): boolean {
-  if (field.includes(day)) return true;
-  if (field.includes(LAST_DAY_TOKEN) && day === lastDayOfMonth(year, month)) return true;
+  for (const value of field) {
+    if (value === day) return true;
+    if (value === LAST_DAY_TOKEN && day === lastDayOfMonth(year, month)) return true;
+    if (typeof value === 'string') {
+      const weekdayMatch = WEEKDAY_TOKEN.exec(value);
+      if (weekdayMatch) {
+        const target = weekdayMatch[1] === LAST_DAY_TOKEN ? lastDayOfMonth(year, month) : parseInt(weekdayMatch[1], 10);
+        if (nearestWeekday(year, month, target) === day) return true;
+      }
+      const offsetMatch = LAST_DAY_OFFSET_TOKEN.exec(value);
+      if (offsetMatch) {
+        const target = lastDayOfMonth(year, month) - parseInt(offsetMatch[1], 10);
+        if (target >= 1 && target === day) return true;
+      }
+    }
+  }
   return false;
 }

--- a/src/time/time-matcher.test.ts
+++ b/src/time/time-matcher.test.ts
@@ -513,4 +513,91 @@ describe('TimeMatcher', function() {
         assert.equal(next.toISOString(), '2026-06-28T12:00:00.000Z');
       });
     })
+
+    describe('nearest weekday (nW / LW)', function() {
+      // 2026: Aug 1 = Sat (so Aug 15 = Sat), Mar 1 = Sun, May 31 = Sun,
+      // Jun 30 = Tue, Oct 31 = Sat.
+      it('shifts 15W off a Saturday to the previous Friday', function () {
+        const matcher = new TimeMatcher('0 0 12 15W * *', 'Etc/UTC');
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 7, 14, 12, 0, 0))));  // Fri 14
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 7, 15, 12, 0, 0)))); // the Saturday
+      });
+
+      it('keeps 1W inside the month when the 1st is a weekend', function () {
+        const matcher = new TimeMatcher('0 0 12 1W * *', 'Etc/UTC');
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 7, 3, 12, 0, 0))));  // Aug 1 = Sat -> Mon 3
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 7, 1, 12, 0, 0))));
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 2, 2, 12, 0, 0))));  // Mar 1 = Sun -> Mon 2
+      });
+
+      it('matches the last weekday of the month for LW', function () {
+        const matcher = new TimeMatcher('0 0 12 LW * *', 'Etc/UTC');
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 4, 29, 12, 0, 0))));  // May 31 = Sun -> Fri 29
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 4, 31, 12, 0, 0))));
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 5, 30, 12, 0, 0))));  // Jun 30 = Tue -> 30
+      });
+
+      it('does not match a non-existent target day (31W in a 30-day month)', function () {
+        const matcher = new TimeMatcher('0 0 12 31W * *', 'Etc/UTC');
+        for (let day = 1; day <= 30; day++) {
+          assert.isFalse(matcher.match(new Date(Date.UTC(2026, 8, day, 12, 0, 0)))); // September
+        }
+      });
+
+      it('getNextMatch resolves nW across the month boundary', function () {
+        // Aug 15 2026 is a Saturday -> the nearest weekday is Fri 14.
+        const next = new TimeMatcher('0 0 12 15W * *', 'Etc/UTC').getNextMatch(new Date('2026-08-01T00:00:00Z'));
+        assert.equal(next.toISOString(), '2026-08-14T12:00:00.000Z');
+      });
+
+      it('getNextMatch advances LW to the next month', function () {
+        // After May's last business day (Fri 29), the next is June's (Tue 30).
+        const next = new TimeMatcher('0 0 12 LW * *', 'Etc/UTC').getNextMatch(new Date('2026-05-30T00:00:00Z'));
+        assert.equal(next.toISOString(), '2026-06-30T12:00:00.000Z');
+      });
+
+      it('resolves the fire time correctly across a DST transition', function () {
+        // March 2026: DST starts Mar 8; Mar 31 (a Tuesday) is the last business
+        // day. Noon America/New_York that day is EDT (UTC-4) -> 16:00Z.
+        const next = new TimeMatcher('0 0 12 LW * *', 'America/New_York').getNextMatch(new Date('2026-03-01T00:00:00Z'));
+        assert.equal(next.toISOString(), '2026-03-31T16:00:00.000Z');
+      });
+    })
+
+    describe('offset from last day (L-n)', function() {
+      it('matches the nth-to-last day of the month', function () {
+        const matcher = new TimeMatcher('0 0 12 L-3 * *', 'Etc/UTC');
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 0, 28, 12, 0, 0))));  // Jan (31) -> 28
+        assert.isFalse(matcher.match(new Date(Date.UTC(2026, 0, 31, 12, 0, 0))));
+        assert.isTrue(matcher.match(new Date(Date.UTC(2026, 1, 25, 12, 0, 0))));  // Feb (28) -> 25
+      });
+
+      it('getNextMatch resolves L-3 within the month', function () {
+        const next = new TimeMatcher('0 0 12 L-3 * *', 'Etc/UTC').getNextMatch(new Date('2026-01-01T00:00:00Z'));
+        assert.equal(next.toISOString(), '2026-01-28T12:00:00.000Z');
+      });
+
+      it('getNextMatch skips months where the offset reaches before the 1st', function () {
+        // L-30 needs a 31-day month; Feb 2026 (28 days) has no match, so the next
+        // fire after Feb 1 is Mar 1 (31 - 30).
+        const next = new TimeMatcher('0 0 12 L-30 * *', 'Etc/UTC').getNextMatch(new Date('2026-02-01T00:00:00Z'));
+        assert.equal(next.toISOString(), '2026-03-01T12:00:00.000Z');
+      });
+    })
+
+    describe('? (no-specific-value alias)', function() {
+      const base = new Date('2026-06-01T00:00:00Z');
+
+      it('treats ? as * in the day-of-week field', function () {
+        const withQuestion = new TimeMatcher('0 0 12 15 * ?', 'Etc/UTC').getNextMatch(base);
+        const withStar = new TimeMatcher('0 0 12 15 * *', 'Etc/UTC').getNextMatch(base);
+        assert.equal(withQuestion.toISOString(), withStar.toISOString());
+      });
+
+      it('treats ? as * in the day-of-month field', function () {
+        const withQuestion = new TimeMatcher('0 0 12 ? * 1', 'Etc/UTC').getNextMatch(base);
+        const withStar = new TimeMatcher('0 0 12 * * 1', 'Etc/UTC').getNextMatch(base);
+        assert.equal(withQuestion.toISOString(), withStar.toISOString());
+      });
+    })
 });


### PR DESCRIPTION
Extends the **day-of-month** field with three Quartz-style modifiers, all resolved per-tick against the actual date, alongside the existing `L` and `#` tokens. No changes to the matching engine beyond `day-of-month.ts`: `time-matcher` and `matcher-walker` already route day-of-month through `matchesDayOfMonth`, so `getNextRun`/`getNextMatch` pick these up for free.

## What's added

### `nW` / `LW` (nearest weekday)
Fires on the nearest weekday (Mon-Fri) to a given day, without crossing the month boundary:
- `15W` nearest weekday to the 15th, `1W` first weekday, `LW` last weekday of the month.
- Saturday shifts to the previous Friday; Sunday to the following Monday; never across the month edge (`1W` on a Saturday 1st becomes Mon 3, not the previous month's Friday).
- Weekends only. **No holiday awareness** (documented in the README).
- `31W` in a 30-day month does not fire (no clamp).

### `L-n` (offset from the last day)
- `L-3` is the third-to-last day of the month.
- Valid offsets are `L-1`..`L-30`; `L-0` / `L-31`+ are rejected at validation.
- In months where the offset reaches before the 1st (e.g. `L-29` in February) it simply does not fire that month, consistent with `31`/`31W` in short months.

### `?` (no-specific-value alias)
- Accepted as an alias for `*` in the day-of-month and day-of-week fields, so Quartz-style expressions (`0 0 12 ? * MON`) parse without error.
- Rejected in lists (`1,?`) and outside the day fields.

## Validation
Lists of tokens are allowed (`1W,LW`, `1,L-3`). Rejected with field-specific errors: ranges/steps with `W` (`1-15W`, `15W/2`), out-of-range forms (`32W`, `L-40`), and `?` misuse. The `1-15W` case is caught on the raw field before range expansion, which would otherwise turn it into `1,...,15W` and slip through.

## Semantics note (not full Quartz compatibility)
The day-of-month vs day-of-week combination keeps node-cron's existing **AND** semantics, and weekday numbering is unchanged (`0-7`, `0`/`7` = Sunday, `1` = Monday). This PR adds the Quartz *modifiers*, but node-cron is **not** Quartz-compatible: the day-of-week numbering differs (Quartz `1` = Sunday) and Quartz's day-field exclusivity model is not adopted. `?` is therefore a syntactic convenience, not a semantic guarantee.

## Tests
Unit (`day-of-month`), validation (`validate-day`, `validate-detailed`) and integration (`time-matcher`, including a DST-transition case) tests added. Full suite: 494 passing.