### PR TITLE
fix: runner promise bugs that could hang scheduling or crash process

### DIFF
--- a/src/scheduler/runner.test.ts
+++ b/src/scheduler/runner.test.ts
@@ -310,6 +310,58 @@ describe('scheduler/runner', function(){
     runner.stop();
   });
 
+  it('does not hang when beforeRun throws', async function(){
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    let errorCaught = false;
+
+    const runner = new Runner(timeMatcher, async () => {
+      return 'should not reach';
+    }, {
+      beforeRun() {
+        throw new Error('beforeRun failed');
+      },
+      onError(date, err) {
+        errorCaught = true;
+      }
+    });
+
+    runner.start();
+    await new Promise(resolve => { setTimeout(resolve, 2000) });
+    runner.stop();
+
+    // The runner should still be scheduling heartbeats (not stuck on a
+    // permanently pending promise). With noOverlap this would previously
+    // block all future executions.
+    assert.isTrue(errorCaught || runner.runCount === 0);
+  });
+
+  it('does not emit unhandled rejection when task throws', async function(){
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    let unhandled = false;
+
+    const handler = () => { unhandled = true; };
+    process.on('unhandledRejection', handler);
+
+    const errorSeen = new Promise<void>((resolve) => {
+      const runner = new Runner(timeMatcher, async () => {
+        throw new Error('task boom');
+      }, {
+        onError() {
+          runner.stop();
+          resolve();
+        }
+      });
+      runner.start();
+    });
+
+    await errorSeen;
+    // Give the event loop a tick for any unhandled rejection to surface.
+    await new Promise(resolve => setTimeout(resolve, 50));
+    process.removeListener('unhandledRejection', handler);
+
+    assert.isFalse(unhandled, 'TrackedPromise rejection should be caught');
+  });
+
 });
 
 function blockIO(ms: number) {

--- a/src/scheduler/runner.test.ts
+++ b/src/scheduler/runner.test.ts
@@ -320,7 +320,7 @@ describe('scheduler/runner', function(){
       beforeRun() {
         throw new Error('beforeRun failed');
       },
-      onError(date, err) {
+      onError() {
         errorCaught = true;
       }
     });

--- a/src/scheduler/runner.test.ts
+++ b/src/scheduler/runner.test.ts
@@ -332,7 +332,56 @@ describe('scheduler/runner', function(){
     // The runner should still be scheduling heartbeats (not stuck on a
     // permanently pending promise). With noOverlap this would previously
     // block all future executions.
-    assert.isTrue(errorCaught || runner.runCount === 0);
+    assert.isTrue(errorCaught, 'onError should be called when beforeRun throws');
+  });
+
+  it('reports beforeRun errors via onError', async function(){
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    let caughtMessage = '';
+
+    const errorSeen = new Promise<void>((resolve) => {
+      const runner = new Runner(timeMatcher, async () => {
+        return 'should not reach';
+      }, {
+        beforeRun() {
+          throw new Error('beforeRun exploded');
+        },
+        onError(date, err) {
+          caughtMessage = err.message;
+          runner.stop();
+          resolve();
+        }
+      });
+      runner.start();
+    });
+
+    await errorSeen;
+    assert.equal(caughtMessage, 'beforeRun exploded');
+  });
+
+  it('does not hang jitter promise when onError throws', async function(){
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    const origRandom = Math.random;
+    Math.random = () => 0.5;
+    let onErrorCallCount = 0;
+
+    const runner = new Runner(timeMatcher, async () => {
+      throw new Error('task boom');
+    }, {
+      maxRandomDelay: 200,
+      noOverlap: true,
+      onError() {
+        onErrorCallCount++;
+        throw new Error('onError also throws');
+      }
+    });
+
+    runner.start();
+    await new Promise(resolve => { setTimeout(resolve, 4000) });
+    Math.random = origRandom;
+    runner.stop();
+
+    assert.isAbove(onErrorCallCount, 1, 'onError should be called multiple times if jitter promise resolves properly');
   });
 
   it('does not emit unhandled rejection when task throws', async function(){

--- a/src/scheduler/runner.ts
+++ b/src/scheduler/runner.ts
@@ -161,53 +161,61 @@ export class Runner {
       }
     };
 
-    const runTask = (date: Date): Promise<any> => {
-      return new Promise(async (resolve) => {
-        const execution: Execution = {
-          id: createID(),
-          reason: 'scheduled'
-        }
+    const runTask = async (date: Date): Promise<void> => {
+      const execution: Execution = {
+        id: createID(),
+        reason: 'scheduled'
+      }
 
-        const shouldExecute = await this.beforeRun(date, execution);
-        const randomDelay = Math.floor(Math.random() * this.maxRandomDelay);
+      let shouldExecute: boolean;
+      try {
+        shouldExecute = await this.beforeRun(date, execution);
+      } catch (error: any) {
+        this.onError(date, error, execution);
+        return;
+      }
 
-        if(shouldExecute){
-          const execute = async () => {
-            try {
-              this.runCount++;
-              execution.startedAt = new Date();
-              const result = await this.onMatch(date, execution);
-              execution.finishedAt = new Date();
-              execution.result = result;
-              this.onFinished(date, execution);
+      if (!shouldExecute) return;
 
-              if( this.maxExecutions && this.runCount >= this.maxExecutions){
-                this.onMaxExecutions(date);
-                this.stop();
-              }
-            } catch (error: any){
-              execution.finishedAt = new Date();
-              execution.error = error;
-              this.onError(date, error, execution);
-            }
+      const execute = async () => {
+        try {
+          this.runCount++;
+          execution.startedAt = new Date();
+          const result = await this.onMatch(date, execution);
+          execution.finishedAt = new Date();
+          execution.result = result;
+          this.onFinished(date, execution);
 
-            resolve(true);
-          };
-
-          // The jitter timer only earns its macrotask hop when a random delay is
-          // actually configured. With the default maxRandomDelay of 0 the delay
-          // is always 0, so run inline and fire on the heartbeat's own tick
-          // instead of bouncing through an extra setTimeout (which adds ~1ms+ of
-          // avoidable drift to every execution).
-          if (randomDelay > 0) {
-            this.jitterTimeout = setTimeout(execute, randomDelay);
-          } else {
-            execute();
+          if (this.maxExecutions && this.runCount >= this.maxExecutions) {
+            this.onMaxExecutions(date);
+            this.stop();
           }
-        } else {
-          resolve(true);
+        } catch (error: any) {
+          execution.finishedAt = new Date();
+          execution.error = error;
+          try {
+            this.onError(date, error, execution);
+          } catch (hookError: any) {
+            this.onErrorFallback(date, hookError);
+          }
         }
-      })
+      };
+
+      // The jitter timer only earns its macrotask hop when a random delay is
+      // actually configured. With the default maxRandomDelay of 0 the delay
+      // is always 0, so run inline and fire on the heartbeat's own tick
+      // instead of bouncing through an extra setTimeout (which adds ~1ms+ of
+      // avoidable drift to every execution).
+      const randomDelay = Math.floor(Math.random() * this.maxRandomDelay);
+      if (randomDelay > 0) {
+        await new Promise<void>(resolve => {
+          this.jitterTimeout = setTimeout(() => {
+            execute().then(() => resolve(), () => resolve());
+          }, randomDelay);
+        });
+      } else {
+        await execute();
+      }
     }
 
     const heartBeat = async () => {
@@ -250,6 +258,9 @@ export class Runner {
             reject(err);
           }
         });
+        // Errors are already reported via onError; suppress the unhandled
+        // rejection that would otherwise crash the process on Node 22+.
+        lastExecution.catch(() => {});
       }
 
       armHeartBeat();


### PR DESCRIPTION
Two bugs in the Runner:

1. `runTask` used `new Promise(async ...)`. If `beforeRun` threw, the promise never settled. With `noOverlap`, this blocked all future executions permanently.

2. The `TrackedPromise` tracking `lastExecution` was never `.catch()`-ed. On Node 22+ this crashes the process with `unhandledRejection`.

Rewrote `runTask` as a plain async function and added `.catch()` on the TrackedPromise.