### PR TITLE
fix: daemon serialized task state with wrong field name

### DIFF
--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -365,6 +365,70 @@ describe('BackgroundScheduledTask', function() {
     });
   });
 
+  describe('state sync from daemon messages', function(){
+    it('transitions to running when daemon reports execution:started', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+
+      fakeChildProcess.send.callsFake((msg: any) => {
+        if (msg.command === 'task:start') {
+          task.emitter.emit('task:started');
+        } else if (msg.command === 'task:execute') {
+          const now = new Date().toISOString();
+          fakeChildProcess.emit('message', {
+            event: 'execution:started',
+            context: {
+              date: now,
+              task: { id: task.id, name: task.name, state: 'running' },
+              execution: { id: 'e1', reason: 'invoked', startedAt: now }
+            }
+          });
+        }
+      });
+
+      await task.start();
+      assert.equal(task.getStatus(), 'idle');
+
+      task.execute().catch(() => {});
+      await new Promise(r => setTimeout(r, 50));
+
+      assert.equal(task.getStatus(), 'running', 'should transition to running from daemon status');
+    });
+
+    it('transitions back to idle when daemon reports execution:finished', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+
+      fakeChildProcess.send.callsFake((msg: any) => {
+        if (msg.command === 'task:start') {
+          task.emitter.emit('task:started');
+        } else if (msg.command === 'task:execute') {
+          const now = new Date().toISOString();
+          fakeChildProcess.emit('message', {
+            event: 'execution:started',
+            context: {
+              date: now,
+              task: { id: task.id, name: task.name, state: 'running' },
+              execution: { id: 'e1', reason: 'invoked', startedAt: now }
+            }
+          });
+          queueMicrotask(() => {
+            fakeChildProcess.emit('message', {
+              event: 'execution:finished',
+              context: {
+                date: now,
+                task: { id: task.id, name: task.name, state: 'idle' },
+                execution: { id: 'e1', reason: 'invoked', startedAt: now, finishedAt: now, result: 'ok' }
+              }
+            });
+          });
+        }
+      });
+
+      await task.start();
+      await task.execute();
+      assert.equal(task.getStatus(), 'idle', 'should transition back to idle after execution');
+    });
+  });
+
   describe('execute', function(){
     it('fails when call execute on stoped task', async function(){
       const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');

--- a/src/tasks/background-scheduled-task/daemon.test.ts
+++ b/src/tasks/background-scheduled-task/daemon.test.ts
@@ -252,6 +252,29 @@ describe('daemon - register', function () {
     task.destroy();
   });
 
+  it('serializes task state field as "state" in messages', async function () {
+    messages = [];
+    const message = {
+      command: 'task:start',
+      path: '../../../test-assets/dummy-task.js',
+      cron: '* * * * * *',
+      options: { name: 'dummy-task' },
+    };
+
+    bind();
+    const onMessage = listeners.find(l => l.event === 'message');
+    const task = await onMessage.fn(message);
+    task.start();
+
+    await new Promise(r => setTimeout(r, 1000));
+    task.destroy();
+
+    const started = messages.find(m => m.event === 'execution:started');
+    assert.isDefined(started, 'execution:started should be sent');
+    assert.isDefined(started.context.task.state, 'task field should use "state" not "status"');
+    assert.isUndefined(started.context.task.status, 'task field should not use "status"');
+  });
+
   it('should handle task:execute command', async function () {
     messages = [];
     const message = {

--- a/src/tasks/background-scheduled-task/daemon.ts
+++ b/src/tasks/background-scheduled-task/daemon.ts
@@ -109,7 +109,7 @@ function safelySerializeContext(context: TaskContext): TaskContext {
     safeContext.task = {
       id: context.task.id,
       name: context.task.name,
-      status: context.task.getStatus()
+      state: context.task.getStatus()
     };
   }
   


### PR DESCRIPTION
The daemon sent context.task.status but the parent read context.task.state, so state transitions from daemon messages never worked. Background tasks never entered 'running' state during execution.

One-line fix in daemon.ts (status -> state). Tests in both daemon.test.ts (validates serialization format) and background-scheduled-task.test.ts (validates parent transitions to running/idle).