### PR TITLE
ci: lint PR titles against Conventional Commits

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,39 @@
+name: Lint PR Title
+
+# PRs are squash-merged, so the PR title becomes the commit message on main.
+# Enforcing Conventional Commits here keeps the history clean and lets
+# release-please categorise changes into the changelog correctly.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Keep in sync with the changelog-sections in release-please-config.json.
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            revert
+            docs
+            chore
+            ci
+            test
+            build
+            style
+          # Scopes are allowed (e.g. feat(day-of-month)) but not required.
+          requireScope: false


### PR DESCRIPTION
Adds a workflow that validates every PR title against Conventional Commits, using [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request).

## Why
PRs are squash-merged, so the **PR title becomes the commit message on `main`**. Enforcing Conventional Commits on the title:
- keeps the history clean and consistent, and
- lets **release-please** (#572) categorise each change into the changelog correctly.

Recent non-conventional titles (e.g. "Rewrite README…", "Fix typos…") are exactly what this catches.

## Behaviour
- Runs on `pull_request_target` (so it also works for fork PRs) and re-checks when the title is edited. It only reads the title; no code is checked out.
- Allowed types match `release-please-config.json`: `feat, fix, perf, refactor, revert, docs, chore, ci, test, build, style`.
- Scopes are allowed (`feat(day-of-month): …`) but not required.
- On failure it posts a comment explaining the expected format; fixing the title re-runs the check automatically.

## Follow-up
Make this check **required** in branch protection for `main` once it has run green once, so non-conventional titles can't be merged.