### PR TITLE
chore: fix type errors in test files

### DIFF
--- a/src/coordinator/run-coordinator.test.ts
+++ b/src/coordinator/run-coordinator.test.ts
@@ -30,7 +30,7 @@ describe('run coordinator', function () {
     let ran = 0;
     let skipped = 0;
     const task = new InlineScheduledTask('* * * * * *', () => { ran++; }, { name: 'job', distributed: true });
-    task.on('execution:skipped', () => skipped++);
+    task.on('execution:skipped', () => { skipped++; });
 
     task.start();
     await wait(1200);
@@ -50,7 +50,7 @@ describe('run coordinator', function () {
     let ran = 0;
     const reasons: string[] = [];
     const task = new InlineScheduledTask('* * * * * *', () => { ran++; }, { name: 'job', distributed: true });
-    task.on('execution:skipped', (ctx) => reasons.push(ctx.reason as string));
+    task.on('execution:skipped', (ctx) => { reasons.push(ctx.reason as string); });
 
     task.start();
     await wait(1200);
@@ -68,7 +68,7 @@ describe('run coordinator', function () {
     let ran = 0;
     const reasons: string[] = [];
     const task = new InlineScheduledTask('* * * * * *', () => { ran++; }, { name: 'job', distributed: true, logger: silent });
-    task.on('execution:skipped', (ctx) => reasons.push(ctx.reason as string));
+    task.on('execution:skipped', (ctx) => { reasons.push(ctx.reason as string); });
 
     task.start();
     await wait(1200);

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -171,8 +171,8 @@ function lifecycleSuite(label: string, factory: (opts?: FactoryOpts) => Schedule
       await task.start();
 
       const events: TaskEvent[] = [];
-      task.on('execution:started', () => events.push('execution:started'));
-      task.on('execution:finished', () => events.push('execution:finished'));
+      task.on('execution:started', () => { events.push('execution:started'); });
+      task.on('execution:finished', () => { events.push('execution:finished'); });
 
       await task.execute();
 
@@ -243,7 +243,7 @@ function lifecycleSuite(label: string, factory: (opts?: FactoryOpts) => Schedule
     it('start emits task:started exactly once', async () => {
       task = factory();
       let count = 0;
-      task.on('task:started', () => count++);
+      task.on('task:started', () => { count++; });
       await task.start();
       expect(count).toBe(1);
     });
@@ -252,7 +252,7 @@ function lifecycleSuite(label: string, factory: (opts?: FactoryOpts) => Schedule
       task = factory();
       await task.start();
       let count = 0;
-      task.on('task:stopped', () => count++);
+      task.on('task:stopped', () => { count++; });
       await task.stop();
       expect(count).toBe(1);
     });
@@ -261,7 +261,7 @@ function lifecycleSuite(label: string, factory: (opts?: FactoryOpts) => Schedule
       task = factory();
       await task.start();
       let count = 0;
-      task.on('task:destroyed', () => count++);
+      task.on('task:destroyed', () => { count++; });
       await task.destroy();
       expect(count).toBe(1);
     });
@@ -271,8 +271,8 @@ function lifecycleSuite(label: string, factory: (opts?: FactoryOpts) => Schedule
       await task.start();
       let started = 0;
       let finished = 0;
-      task.on('execution:started', () => started++);
-      task.on('execution:finished', () => finished++);
+      task.on('execution:started', () => { started++; });
+      task.on('execution:finished', () => { finished++; });
       await task.execute();
       expect(started).toBe(1);
       expect(finished).toBe(1);
@@ -283,8 +283,8 @@ function lifecycleSuite(label: string, factory: (opts?: FactoryOpts) => Schedule
       await task.start();
       let started = 0;
       let failed = 0;
-      task.on('execution:started', () => started++);
-      task.on('execution:failed', () => failed++);
+      task.on('execution:started', () => { started++; });
+      task.on('execution:failed', () => { failed++; });
       try { await task.execute(); } catch { /* expected */ }
       expect(started).toBe(1);
       expect(failed).toBe(1);

--- a/src/node-cron.test.ts
+++ b/src/node-cron.test.ts
@@ -105,8 +105,9 @@ describe('node-cron', function() {
 
             expect(task).toBeDefined();
             expect(task).toBeInstanceOf(InlineScheduledTask);
-            expect(task.runner.noOverlap).toBeDefined();
-            expect(task.runner.noOverlap).toBe(true);
+            const runner = (task as InlineScheduledTask).runner;
+            expect(runner.noOverlap).toBeDefined();
+            expect(runner.noOverlap).toBe(true);
 
             task.stop();
         });
@@ -120,8 +121,9 @@ describe('node-cron', function() {
 
             expect(task).toBeDefined();
             expect(task).toBeInstanceOf(InlineScheduledTask);
-            expect(task.runner.maxExecutions).toBeDefined();
-            expect(task.runner.maxExecutions).toBe(5);
+            const runner = (task as InlineScheduledTask).runner;
+            expect(runner.maxExecutions).toBeDefined();
+            expect(runner.maxExecutions).toBe(5);
 
             task.stop();
         });

--- a/src/tasks/inline-scheduled-task.test.ts
+++ b/src/tasks/inline-scheduled-task.test.ts
@@ -127,8 +127,8 @@ describe('InlineScheduledTask', function() {
     expect(event?.date).toBeDefined()
     expect(event?.triggeredAt).toBeDefined()
     expect(event?.execution).toBeDefined()
-    expect(event?.execution.id).toBeDefined()
-    expect(event?.execution.result).toBeUndefined()
+    expect(event?.execution!.id).toBeDefined()
+    expect(event?.execution!.result).toBeUndefined()
     task.destroy();
   });
 
@@ -144,9 +144,9 @@ describe('InlineScheduledTask', function() {
     expect(event?.date).toBeDefined()
     expect(event?.triggeredAt).toBeDefined()
     expect(event?.execution).toBeDefined()
-    expect(event?.execution.id).toBeDefined()
-    expect(event?.execution.result).toBeDefined()
-    expect(event?.execution.error).toBeUndefined()
+    expect(event?.execution!.id).toBeDefined()
+    expect(event?.execution!.result).toBeDefined()
+    expect(event?.execution!.error).toBeUndefined()
     task.destroy();
   });
 
@@ -162,9 +162,9 @@ describe('InlineScheduledTask', function() {
     expect(event?.date).toBeDefined()
     expect(event?.triggeredAt).toBeDefined()
     expect(event?.execution).toBeDefined()
-    expect(event?.execution.id).toBeDefined()
-    expect(event?.execution.result).toBeUndefined()
-    expect(event?.execution.error).toBeDefined()
+    expect(event?.execution!.id).toBeDefined()
+    expect(event?.execution!.result).toBeUndefined()
+    expect(event?.execution!.error).toBeDefined()
     task.destroy();
   });
 


### PR DESCRIPTION
Fixes the type errors accumulated in the test files (Vitest does not typecheck, so they went unnoticed). No behavior change. Clears the way for CI to start running `tsc --noEmit` on PRs.