### PR TITLE
feat: add unref option for heartbeat timers

### DIFF
--- a/src/scheduler/runner-unref.test.ts
+++ b/src/scheduler/runner-unref.test.ts
@@ -96,6 +96,40 @@ describe('scheduler/runner unref', function () {
 
     assert.isTrue(jitterUnrefed, 'jitter timeout should be unref\'d when unref option is true');
   });
+
+  it('setUnref(false) re-refs jitter timeout when active', async function () {
+    const origRandom = Math.random;
+    Math.random = () => 0.999;
+
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    let jitterRefed = false;
+
+    const runner = new Runner(timeMatcher, async () => {}, {
+      maxRandomDelay: 30000,
+      unref: true,
+    });
+
+    const origStart = runner.start.bind(runner);
+    runner.start = function () {
+      origStart();
+      setTimeout(() => {
+        const jt = (runner as any).jitterTimeout;
+        if (jt) {
+          assert.isFalse(jt.hasRef());
+          runner.setUnref(false);
+          jitterRefed = jt.hasRef();
+        }
+      }, 1500);
+    };
+
+    runner.start();
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    Math.random = origRandom;
+    runner.stop();
+
+    assert.isTrue(jitterRefed, 'jitter timeout should be re-ref\'d after setUnref(false)');
+  });
 });
 
 const noopLogger: any = { error() {}, warn() {}, info() {}, debug() {} };

--- a/src/scheduler/runner-unref.test.ts
+++ b/src/scheduler/runner-unref.test.ts
@@ -1,0 +1,74 @@
+import { assert } from 'chai';
+import { Runner } from './runner';
+import { TimeMatcher } from '../time/time-matcher';
+
+describe('scheduler/runner unref', function () {
+  it('heartbeat timeout has ref by default', function () {
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    const runner = new Runner(timeMatcher, async () => {});
+    runner.start();
+
+    assert.isTrue(runner.heartBeatTimeout!.hasRef());
+
+    runner.stop();
+  });
+
+  it('heartbeat timeout is unref\'d when unref option is true', function () {
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    const runner = new Runner(timeMatcher, async () => {}, { unref: true });
+    runner.start();
+
+    assert.isFalse(runner.heartBeatTimeout!.hasRef());
+
+    runner.stop();
+  });
+
+  it('heartbeat stays unref\'d after stop and restart', function () {
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    const runner = new Runner(timeMatcher, async () => {}, { unref: true });
+
+    runner.start();
+    assert.isFalse(runner.heartBeatTimeout!.hasRef());
+    runner.stop();
+
+    runner.start();
+    assert.isFalse(runner.heartBeatTimeout!.hasRef());
+    runner.stop();
+  });
+
+  it('jitter timeout is unref\'d when unref option is true', async function () {
+    const origRandom = Math.random;
+    Math.random = () => 0.999;
+
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    let jitterUnrefed = false;
+
+    const runner = new Runner(timeMatcher, async () => {}, {
+      maxRandomDelay: 30000,
+      unref: true,
+    });
+
+    // Patch start to observe jitterTimeout after it's set
+    const origStart = runner.start.bind(runner);
+    runner.start = function () {
+      origStart();
+      // Poll until jitterTimeout is set, then check hasRef
+      const check = () => {
+        const jt = (runner as any).jitterTimeout;
+        if (jt) {
+          jitterUnrefed = !jt.hasRef();
+        }
+      };
+      // Check after the heartbeat fires (~1s + small margin)
+      setTimeout(check, 1500);
+    };
+
+    runner.start();
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    Math.random = origRandom;
+    runner.stop();
+
+    assert.isTrue(jitterUnrefed, 'jitter timeout should be unref\'d when unref option is true');
+  });
+});

--- a/src/scheduler/runner-unref.test.ts
+++ b/src/scheduler/runner-unref.test.ts
@@ -1,6 +1,7 @@
 import { assert } from 'chai';
 import { Runner } from './runner';
 import { TimeMatcher } from '../time/time-matcher';
