### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,27 @@
 name: Publish to npm
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'  # include pre-releases like v1.2.3-beta.1
+  workflow_dispatch:
+    inputs:
+      dist_tag:
+        description: 'npm dist-tag to publish under'
+        type: choice
+        default: latest
+        required: true
+        options:
+          - latest
+          - beta
+          - next
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+
+    # OIDC trusted publishing: the id-token is exchanged with npm at publish
+    # time, so no NPM_TOKEN secret is needed. It also enables provenance.
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout repo
@@ -20,6 +33,10 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org/'
 
+      # Trusted publishing requires npm >= 11.5.1; node 20 ships an older npm.
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm install
 
@@ -29,24 +46,8 @@ jobs:
       - name: Tests
         run: npm run test
 
-      - name: Run build
+      - name: Build
         run: npm run build
 
-      - name: Detect pre-release
-        id: prerelease
-        run: |
-          if [[ "${GITHUB_REF##*/}" == *"-"* ]]; then
-            echo "is_prerelease=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_prerelease=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Publish to npm
-        run: |
-          if [[ "${{ steps.prerelease.outputs.is_prerelease }}" == "true" ]]; then
-            npm publish --tag beta
-          else
-            npm publish
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --tag "${{ inputs.dist_tag }}"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
   "files": [
     "dist/"
   ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/node-cron/node-cron.git"


### PR DESCRIPTION
Switch the npm publish workflow to **manual dispatch** authenticated with **GitHub OIDC trusted publishing** instead of a long-lived `NPM_TOKEN`. This also turns on npm **provenance** attestations.

## Changes
- **`publish.yml`**: trigger is now `workflow_dispatch` with a `dist_tag` choice input (`latest`/`beta`/`next`). You pick the ref (tag/branch) and the dist-tag from the Actions UI.
- `permissions: id-token: write` for the OIDC token exchange.
- Upgrade npm to latest in the job (trusted publishing requires npm >= 11.5.1; node 20 ships an older npm).
- Removed `NODE_AUTH_TOKEN` / `secrets.NPM_TOKEN` entirely.
- **`package.json`**: added `publishConfig` with `provenance: true` and `access: public`.

## Required one-time setup on npmjs.com (manual, before first publish)
1. On `https://www.npmjs.com/package/node-cron/access`, add a **Trusted Publisher** → GitHub Actions:
   - Organization/user: `node-cron`, Repository: `node-cron`, Workflow filename: `publish.yml`, Environment: blank.
2. Set publishing access to **"Require two-factor authentication and disallow tokens (recommended)"** (OIDC keeps working; leaked tokens can no longer publish).
3. Delete the `NPM_TOKEN` repo secret.

Order matters: register the trusted publisher **before** disallowing tokens.

## New release flow
Bump version + commit + tag, then **Actions → Publish to npm → Run workflow**, select the ref and dist-tag. The npm page will show the "Published with provenance" badge.