### PR TITLE
feat: add cron.shutdown(timeout?) for graceful teardown

### DIFF
--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -157,8 +157,44 @@ export const validateDetailed = validateDetailedExpression;
 export const parse = parseExpression;
 
 /**
+ * Stops all registered tasks, waits for any in-progress executions to finish
+ * (up to `timeout` ms), then destroys all tasks. Returns a Promise that
+ * resolves when everything is cleaned up.
+ *
+ * @param timeout - Maximum milliseconds to wait for in-progress executions.
+ *   Defaults to 5000.
+ */
+export async function shutdown(timeout = 5000): Promise<void> {
+  const tasks = registry.all();
+  const pending: Promise<any>[] = [];
+
+  for (const task of tasks.values()) {
+    const busy = task.isBusy();
+    const wait = new Promise<void>(resolve => {
+      task.once('execution:finished', resolve);
+      task.once('execution:failed', resolve);
+    });
+    task.stop();
+    if (busy) {
+      pending.push(wait);
+    }
+  }
+
+  if (pending.length) {
+    await Promise.race([
+      Promise.allSettled(pending),
+      new Promise(r => setTimeout(r, timeout))
+    ]);
+  }
+
+  for (const task of tasks.values()) {
+    task.destroy();
+  }
+}
+
+/**
  * Retrieves all scheduled tasks from the registry.
- * 
+ *
  * @returns A map of scheduled tasks
  */
 export const getTasks = registry.all;
