### PR TITLE
ci: publish to npm automatically when a release is cut

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish to npm
 
 on:
+  # Manual publish, with a choice of dist-tag (for prereleases etc.).
   workflow_dispatch:
     inputs:
       dist_tag:
@@ -13,17 +14,17 @@ on:
           - beta
           - next
 
-  # Automatic publish on each GitHub Release (created by release-please when its
-  # release PR is merged). Disabled for now: publishing stays a manual
-  # workflow_dispatch. To enable, uncomment the block below.
-  #
-  # NOTE: a Release created with the default GITHUB_TOKEN does NOT trigger other
-  # workflows. For this trigger to fire, give release-please-action a PAT (or a
-  # GitHub App token) instead of secrets.GITHUB_TOKEN. With the default token,
-  # publish from inside the release-please job using its `release_created` output.
-  #
-  # release:
-  #   types: [published]
+  # Called by release-please.yml right after it cuts a release, so merging the
+  # `chore(main): release X.Y.Z` PR publishes automatically. A reusable-workflow
+  # call (rather than `on: release`) is used because a Release created with the
+  # default GITHUB_TOKEN does not trigger event-based workflows.
+  workflow_call:
+    inputs:
+      dist_tag:
+        description: 'npm dist-tag to publish under'
+        type: string
+        default: latest
+        required: false
 
 jobs:
   publish:
@@ -62,6 +63,6 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        # `inputs.dist_tag` is set on workflow_dispatch; on a release event (when
-        # the trigger above is enabled) it is empty, so fall back to `latest`.
-        run: npm publish --provenance --tag "${{ inputs.dist_tag || 'latest' }}"
+        # `inputs.dist_tag` comes from workflow_dispatch (chosen) or workflow_call
+        # (defaults to latest).
+        run: npm publish --provenance --tag "${{ inputs.dist_tag }}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,8 +2,8 @@ name: Release Please
 
 # Maintains a "release PR" that bumps the version and updates CHANGELOG.md from
 # Conventional Commits as they land on main. Merging that PR creates the git tag
-# (vX.Y.Z) and the GitHub Release. Publishing to npm stays a separate, manual
-# step (see publish.yml) for now.
+# (vX.Y.Z) and the GitHub Release, and then publishes to npm via the publish
+# workflow (called below only when a release was actually created).
 on:
   push:
     branches:
@@ -16,9 +16,25 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           # Reads release-please-config.json and .release-please-manifest.json
           # from the repo root.
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Runs only when the previous job just cut a release (i.e. the release PR was
+  # merged). Calls the publish workflow as a reusable workflow so npm publishing
+  # stays defined in one place (publish.yml) and keeps OIDC trusted publishing.
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/publish.yml
+    with:
+      dist_tag: latest


### PR DESCRIPTION
Closes the loop: merging the `chore(main): release X.Y.Z` PR now tags, releases **and** publishes to npm in one go.

## How
- `release-please.yml` exposes its `release_created` output and adds a `publish` job that runs **only when a release was just cut**. That job calls `publish.yml` as a reusable workflow.
- `publish.yml` gains a `workflow_call` trigger alongside `workflow_dispatch`, so the same OIDC trusted-publishing logic serves both manual and automatic publishes. Auto-publish uses `dist_tag: latest`; manual still offers the `latest`/`beta`/`next` choice.

## Why a reusable-workflow call instead of `on: release`
A GitHub Release created with the default `GITHUB_TOKEN` does **not** trigger event-based workflows (anti-loop protection). Calling `publish.yml` from within the same release-please run sidesteps that without needing a PAT or GitHub App token.

## Flow after this
1. Commits land on `main` → release-please keeps the rolling release PR updated.
2. You merge the `chore(main): release X.Y.Z` PR.
3. release-please creates the tag `vX.Y.Z` + GitHub Release, then the `publish` job publishes to npm with provenance.

Manual `workflow_dispatch` publishing still works unchanged (e.g. for a `beta` dist-tag).

## One thing to verify on the first auto-publish
npm trusted publishing must accept `publish.yml` when it runs as a reusable workflow (it matches on the job's workflow ref, which stays `publish.yml`). If the first automatic publish is rejected by npm, the fallback is to switch this to `on: release` + a PAT/App token for release-please. Manual dispatch is unaffected either way.