### PR TITLE
fix: correct shutdown listener typing that broke the build

### DIFF
--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -172,8 +172,8 @@ export async function shutdown(timeout = 5000): Promise<void> {
   for (const task of tasks.values()) {
     const busy = task.isBusy();
     const wait = new Promise<void>(resolve => {
-      task.once('execution:finished', resolve);
-      task.once('execution:failed', resolve);
+      task.once('execution:finished', () => resolve());
+      task.once('execution:failed', () => resolve());
     });
     task.stop();
     if (busy) {


### PR DESCRIPTION
The `shutdown` commit passed `resolve` directly as an `execution:finished`/`execution:failed` listener, but `TaskContext` is not assignable to `void | PromiseLike<void>`, which broke `npm run build` (TS2345, and Rollup wipes `dist/` before failing). Wrap it in `() => resolve()`. The build passes again.