@@ -189,6 +225,7 @@ export interface NodeCron {
   getTask: typeof getTask;
   setLogger: typeof setLogger;
   setRunCoordinator: typeof setRunCoordinator;
+  shutdown: typeof shutdown;
 }
 
 export const nodeCron: NodeCron = {
@@ -201,6 +238,7 @@ export const nodeCron: NodeCron = {
   getTask,
   setLogger,
   setRunCoordinator,
+  shutdown,
 };
 
 /**

--- a/src/shutdown.test.ts
+++ b/src/shutdown.test.ts
@@ -1,0 +1,156 @@
+import { assert } from 'chai';
+import { createTask, getTasks, shutdown } from './node-cron';
+import { ScheduledTask } from './tasks/scheduled-task';
+
+const noopLogger: any = { error() {}, warn() {}, info() {}, debug() {} };
+
+function idleTask(expression = '* * * * * *'): ScheduledTask {
+  return createTask(expression, () => 'ok', { logger: noopLogger });
+}
+
+/**
+ * Creates an inline task whose scheduled execution blocks until `unblock()` is called.
+ * The task uses '* * * * * *' (every second) and starts immediately so it fires soon.
+ * Returns the task and a function to unblock the running execution.
+ */
+function makeBusyTask(): { task: ScheduledTask; unblock: () => void } {
+  let unblock!: () => void;
+  const blocker = new Promise<void>(resolve => { unblock = resolve; });
+
+  const task = createTask('* * * * * *', () => blocker, { logger: noopLogger });
+  task.start();
+  return { task, unblock };
+}
+
+/**
+ * Wait until isBusy() returns true, with a timeout to avoid hanging tests.
+ */
+function waitUntilBusy(task: ScheduledTask, timeoutMs = 2000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = setTimeout(() => reject(new Error('Task did not become busy')), timeoutMs);
+    const check = () => {
+      if (task.isBusy()) {
+        clearTimeout(deadline);
+        resolve();
+      } else {
+        setImmediate(check);
+      }
+    };
+    check();
+  });
+}
+
+afterEach(async () => {
+  // Clean up any lingering tasks between tests
+  for (const task of getTasks().values()) {
+    try {
+      if (task.getStatus() !== 'destroyed') {
+        task.destroy();
+      }
+    } catch { /* ignore */ }
+  }
+});
+
+describe('shutdown', () => {
+  it('resolves immediately when no tasks are registered', async () => {
+    for (const task of getTasks().values()) {
+      task.destroy();
+    }
+    await shutdown();
+  });
+
+  it('stops and destroys all idle tasks', async () => {
+    const t1 = idleTask();
+    const t2 = idleTask();
+    t1.start();
+    t2.start();
+
+    await shutdown();
+
+    assert.equal(t1.getStatus(), 'destroyed');
+    assert.equal(t2.getStatus(), 'destroyed');
+  });
+
+  it('registry is empty after shutdown', async () => {
+    idleTask();
+    idleTask();
+
+    await shutdown();
+
+    assert.equal(getTasks().size, 0);
+  });
+
+  it('waits for a busy task to finish before destroying', async () => {
+    const { task, unblock } = makeBusyTask();
+
+    // Wait for the scheduled execution to actually start
+    await waitUntilBusy(task);
+    assert.isTrue(task.isBusy());
+
+    // Unblock the task after a short delay
+    setTimeout(unblock, 20);
+
+    await shutdown(500);
+
+    assert.equal(task.getStatus(), 'destroyed');
+  });
+
+  it('waits for multiple busy tasks to finish', async () => {
+    const b1 = makeBusyTask();
+    const b2 = makeBusyTask();
+
+    await waitUntilBusy(b1.task);
+    await waitUntilBusy(b2.task);
+
+    assert.isTrue(b1.task.isBusy());
+    assert.isTrue(b2.task.isBusy());
+
+    setTimeout(b1.unblock, 10);
+    setTimeout(b2.unblock, 30);
+
+    await shutdown(500);
+
+    assert.equal(b1.task.getStatus(), 'destroyed');
+    assert.equal(b2.task.getStatus(), 'destroyed');
+  });
+
+  it('destroys tasks after timeout even when still busy', async () => {
+    // Never unblock - task stays busy forever
+    const { task } = makeBusyTask();
+
+    await waitUntilBusy(task);
+    assert.isTrue(task.isBusy());
+
+    const start = Date.now();
+    await shutdown(50);
+    const elapsed = Date.now() - start;
+
+    assert.isAbove(elapsed, 40, 'should wait for at least the timeout');
+    assert.isBelow(elapsed, 500, 'should not wait much longer than the timeout');
+    assert.equal(task.getStatus(), 'destroyed');
+  });
+
+  it('uses 5000 ms as the default timeout (does not hang on short busy tasks)', async () => {
+    const { task, unblock } = makeBusyTask();
+
+    await waitUntilBusy(task);
+
+    // Unblock quickly so the default timeout is never hit
+    setTimeout(unblock, 10);
+
+    const start = Date.now();
+    await shutdown(); // no timeout arg - uses default 5000
+    const elapsed = Date.now() - start;
+
+    assert.isBelow(elapsed, 1000);
+    assert.equal(task.getStatus(), 'destroyed');
+  });
+
+  it('is safe to call when no tasks exist', async () => {
+    for (const task of getTasks().values()) {
+      task.destroy();
+    }
+    await shutdown();
+    await shutdown();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `shutdown(timeout?)` to the public API (exported from node-cron, added to `NodeCron` interface)
- Stops all registered tasks, waits for in-progress executions to finish (up to `timeout` ms, default 5000), then destroys all tasks
- Essential for graceful `SIGTERM` handling in containers (Docker, K8s)

## Design

- Checks `isBusy()` before `stop()` (since `stop()` transitions state to `'stopped'` immediately, making `isBusy()` always false after)
- Registers `once('execution:finished/failed')` listeners before `stop()` to avoid the race condition where an execution finishes between the busy check and listener registration
- Uses `Promise.race` with timeout so it never hangs
- After timeout, force-destroys all remaining tasks

## Test plan

- [x] Resolves immediately when no tasks are registered
- [x] Stops and destroys all idle tasks
- [x] Registry is empty after shutdown
- [x] Waits for a busy task to finish before destroying
- [x] Waits for multiple busy tasks to finish
- [x] Destroys tasks after timeout even when still busy
- [x] Uses 5000ms as default timeout
- [x] Safe to call multiple times when no tasks exist
- [x] Full suite passes (612 tests)