### PR TITLE
fix: weekday 7-to-0 conversion corrupting ranges

### DIFF
--- a/src/pattern/conversion/index.test.ts
+++ b/src/pattern/conversion/index.test.ts
@@ -14,6 +14,43 @@ describe('month-names-conversion', function() {
     });
 });
 
+describe('weekday 7-to-0 normalization', function() {
+    it('should convert standalone 7 to 0', function() {
+        const expressions = conversion('* * * * * 7');
+        assert.deepEqual(expressions[5], [0]);
+    });
+
+    it('should convert 7 in a list to 0', function() {
+        const expressions = conversion('* * * * * 1,7');
+        assert.deepEqual(expressions[5], [1,0]);
+    });
+
+    it('should deduplicate when both 0 and 7 are present', function() {
+        const expressions = conversion('* * * * * 0,7');
+        assert.deepEqual(expressions[5], [0]);
+    });
+
+    it('should expand range 5-7 to Fri,Sat,Sun', function() {
+        const expressions = conversion('* * * * * 5-7');
+        assert.deepEqual(expressions[5], [5,6,0]);
+    });
+
+    it('should expand range 1-7 to all days', function() {
+        const expressions = conversion('* * * * * 1-7');
+        assert.deepEqual(expressions[5], [1,2,3,4,5,6,0]);
+    });
+
+    it('should expand range 6-7 to Sat,Sun', function() {
+        const expressions = conversion('* * * * * 6-7');
+        assert.deepEqual(expressions[5], [6,0]);
+    });
+
+    it('should expand range 0-7 to all days', function() {
+        const expressions = conversion('* * * * * 0-7');
+        assert.deepEqual(expressions[5], [0,1,2,3,4,5,6]);
+    });
+});
+
 describe('nicknames', function() {
     it('should convert @yearly', function() {
         const expressions = conversion('@yearly');

--- a/src/pattern/conversion/index.ts
+++ b/src/pattern/conversion/index.ts
@@ -111,6 +111,19 @@ export default (() => {
 
         expressions = normalizeIntegers(expressions);
 
+        // Normalize weekday 7 (Sunday) to 0 after range expansion and integer
+        // parsing. Doing it at the string level before range expansion would
+        // corrupt ranges like 5-7 into 5-0.
+        const weekdays = expressions[5];
+        for (let i = 0; i < weekdays.length; i++) {
+            if (weekdays[i] === 7) weekdays[i] = 0;
+            else if (typeof weekdays[i] === 'string' && weekdays[i].startsWith('7')) {
+                weekdays[i] = '0' + weekdays[i].slice(1);
+            }
+        }
+        // Deduplicate in case both 0 and 7 were present.
+        expressions[5] = [...new Set(weekdays)];
+
         return expressions;
     }
 

--- a/src/pattern/conversion/week-day-names-conversion.test.ts
+++ b/src/pattern/conversion/week-day-names-conversion.test.ts
@@ -13,8 +13,15 @@ describe('week-day-names-conversion', function() {
         expect(weekDays).to.equal('1,2,3,4,5,6,0');
     });
 
-    it('shuld convert 7 to 0', function() {
+    it('should pass through 7 unchanged (normalized later in the pipeline)', function() {
         const weekDays = conversion('7');
-        expect(weekDays).to.equal('0');
+        expect(weekDays).to.equal('7');
+    });
+
+    it('should not touch ranges containing 7', function() {
+        expect(conversion('5-7')).to.equal('5-7');
+        expect(conversion('1-7')).to.equal('1-7');
+        expect(conversion('6-7')).to.equal('6-7');
+        expect(conversion('0-7')).to.equal('0-7');
     });
 });

--- a/src/pattern/conversion/week-day-names-conversion.ts
+++ b/src/pattern/conversion/week-day-names-conversion.ts
@@ -11,7 +11,6 @@ export default (() => {
     }
   
     function convertWeekDays(expression){
-        expression = expression.replace('7', '0');
         expression = convertWeekDayName(expression, weekDays);
         return convertWeekDayName(expression, shortWeekDays);
     }


### PR DESCRIPTION
`expression.replace('7', '0')` ran before range expansion, so `5-7` became `5-0` and expanded to the wrong days.

Moved the 7-to-0 normalization to after range expansion, operating on the numeric array.

| Expression | Before | After |
|------------|--------|-------|
| `5-7` | `[0,1,2,3,4,5]` | `[5,6,0]` |
| `1-7` | `[0,1]` | `[1,2,3,4,5,6,0]` |
| `6-7` | `[0,1,2,3,4,5,6]` | `[6,0]` |
| `0-7` | `[0]` | `[0,1,2,3,4,5,6]` |