### PR TITLE
fix: prevent double destroy on registry remove

### DIFF
--- a/src/task-registry.test.ts
+++ b/src/task-registry.test.ts
@@ -74,6 +74,22 @@ describe('TaskRegistry', function(){
     assert.lengthOf(tasks, 3);
   });
 
+  it('calls destroy exactly once when remove is called', function(){
+    const task = createTask();
+    registry.add(task);
+
+    let destroyCount = 0;
+    const original = task.destroy.bind(task);
+    task.destroy = function() {
+      destroyCount++;
+      return original();
+    };
+
+    registry.remove(task);
+    assert.equal(destroyCount, 1, 'destroy should be called exactly once');
+    assert.isFalse(registry.has(task.id));
+  });
+
   it('kills all tasks', function() {
     registry.add(createTask());
     registry.add(createTask());

--- a/src/task-registry.ts
+++ b/src/task-registry.ts
@@ -21,8 +21,8 @@ export class TaskRegistry {
 
   remove(task: ScheduledTask ){
     if(this.has(task.id)){
-      task?.destroy();
       tasks.delete(task.id);
+      task.destroy();
     }
   }
 


### PR DESCRIPTION
remove() called destroy() before deleting from the map. The task:destroyed listener called remove() again, triggering a second destroy(). Now deletes from the map first so the re-entrant call is a clean no-op.