### PR TITLE
fix: correct falied->failed typo in daemon task error log

### DIFF
--- a/src/tasks/background-scheduled-task/daemon.ts
+++ b/src/tasks/background-scheduled-task/daemon.ts
@@ -159,7 +159,7 @@ export function bind(){
       try {
         if (task) await task.execute();
       } catch(error: any){
-        logger.debug('Daemon task:execute falied:', error);
+        logger.debug('Daemon task:execute failed:', error);
       }
       return task;
     }


### PR DESCRIPTION
Fix user-facing debug log message typo in daemon.ts (src/tasks/background-scheduled-task/daemon.ts).

**Before:** logger.debug('Daemon task:execute falied:', error);
**After:** logger.debug('Daemon task:execute failed:', error);

Co-authored-by: Jah-yee <jydu_seven@outlook.com>