### PR TITLE
fix: kill orphan child process on background task stop/destroy timeout

### DIFF
--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -268,13 +268,23 @@ describe('BackgroundScheduledTask', function() {
     it('fails on stop timeout', async function(){
       const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
       task.forkProcess = fakeChildProcess as any;
-   
+
       try {
         await task.stop();
         assert.fail("should fail before")
       } catch (error: any){
         assert.equal(error.message, 'Stop operation timed out');
       }
+    });
+
+    it('kills the fork process when stop times out (no orphan)', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      task.forkProcess = fakeChildProcess as any;
+
+      try { await task.stop(); } catch { /* expected timeout */ }
+
+      assert.isTrue(fakeChildProcess.kill.called, 'the daemon must be killed on stop timeout');
+      assert.isUndefined(task.forkProcess, 'forkProcess must be cleared after a timed-out stop');
     });
   });
 
@@ -308,6 +318,16 @@ describe('BackgroundScheduledTask', function() {
       } catch (error: any){
         assert.equal(error.message, 'Destroy operation timed out');
       }
+    });
+
+    it('kills the fork process when destroy times out (no orphan)', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      task.forkProcess = fakeChildProcess as any;
+
+      try { await task.destroy(); } catch { /* expected timeout */ }
+
+      assert.isTrue(fakeChildProcess.kill.called, 'the daemon must be killed on destroy timeout');
+      assert.isUndefined(task.forkProcess, 'forkProcess must be cleared after a timed-out destroy');
     });
   });
 

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -242,8 +242,10 @@ class BackgroundScheduledTask implements ScheduledTask{
       
       const timeoutId = setTimeout(() => {
         clearTimeout(timeoutId);
+        this.forkProcess?.kill();
+        this.forkProcess = undefined;
         reject(new Error('Stop operation timed out'))
-      }, 5000); 
+      }, 5000);
       
       const cleanupAndResolve = () => {
         clearTimeout(timeoutId);
@@ -276,8 +278,10 @@ class BackgroundScheduledTask implements ScheduledTask{
 
       const timeoutId = setTimeout(() => {
         clearTimeout(timeoutId);
+        this.forkProcess?.kill();
+        this.forkProcess = undefined;
         reject(new Error('Destroy operation timed out'))
-      }, 5000); 
+      }, 5000);
   
       
       const onDestroy = () => {


### PR DESCRIPTION
stop() and destroy() had a 5s timeout that rejected the promise but left the child process alive. Now kills the fork and clears the reference before rejecting, same as failStart already does.