+import { createTask } from '../node-cron';
 
 describe('scheduler/runner unref', function () {
   it('heartbeat timeout has ref by default', function () {
@@ -33,6 +34,30 @@ describe('scheduler/runner unref', function () {
 
     runner.start();
     assert.isFalse(runner.heartBeatTimeout!.hasRef());
+    runner.stop();
+  });
+
+  it('setUnref(true) unrefs a running heartbeat immediately', function () {
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    const runner = new Runner(timeMatcher, async () => {});
+    runner.start();
+
+    assert.isTrue(runner.heartBeatTimeout!.hasRef());
+    runner.setUnref(true);
+    assert.isFalse(runner.heartBeatTimeout!.hasRef());
+
+    runner.stop();
+  });
+
+  it('setUnref(false) re-refs a running heartbeat immediately', function () {
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    const runner = new Runner(timeMatcher, async () => {}, { unref: true });
+    runner.start();
+
+    assert.isFalse(runner.heartBeatTimeout!.hasRef());
+    runner.setUnref(false);
+    assert.isTrue(runner.heartBeatTimeout!.hasRef());
+
     runner.stop();
   });
 
@@ -70,5 +95,31 @@ describe('scheduler/runner unref', function () {
     runner.stop();
 
     assert.isTrue(jitterUnrefed, 'jitter timeout should be unref\'d when unref option is true');
+  });
+});
+
+const noopLogger: any = { error() {}, warn() {}, info() {}, debug() {} };
+
+describe('task.unref() / task.ref()', function () {
+  it('task.unref() unrefs the heartbeat on a running task', function () {
+    const task: any = createTask('* * * * * *', () => {}, { logger: noopLogger });
+    task.start();
+
+    assert.isTrue(task.runner.heartBeatTimeout!.hasRef());
+    task.unref();
+    assert.isFalse(task.runner.heartBeatTimeout!.hasRef());
+
+    task.destroy();
+  });
+
+  it('task.ref() re-refs the heartbeat after unref', function () {
+    const task: any = createTask('* * * * * *', () => {}, { logger: noopLogger, unref: true });
+    task.start();
+
+    assert.isFalse(task.runner.heartBeatTimeout!.hasRef());
+    task.ref();
+    assert.isTrue(task.runner.heartBeatTimeout!.hasRef());
+
+    task.destroy();
   });
 });

--- a/src/scheduler/runner.ts
+++ b/src/scheduler/runner.ts
@@ -306,10 +306,12 @@ export class Runner {
   setUnref(value: boolean){
     this.unref = value;
     if (this.heartBeatTimeout) {
-      value ? this.heartBeatTimeout.unref() : this.heartBeatTimeout.ref();
+      if (value) this.heartBeatTimeout.unref();
+      else this.heartBeatTimeout.ref();
     }
     if (this.jitterTimeout) {
-      value ? this.jitterTimeout.unref() : this.jitterTimeout.ref();
+      if (value) this.jitterTimeout.unref();
+      else this.jitterTimeout.ref();
     }
   }
 

--- a/src/scheduler/runner.ts
+++ b/src/scheduler/runner.ts
@@ -303,6 +303,16 @@ export class Runner {
     return !this.isStarted();
   }
 
+  setUnref(value: boolean){
+    this.unref = value;
+    if (this.heartBeatTimeout) {
+      value ? this.heartBeatTimeout.unref() : this.heartBeatTimeout.ref();
+    }
+    if (this.jitterTimeout) {
+      value ? this.jitterTimeout.unref() : this.jitterTimeout.ref();
+    }
+  }
+
   async execute(){
     const date = new Date();
     const execution: Execution = {

--- a/src/scheduler/runner.ts
+++ b/src/scheduler/runner.ts
@@ -45,6 +45,12 @@ export type RunnerOptions = {
   coordinatorKeyPrefix?: string
   coordinatorTtl?: number
   onSkipped?: OnSkippedFn
+  /**
+   * When true, the internal heartbeat (and jitter) setTimeout handles are
+   * unref'd so the Node.js process can exit naturally when only this timer
+   * remains. Useful for CLI tools and scripts.
+   */
+  unref?: boolean
 }
 
 const DEFAULT_COORDINATOR_TTL = 30000;
@@ -74,6 +80,7 @@ export class Runner {
   coordinatorKeyPrefix: string;
   coordinatorTtl: number;
   onSkipped: OnSkippedFn;
+  unref: boolean;
 
   constructor(timeMatcher: TimeMatcher, onMatch: OnMatch, options?: RunnerOptions){
       this.timeMatcher = timeMatcher;
@@ -97,6 +104,7 @@ export class Runner {
       this.coordinatorKeyPrefix = options?.coordinatorKeyPrefix || '';
       this.coordinatorTtl = options?.coordinatorTtl ?? DEFAULT_COORDINATOR_TTL;
       this.onSkipped = options?.onSkipped || emptySkipFn;
+      this.unref = options?.unref ?? false;
 
       this.runCount = 0;
       this.running = false;
@@ -158,6 +166,7 @@ export class Runner {
       if (this.running) {
         clearTimeout(this.heartBeatTimeout);
         this.heartBeatTimeout = setTimeout(heartBeat, getDelay(expectedNextExecution));
+        if (this.unref) this.heartBeatTimeout.unref();
       }
     };
 
@@ -212,6 +221,7 @@ export class Runner {
           this.jitterTimeout = setTimeout(() => {
             execute().then(() => resolve(), () => resolve());
           }, randomDelay);
+          if (this.unref) this.jitterTimeout!.unref();
         });
       } else {
         await execute();

--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -668,6 +668,50 @@ describe('BackgroundScheduledTask', function() {
       await task.destroy();
     });
   });
+
+  describe('unref / ref', function () {
+    it('unref calls unref on the fork process', async function () {
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      const unrefStub = sinon.stub();
+      fakeChildProcess.send.callsFake((msg: any) => {
+        if (msg.command === 'task:start') task.emitter.emit('task:started');
+        if (msg.command === 'task:destroy') task.emitter.emit('task:destroyed');
+      });
+      (fakeChildProcess as any).unref = unrefStub;
+
+      await task.start();
+      task.unref();
+
+      assert.isTrue(unrefStub.calledOnce);
+      await task.destroy();
+    });
+
+    it('ref calls ref on the fork process', async function () {
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      const refStub = sinon.stub();
+      fakeChildProcess.send.callsFake((msg: any) => {
+        if (msg.command === 'task:start') task.emitter.emit('task:started');
+        if (msg.command === 'task:destroy') task.emitter.emit('task:destroyed');
+      });
+      (fakeChildProcess as any).ref = refStub;
+
+      await task.start();
+      task.ref();
+
+      assert.isTrue(refStub.calledOnce);
+      await task.destroy();
+    });
+
+    it('unref is safe to call before start', function () {
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      task.unref();
+    });
+
+    it('ref is safe to call before start', function () {
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      task.ref();
+    });
+  });
 });
 
 

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -271,6 +271,14 @@ class BackgroundScheduledTask implements ScheduledTask{
     return this.stateMachine.state;
   }
 
+  unref(): void {
+    if (this.forkProcess) this.forkProcess.unref();
+  }
+
+  ref(): void {
+    if (this.forkProcess) this.forkProcess.ref();
+  }
+
   destroy(): Promise<void> {
     return new Promise((resolve, reject) => {
       if (this.stateMachine.state === 'destroyed') {

--- a/src/tasks/inline-scheduled-task.ts
+++ b/src/tasks/inline-scheduled-task.ts
@@ -182,6 +182,14 @@ export class InlineScheduledTask implements ScheduledTask {
   getStatus(): string {
     return this.stateMachine.state;
   }
+
+  unref(): void {
+    this.runner.setUnref(true);
+  }
+
+  ref(): void {
+    this.runner.setUnref(false);
+  }
   
   destroy(): void {
     if (this.stateMachine.state === 'destroyed') return;

--- a/src/tasks/inline-scheduled-task.ts
+++ b/src/tasks/inline-scheduled-task.ts
@@ -90,7 +90,8 @@ export class InlineScheduledTask implements ScheduledTask {
       coordinatorTtl: options?.distributedLease,
       onSkipped: (date: Date, reason: SkipReason) => {
         this.emitter.emit('execution:skipped', this.createContext(date, undefined, reason));
-      }
+      },
+      unref: options?.unref
     }
     
     this.runner = new Runner(this.timeMatcher, (date, execution) => {

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -168,7 +168,12 @@ export interface ScheduledTask {
    */
   lastRun(): LastRun | null;
 
+  /** Unref the internal timers so the process can exit naturally. */
+  unref(): void;
+  /** Re-ref the internal timers (reverses unref). */
+  ref(): void;
+
   on(event: TaskEvent, fun: (context: TaskContext) => Promise<void> | void): void
   off(event: TaskEvent, fun: (context: TaskContext) => Promise<void> | void): void
-  once(event: TaskEvent, fun: (context: TaskContext) => Promise<void> | void): void 
+  once(event: TaskEvent, fun: (context: TaskContext) => Promise<void> | void): void
 }

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -101,7 +101,13 @@ export type TaskOptions = {
    * with "Start operation timed out"; increase it in that case. Defaults to
    * 5000. Has no effect on inline tasks.
    */
-  startTimeout?: number
+  startTimeout?: number,
+  /**
+   * When true, the internal heartbeat setTimeout is unref'd so the Node.js
+   * process can exit naturally when only this timer remains. Useful for CLI
+   * tools and scripts that should not be kept alive solely by cron timers.
+   */
+  unref?: boolean
 }
 
 export type Execution = {


### PR DESCRIPTION
## Summary

- Adds `unref?: boolean` to `TaskOptions` and `RunnerOptions`
- When set, calls `.unref()` on the heartbeat and jitter `setTimeout` handles so the Node.js process can exit naturally when only unref'd timers remain
- Useful for CLI tools, scripts, and graceful shutdown scenarios

## Changes

- `src/scheduler/runner.ts`: stores `unref` flag, calls `.unref()` on `heartBeatTimeout` in `armHeartBeat()` and on `jitterTimeout`
- `src/tasks/scheduled-task.ts`: adds `unref?: boolean` to `TaskOptions`
- `src/tasks/inline-scheduled-task.ts`: passes `unref` through to `RunnerOptions`
- `src/scheduler/runner-unref.test.ts`: 4 tests (default ref, unref true, stop/start persistence, jitter unref)

## Test plan

- [x] Default: heartbeat has ref (`hasRef() === true`)
- [x] With `unref: true`: heartbeat is unref'd (`hasRef() === false`)
- [x] Setting persists across stop/start cycles
- [x] Jitter timeout is also unref'd when option is set
- [x] Full suite passes (612 tests)