### PR TITLE
fix(release-please): match existing v-prefixed tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+<!-- Unreleased changes are staged in the open release-please PR, not here. -->
 
 ## [4.5.0] - 2026-06-21
 
@@ -169,7 +169,6 @@ that start stopped, per-task `logger`, and a dual ESM/CJS build. The legacy
 `scheduled`/`runOnInit` options were removed and several event names changed.
 See the [migration guide](https://nodecron.com/migrating-from-v3).
 
-[Unreleased]: https://github.com/node-cron/node-cron/compare/v4.5.0...HEAD
 [4.5.0]: https://github.com/node-cron/node-cron/compare/v4.4.1...v4.5.0
 [4.4.1]: https://github.com/node-cron/node-cron/compare/v4.4.0...v4.4.1
 [4.4.0]: https://github.com/node-cron/node-cron/compare/v4.3.0...v4.4.0

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,8 @@
     ".": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md",
+      "include-component-in-tag": false,
+      "include-v-in-tag": true,
       "changelog-sections": [
         { "type": "feat", "section": "Added" },
         { "type": "fix", "section": "Fixed" },


### PR DESCRIPTION
Fixes the misconfiguration from #572 that made release-please open a bogus **5.0.0** release PR (#574).

## Root cause
The repo's tags are `vX.Y.Z` (e.g. `v4.5.0`). But `release-type: node` defaults to **component-prefixed tags** (`node-cron-vX.Y.Z`), so release-please looked for `node-cron-v4.5.0`, did not find it, assumed there was no prior release, walked the entire history, and proposed `5.0.0` from already-shipped changes (#551, #548).

## Fix
- `"include-component-in-tag": false` (+ explicit `"include-v-in-tag": true`) so it tracks the existing `vX.Y.Z` tags with `v4.5.0` as the baseline.
- Dropped the manual `## [Unreleased]` section (and its link ref): with release-please the pending changes live in the open release PR.

The `on: push` trigger is intentional and kept: the release PR is a rolling preview that updates on each merge to main, and is only released when **you** merge it.

## After merge
Merging this pushes to main and re-runs release-please with the fixed config. It should **update #574** down to a **`4.6.0`** minor (only the `feat` from #570 since `v4.5.0`), not `5.0.0`. If it does not update cleanly, close #574 and it will be recreated on the next push to main.