### PR TITLE
feat: support cron expression nicknames

### DIFF
--- a/src/pattern/conversion/index.test.ts
+++ b/src/pattern/conversion/index.test.ts
@@ -13,3 +13,26 @@ describe('month-names-conversion', function() {
       assert.deepEqual(expressions[5], [1,0]);
     });
 });
+
+describe('nicknames', function() {
+    it('should convert @yearly', function() {
+        const expressions = conversion('@yearly');
+        assert.deepEqual(expressions[0], [0]);
+        assert.deepEqual(expressions[1], [0]);
+        assert.deepEqual(expressions[2], [0]);
+        assert.deepEqual(expressions[4], [1]);
+    });
+
+    it('should convert @daily', function() {
+        const expressions = conversion('@daily');
+        assert.deepEqual(expressions[0], [0]);
+        assert.deepEqual(expressions[1], [0]);
+        assert.deepEqual(expressions[2], [0]);
+    });
+
+    it('should convert @hourly', function() {
+        const expressions = conversion('@hourly');
+        assert.deepEqual(expressions[0], [0]);
+        assert.deepEqual(expressions[1], [0]);
+    });
+});

--- a/src/pattern/conversion/index.ts
+++ b/src/pattern/conversion/index.ts
@@ -2,6 +2,7 @@ import monthNamesConversion from './month-names-conversion';
 import weekDayNamesConversion from './week-day-names-conversion';
 import convertAsterisksToRanges from './asterisk-to-range-conversion';
 import convertRanges from './range-conversion';
