### PR TITLE
fix: clear jitter timeout on runner stop

### DIFF
--- a/src/scheduler/runner.test.ts
+++ b/src/scheduler/runner.test.ts
@@ -274,6 +274,28 @@ describe('scheduler/runner', function(){
 
   });
 
+  it('clears jitter timeout on stop', async function(){
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    let taskCalled = false;
+
+    const runner = new Runner(timeMatcher, async () => {
+      taskCalled = true;
+    }, { maxRandomDelay: 5000 });
+
+    runner.start();
+
+    // Wait for heartbeat to fire and start the jitter delay
+    await new Promise(resolve => { setTimeout(resolve, 1200) });
+
+    // Stop while the jitter timeout is still pending
+    runner.stop();
+
+    // Wait long enough for the jitter timeout to have fired if it was not cleared
+    await new Promise(resolve => { setTimeout(resolve, 6000) });
+
+    assert.isFalse(taskCalled, 'task should not run after stop() cancels the jitter timeout');
+  });
+
   it('sets a max delay on heartbeat', function(){
     const timeMatcher = new TimeMatcher('0 0 1 1 *');
     const runner = createRunner(timeMatcher, 1000);

--- a/src/scheduler/runner.test.ts
+++ b/src/scheduler/runner.test.ts
@@ -277,21 +277,23 @@ describe('scheduler/runner', function(){
   it('clears jitter timeout on stop', async function(){
     const timeMatcher = new TimeMatcher('* * * * * *');
     let taskCalled = false;
+    const origRandom = Math.random;
+    // Force a long jitter delay so stop() is called while it's pending
+    Math.random = () => 0.999;
 
     const runner = new Runner(timeMatcher, async () => {
       taskCalled = true;
-    }, { maxRandomDelay: 5000 });
+    }, { maxRandomDelay: 30000 });
 
     runner.start();
 
-    // Wait for heartbeat to fire and start the jitter delay
-    await new Promise(resolve => { setTimeout(resolve, 1200) });
-
-    // Stop while the jitter timeout is still pending
+    // Wait for heartbeat to fire and start the jitter delay (~29970ms)
+    await new Promise(resolve => { setTimeout(resolve, 1500) });
     runner.stop();
+    Math.random = origRandom;
 
-    // Wait long enough for the jitter timeout to have fired if it was not cleared
-    await new Promise(resolve => { setTimeout(resolve, 6000) });
+    // Wait to confirm the jitter timeout was actually cleared
+    await new Promise(resolve => { setTimeout(resolve, 2000) });
 
     assert.isFalse(taskCalled, 'task should not run after stop() cancels the jitter timeout');
   });

--- a/src/scheduler/runner.ts
+++ b/src/scheduler/runner.ts
@@ -61,6 +61,7 @@ export class Runner {
   running: boolean;
 
   heartBeatTimeout?: NodeJS.Timeout;
+  private jitterTimeout?: NodeJS.Timeout;
   logger: Logger;
   onMissedExecution: OnFn;
   onOverlap: OnFn;
@@ -199,7 +200,7 @@ export class Runner {
           // instead of bouncing through an extra setTimeout (which adds ~1ms+ of
           // avoidable drift to every execution).
           if (randomDelay > 0) {
-            setTimeout(execute, randomDelay);
+            this.jitterTimeout = setTimeout(execute, randomDelay);
           } else {
             execute();
           }
@@ -266,6 +267,10 @@ export class Runner {
     if(this.heartBeatTimeout) {
       clearTimeout(this.heartBeatTimeout);
       this.heartBeatTimeout = undefined;
+    }
+    if(this.jitterTimeout) {
+      clearTimeout(this.jitterTimeout);
+      this.jitterTimeout = undefined;
     }
   }
   


### PR DESCRIPTION
When maxRandomDelay > 0, the jitter setTimeout was not tracked. Calling stop() during the delay let the execution fire anyway. Now stores the timeout ID and clears it in stop().