### PR TITLE
ci: run build and typecheck on pull requests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,6 +26,28 @@ jobs:
       - name: Lint
         run: node --run lint
 
+  build:
+    name: Build and typecheck
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Typecheck
+        run: npm run typecheck
+
   unit:
     name: Unit tests
     runs-on: ubuntu-24.04-arm

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "vitest run --coverage",
     "test:watch": "vitest",
     "lint": "./node_modules/.bin/eslint ./src",
+    "typecheck": "tsc --noEmit",
     "check": "npm run lint && npm test",
     "build": "rollup -c",
     "dev": "rollup -c -w",


### PR DESCRIPTION
Adds `npm run build` and `tsc --noEmit` to the PR CI. Not running these is how the `shutdown` build error reached main. Depends on #595 (build fix) and #597 (test type fixes): this PR CI stays red until both land on main.