### PR TITLE
fix: background task state transition on stop/destroy without fork

### DIFF
--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -286,6 +286,40 @@ describe('BackgroundScheduledTask', function() {
       assert.isUndefined(result);
     });
 
+    it('transitions to destroyed when forkProcess is absent', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      assert.equal(task.getStatus(), 'stopped');
+
+      await task.destroy();
+      assert.equal(task.getStatus(), 'destroyed');
+    });
+
+    it('emits task:destroyed when forkProcess is absent', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      let emitted = false;
+      task.on('task:destroyed', () => { emitted = true; });
+
+      await task.destroy();
+      assert.isTrue(emitted);
+    });
+
+    it('transitions to stopped on stop() when forkProcess is absent', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      // Already stopped, should remain stopped without error
+      await task.stop();
+      assert.equal(task.getStatus(), 'stopped');
+    });
+
+    it('is a no-op when already destroyed', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      await task.destroy();
+      assert.equal(task.getStatus(), 'destroyed');
+
+      // Second destroy should not throw
+      await task.destroy();
+      assert.equal(task.getStatus(), 'destroyed');
+    });
+
     it('destroys a task an kills the fork', async function(){
       const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
       task.forkProcess = fakeChildProcess as any;

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -237,6 +237,7 @@ class BackgroundScheduledTask implements ScheduledTask{
   stop(): Promise<void> {
     return new Promise((resolve, reject) => {
       if (!this.forkProcess) {
+        this.emitter.emit('task:stopped');
         return resolve(undefined);
       }
       
@@ -270,7 +271,12 @@ class BackgroundScheduledTask implements ScheduledTask{
 
   destroy(): Promise<void> {
     return new Promise((resolve, reject) => {
+      if (this.stateMachine.state === 'destroyed') {
+        return resolve(undefined);
+      }
+
       if (!this.forkProcess) {
+        this.emitter.emit('task:destroyed');
         return resolve(undefined);
       }
 


### PR DESCRIPTION
stop() and destroy() returned immediately without transitioning state or emitting events when forkProcess was absent. Now emits the proper events so getStatus() returns the correct state.