+import { resolveNickname } from './nicknames';
 
 export default (() => {
 
@@ -100,7 +101,7 @@ export default (() => {
     }
 
     function interpret(expression){
-        let expressions = removeSpaces(`${expression}`).split(' ');
+        let expressions = removeSpaces(resolveNickname(`${expression}`)).split(' ');
         expressions = appendSecondExpression(expressions);
         expressions = convertQuestionMarks(expressions);
         expressions[4] = monthNamesConversion(expressions[4]);

--- a/src/pattern/conversion/nicknames.test.ts
+++ b/src/pattern/conversion/nicknames.test.ts
@@ -1,0 +1,45 @@
+import { assert } from 'chai';
+import { resolveNickname } from './nicknames';
+
+describe('resolveNickname', function () {
+    it('@yearly resolves to 0 0 1 1 *', function () {
+        assert.equal(resolveNickname('@yearly'), '0 0 1 1 *');
+    });
+
+    it('@annually resolves to 0 0 1 1 *', function () {
+        assert.equal(resolveNickname('@annually'), '0 0 1 1 *');
+    });
+
+    it('@monthly resolves to 0 0 1 * *', function () {
+        assert.equal(resolveNickname('@monthly'), '0 0 1 * *');
+    });
+
+    it('@weekly resolves to 0 0 * * 0', function () {
+        assert.equal(resolveNickname('@weekly'), '0 0 * * 0');
+    });
+
+    it('@daily resolves to 0 0 * * *', function () {
+        assert.equal(resolveNickname('@daily'), '0 0 * * *');
+    });
+
+    it('@midnight resolves to 0 0 * * *', function () {
+        assert.equal(resolveNickname('@midnight'), '0 0 * * *');
+    });
+
+    it('@hourly resolves to 0 * * * *', function () {
+        assert.equal(resolveNickname('@hourly'), '0 * * * *');
+    });
+
+    it('is case-insensitive', function () {
+        assert.equal(resolveNickname('@Daily'), '0 0 * * *');
+        assert.equal(resolveNickname('@YEARLY'), '0 0 1 1 *');
+    });
+
+    it('passes through regular expressions unchanged', function () {
+        assert.equal(resolveNickname('*/5 * * * *'), '*/5 * * * *');
+    });
+
+    it('passes through unknown nicknames unchanged', function () {
+        assert.equal(resolveNickname('@unknown'), '@unknown');
+    });
+});

--- a/src/pattern/conversion/nicknames.ts
+++ b/src/pattern/conversion/nicknames.ts
@@ -1,0 +1,14 @@
+const NICKNAMES: Record<string, string> = {
+    '@yearly': '0 0 1 1 *',
+    '@annually': '0 0 1 1 *',
+    '@monthly': '0 0 1 * *',
+    '@weekly': '0 0 * * 0',
+    '@daily': '0 0 * * *',
+    '@midnight': '0 0 * * *',
+    '@hourly': '0 * * * *',
+};
+
+export function resolveNickname(expression: string): string {
+    const key = expression.trim().toLowerCase();
+    return NICKNAMES[key] ?? expression;
+}

--- a/src/pattern/validation/pattern-validation.ts
+++ b/src/pattern/validation/pattern-validation.ts
@@ -1,5 +1,6 @@
 import convertExpression from '../conversion/index';
 import { isNthWeekdayToken } from '../../time/day-of-week';
+import { resolveNickname } from '../conversion/nicknames';
 
 const validationRegex = /^(?:\d+|\*|\*\/\d+)$/;
 
@@ -204,10 +205,12 @@ export function validateDetailed(pattern: string): DetailedValidation {
     if (typeof pattern !== 'string')
         return { valid: false, errors: [{ field: 'expression', message: 'pattern must be a string' }] };
 
-    if (!ALLOWED_CHARS_REGEX.test(pattern))
+    const resolved = resolveNickname(pattern);
+
+    if (!ALLOWED_CHARS_REGEX.test(resolved))
         return { valid: false, errors: [{ field: 'expression', value: pattern, message: 'pattern includes illegal characters' }] };
 
-    const raw = pattern.replace(/\s{2,}/g, ' ').trim().split(' ');
+    const raw = resolved.replace(/\s{2,}/g, ' ').trim().split(' ');
     if (raw.length !== 5 && raw.length !== 6)
         return { valid: false, errors: [{ field: 'expression', value: pattern, message: `expected 5 or 6 fields but got ${raw.length}` }] };
 
@@ -256,11 +259,14 @@ export function parse(pattern: string): ParsedFields {
 function validate(pattern) {
     if (typeof pattern !== 'string')
         throw new TypeError('pattern must be a string!');
-    if (!ALLOWED_CHARS_REGEX.test(pattern))
+
+    const resolved = resolveNickname(pattern);
+
+    if (!ALLOWED_CHARS_REGEX.test(resolved))
         throw new TypeError('pattern includes illegal characters!');
 
-    const patterns = pattern.split(' ');
-    const executablePatterns = convertExpression(pattern);
+    const patterns = resolved.split(' ');
+    const executablePatterns = convertExpression(resolved);
 
     if (patterns.length === 5) patterns.unshift('0');
 

--- a/src/pattern/validation/validate.test.ts
+++ b/src/pattern/validation/validate.test.ts
@@ -61,4 +61,23 @@ describe('pattern-validation', function() {
                 .forEach((expr) => expect(() => validate(expr), expr).to.not.throw());
         });
     });
+
+    describe('nicknames', function() {
+        const valid = ['@yearly', '@annually', '@monthly', '@weekly', '@daily', '@midnight', '@hourly'];
+
+        valid.forEach((nickname) => {
+            it(`accepts ${nickname}`, function() {
+                expect(() => validate(nickname)).to.not.throw();
+            });
+        });
+
+        it('is case-insensitive', function() {
+            expect(() => validate('@Daily')).to.not.throw();
+            expect(() => validate('@YEARLY')).to.not.throw();
+        });
+
+        it('rejects unknown nicknames', function() {
+            expect(() => validate('@every_second')).to.throw();
+        });
+    });
 });


### PR DESCRIPTION
## Summary

- Add `@yearly`, `@annually`, `@monthly`, `@weekly`, `@daily`, `@midnight`, and `@hourly` as aliases for standard cron expressions
- Nicknames are resolved before parsing and validation, so they work in `schedule()`, `validate()`, `validateDetailed()`, and `parse()`
- Case-insensitive (`@Daily`, `@YEARLY` both work)
- Unknown nicknames (`@every_second`) are rejected by validation as expected

## Test plan

- [x] Unit tests for `resolveNickname()` (all nicknames, case-insensitivity, passthrough)
- [x] Integration tests in conversion (parsed fields match expected values)
- [x] Validation tests (all nicknames accepted, unknown rejected)
- [x] Full suite: 534 tests passing