### PR TITLE
fix: harden cron.shutdown() teardown

### DIFF
--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -170,11 +170,27 @@ export async function shutdown(timeout = 5000): Promise<void> {
   const pending: Promise<any>[] = [];
 
   for (const task of tasks.values()) {
-    const busy = task.isBusy();
+    // Registered before stop() so an execution that finishes in that same
+    // window is still caught, instead of forcing a full-timeout wait for an
+    // event that already fired. Both listeners are removed as soon as either
+    // one settles, so a task never leaks the listener for the event that did
+    // not fire.
     const wait = new Promise<void>(resolve => {
-      task.once('execution:finished', () => resolve());
-      task.once('execution:failed', () => resolve());
+      const onSettled = () => {
+        task.off('execution:finished', onSettled);
+        task.off('execution:failed', onSettled);
+        resolve();
+      };
+      task.once('execution:finished', onSettled);
+      task.once('execution:failed', onSettled);
     });
+
+    // Checked right after the listeners above are armed (so there is no gap
+    // between "is it busy" and "we are listening") and before stop(): stop()
+    // transitions the task's own status away from 'running' immediately, even
+    // for an inline task whose execution is still in flight, so isBusy() can
+    // no longer be trusted once stop() has been called.
+    const busy = task.isBusy();
 
     // A background task's stop() returns a Promise that can reject (e.g.
     // "Stop operation timed out" when the daemon is stuck). Left unhandled

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -170,11 +170,7 @@ export async function shutdown(timeout = 5000): Promise<void> {
   const pending: Promise<any>[] = [];
 
   for (const task of tasks.values()) {
-    // Registered before stop() so an execution that finishes in that same
-    // window is still caught, instead of forcing a full-timeout wait for an
-    // event that already fired. Both listeners are removed as soon as either
-    // one settles, so a task never leaks the listener for the event that did
-    // not fire.
+    // Armed before stop() so a run finishing in that window is still caught.
     const wait = new Promise<void>(resolve => {
       const onSettled = () => {
         task.off('execution:finished', onSettled);
@@ -185,17 +181,10 @@ export async function shutdown(timeout = 5000): Promise<void> {
       task.once('execution:failed', onSettled);
     });
 
-    // Checked right after the listeners above are armed (so there is no gap
-    // between "is it busy" and "we are listening") and before stop(): stop()
-    // transitions the task's own status away from 'running' immediately, even
-    // for an inline task whose execution is still in flight, so isBusy() can
-    // no longer be trusted once stop() has been called.
+    // Read before stop(), which flips the status away from 'running' at once.
     const busy = task.isBusy();
 
-    // A background task's stop() returns a Promise that can reject (e.g.
-    // "Stop operation timed out" when the daemon is stuck). Left unhandled
-    // that becomes an unhandled rejection, which crashes the process by
-    // default; log it instead.
+    // A rejected stop()/destroy() left unhandled would crash the process.
     Promise.resolve(task.stop()).catch((error: any) => {
       logger.error(`Error stopping task "${task.name}" during shutdown: ${error?.message ?? error}`);
     });
@@ -213,7 +202,6 @@ export async function shutdown(timeout = 5000): Promise<void> {
   }
 
   for (const task of tasks.values()) {
-    // Same rationale as stop() above: destroy() can also reject.
     Promise.resolve(task.destroy()).catch((error: any) => {
       logger.error(`Error destroying task "${task.name}" during shutdown: ${error?.message ?? error}`);
     });

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -175,7 +175,15 @@ export async function shutdown(timeout = 5000): Promise<void> {
       task.once('execution:finished', () => resolve());
       task.once('execution:failed', () => resolve());
     });
-    task.stop();
+
+    // A background task's stop() returns a Promise that can reject (e.g.
+    // "Stop operation timed out" when the daemon is stuck). Left unhandled
+    // that becomes an unhandled rejection, which crashes the process by
+    // default; log it instead.
+    Promise.resolve(task.stop()).catch((error: any) => {
+      logger.error(`Error stopping task "${task.name}" during shutdown: ${error?.message ?? error}`);
+    });
+
     if (busy) {
       pending.push(wait);
     }
@@ -189,7 +197,10 @@ export async function shutdown(timeout = 5000): Promise<void> {
   }
 
   for (const task of tasks.values()) {
-    task.destroy();
+    // Same rationale as stop() above: destroy() can also reject.
+    Promise.resolve(task.destroy()).catch((error: any) => {
+      logger.error(`Error destroying task "${task.name}" during shutdown: ${error?.message ?? error}`);
+    });
   }
 }
 

--- a/src/shutdown.test.ts
+++ b/src/shutdown.test.ts
@@ -183,7 +183,7 @@ describe('shutdown', () => {
     await shutdown();
   });
 
-  describe('A1: does not crash on a rejecting stop()/destroy()', () => {
+  describe('does not crash on a rejecting stop()/destroy()', () => {
     it('never surfaces an unhandled rejection when stop() and destroy() reject, and logs the failure', async () => {
       const unhandled: any[] = [];
       const onUnhandledRejection = (reason: any) => unhandled.push(reason);
@@ -192,7 +192,7 @@ describe('shutdown', () => {
       const errorFn = vi.fn();
       setLogger({ error: errorFn, warn() {}, info() {}, debug() {} });
 
-      const id = 'a1-rejecting-task';
+      const id = 'rejecting-task';
       getTasks().set(id, makeRejectingTask(id));
 
       try {
@@ -223,7 +223,7 @@ describe('shutdown', () => {
       const onUnhandledRejection = (reason: any) => unhandled.push(reason);
       process.on('unhandledRejection', onUnhandledRejection);
 
-      const id = 'a1-rejecting-task-non-error';
+      const id = 'rejecting-task-non-error';
       getTasks().set(id, makeRejectingTask(id, 'stop failed', 'destroy failed'));
 
       try {
@@ -237,7 +237,7 @@ describe('shutdown', () => {
     });
   });
 
-  describe('B10: listener cleanup and isBusy() race', () => {
+  describe('listener cleanup and isBusy() race', () => {
     it('removes both the execution:finished and execution:failed listeners it registers', async () => {
       const { task, unblock } = makeBusyTask();
       const emitter = (task as any).emitter;
@@ -287,7 +287,7 @@ describe('shutdown', () => {
     });
   });
 
-  describe('M5: waits for an in-progress background execution before killing the daemon', () => {
+  describe('waits for an in-progress background execution before killing the daemon', () => {
     function makeFakeChild() {
       const child: any = new EventEmitter();
       child.killed = false;
@@ -297,7 +297,7 @@ describe('shutdown', () => {
           queueMicrotask(() => child.emit('message', { event: 'task:started', context: { date: new Date().toISOString() } }));
         }
         if (msg.command === 'task:stop') {
-          // The daemon stops scheduling new runs immediately, but (per M5)
+          // The daemon stops scheduling new runs immediately, but
           // must not report task:stopped as if the in-flight execution were
           // over - execution:finished is reported later, on its own.
           queueMicrotask(() => child.emit('message', {

--- a/src/shutdown.test.ts
+++ b/src/shutdown.test.ts
@@ -1,10 +1,34 @@
-import { createTask, getTasks, shutdown } from './node-cron';
+import { EventEmitter } from 'events';
+import { createTask, getTasks, shutdown, setLogger } from './node-cron';
+import { resetLogger } from './logger';
 import { ScheduledTask } from './tasks/scheduled-task';
 
 const noopLogger: any = { error() {}, warn() {}, info() {}, debug() {} };
 
 function idleTask(expression = '* * * * * *'): ScheduledTask {
   return createTask(expression, () => 'ok', { logger: noopLogger });
+}
+
+/**
+ * A minimal ScheduledTask double whose stop()/destroy() reject, to exercise
+ * shutdown()'s handling of a rejecting task without going through a real
+ * background daemon. Inserted directly into the registry (getTasks() returns
+ * the live Map), so it must be removed again by the test.
+ */
+function makeRejectingTask(id: string, stopRejectsWith: any = new Error('Stop operation timed out'), destroyRejectsWith: any = new Error('Destroy operation timed out')): ScheduledTask {
+  const emitter = new EventEmitter();
+  let state = 'stopped';
+  return {
+    id,
+    name: id,
+    isBusy: () => false,
+    getStatus: () => state,
+    stop: () => Promise.reject(stopRejectsWith),
+    destroy: () => { state = 'destroyed'; return Promise.reject(destroyRejectsWith); },
+    on: (event: any, fn: any) => emitter.on(event, fn),
+    off: (event: any, fn: any) => emitter.off(event, fn),
+    once: (event: any, fn: any) => emitter.once(event, fn),
+  } as unknown as ScheduledTask;
 }
 
 /**
@@ -151,5 +175,59 @@ describe('shutdown', () => {
     }
     await shutdown();
     await shutdown();
+  });
+
+  describe('A1: does not crash on a rejecting stop()/destroy()', () => {
+    it('never surfaces an unhandled rejection when stop() and destroy() reject, and logs the failure', async () => {
+      const unhandled: any[] = [];
+      const onUnhandledRejection = (reason: any) => unhandled.push(reason);
+      process.on('unhandledRejection', onUnhandledRejection);
+
+      const errorFn = vi.fn();
+      setLogger({ error: errorFn, warn() {}, info() {}, debug() {} });
+
+      const id = 'a1-rejecting-task';
+      getTasks().set(id, makeRejectingTask(id));
+
+      try {
+        // Resolves cleanly: the rejections from stop()/destroy() are caught
+        // internally instead of being left as unhandled rejections.
+        await expect(shutdown(50)).resolves.toBeUndefined();
+
+        // Give the microtask/macrotask queue a chance to surface any
+        // unhandled rejection that shutdown() failed to catch.
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(unhandled).toEqual([]);
+
+        // Both the stop() and destroy() rejections are logged through
+        // node-cron's own Logger instead of being silently swallowed.
+        const messages = errorFn.mock.calls.map((call: any[]) => call[0]);
+        expect(messages.some((m: string) => m.includes('Stop operation timed out'))).toBe(true);
+        expect(messages.some((m: string) => m.includes('Destroy operation timed out'))).toBe(true);
+      } finally {
+        process.off('unhandledRejection', onUnhandledRejection);
+        getTasks().delete(id);
+        resetLogger();
+      }
+    });
+
+    it('logs a rejection that is not an Error instance without throwing', async () => {
+      const unhandled: any[] = [];
+      const onUnhandledRejection = (reason: any) => unhandled.push(reason);
+      process.on('unhandledRejection', onUnhandledRejection);
+
+      const id = 'a1-rejecting-task-non-error';
+      getTasks().set(id, makeRejectingTask(id, 'stop failed', 'destroy failed'));
+
+      try {
+        await expect(shutdown(50)).resolves.toBeUndefined();
+        await new Promise(r => setTimeout(r, 50));
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off('unhandledRejection', onUnhandledRejection);
+        getTasks().delete(id);
+      }
+    });
   });
 });

--- a/src/shutdown.test.ts
+++ b/src/shutdown.test.ts
@@ -1,7 +1,13 @@
+import { fork } from 'child_process';
 import { EventEmitter } from 'events';
 import { createTask, getTasks, shutdown, setLogger } from './node-cron';
 import { resetLogger } from './logger';
 import { ScheduledTask } from './tasks/scheduled-task';
+
+// Background tasks fork a daemon process; the daemon artifact only exists in
+// the built output, so fork() is mocked with a fake child that replays the
+// task lifecycle events. The real fork path is covered against the build.
+vi.mock('child_process', () => ({ fork: vi.fn() }));
 
 const noopLogger: any = { error() {}, warn() {}, info() {}, debug() {} };
 
@@ -280,4 +286,93 @@ describe('shutdown', () => {
       expect(task.getStatus()).toBe('destroyed');
     });
   });
+
+  describe('M5: waits for an in-progress background execution before killing the daemon', () => {
+    function makeFakeChild() {
+      const child: any = new EventEmitter();
+      child.killed = false;
+      child.kill = vi.fn(() => { child.killed = true; });
+      child.send = vi.fn((msg: any) => {
+        if (msg.command === 'task:start') {
+          queueMicrotask(() => child.emit('message', { event: 'task:started', context: { date: new Date().toISOString() } }));
+        }
+        if (msg.command === 'task:stop') {
+          // The daemon stops scheduling new runs immediately, but (per M5)
+          // must not report task:stopped as if the in-flight execution were
+          // over - execution:finished is reported later, on its own.
+          queueMicrotask(() => child.emit('message', {
+            event: 'task:stopped',
+            context: { date: new Date().toISOString(), task: { state: 'stopped' } }
+          }));
+        }
+        return true;
+      });
+      return child;
+    }
+
+    afterEach(() => {
+      vi.mocked(fork).mockReset();
+    });
+
+    it('waits for the in-flight execution to finish before killing the daemon, within the timeout', async () => {
+      const child = makeFakeChild();
+      vi.mocked(fork).mockReturnValue(child);
+
+      const task = createTask('* * * * * *', './test-assets/dummy-task.js', { logger: noopLogger });
+      await task.start();
+
+      // The daemon reports an execution in progress.
+      child.emit('message', {
+        event: 'execution:started',
+        context: {
+          date: new Date().toISOString(),
+          task: { state: 'running' },
+          execution: { id: 'e1', reason: 'scheduled', startedAt: new Date().toISOString() }
+        }
+      });
+      expect(task.isBusy()).toBe(true);
+
+      let finishedFired = false;
+      let killedWhenFinishedFired: boolean | undefined;
+      task.once('execution:finished', () => {
+        finishedFired = true;
+        killedWhenFinishedFired = (child.kill as any).mock.calls.length > 0;
+      });
+
+      // The execution reports back only after a short delay.
+      setTimeout(() => {
+        child.emit('message', {
+          event: 'execution:finished',
+          context: {
+            date: new Date().toISOString(),
+            task: { state: 'idle' },
+            execution: { id: 'e1', reason: 'scheduled', startedAt: new Date().toISOString(), finishedAt: new Date().toISOString(), result: 'ok' }
+          }
+        });
+      }, 30);
+
+      const shutdownPromise = shutdown(2000);
+
+      // task:stop has been sent and task:stopped processed by now (both are
+      // queueMicrotask), but the execution has not finished yet: the daemon
+      // must not have been killed already.
+      await wait(10);
+      expect(child.kill).not.toHaveBeenCalled();
+
+      const start = Date.now();
+      await shutdownPromise;
+      const elapsed = Date.now() - start;
+
+      expect(finishedFired).toBe(true);
+      // The daemon was not killed before its in-flight execution reported back.
+      expect(killedWhenFinishedFired).toBe(false);
+      // shutdown() did not wait for the full timeout either.
+      expect(elapsed).toBeLessThan(1000);
+      expect(child.kill).toHaveBeenCalled();
+    });
+  });
 });
+
+function wait(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/src/shutdown.test.ts
+++ b/src/shutdown.test.ts
@@ -230,4 +230,54 @@ describe('shutdown', () => {
       }
     });
   });
+
+  describe('B10: listener cleanup and isBusy() race', () => {
+    it('removes both the execution:finished and execution:failed listeners it registers', async () => {
+      const { task, unblock } = makeBusyTask();
+      const emitter = (task as any).emitter;
+
+      await waitUntilBusy(task);
+      setTimeout(unblock, 10);
+
+      await shutdown(500);
+
+      expect(emitter.listenerCount('execution:finished')).toBe(0);
+      expect(emitter.listenerCount('execution:failed')).toBe(0);
+    });
+
+    it('does not leak a listener when the task fails instead of finishing', async () => {
+      let fail!: () => void;
+      const failing = new Promise((_, reject) => { fail = () => reject(new Error('boom')); });
+      const task = createTask('* * * * * *', () => failing, { logger: noopLogger });
+      task.start();
+      const emitter = (task as any).emitter;
+
+      await waitUntilBusy(task);
+      setTimeout(fail, 10);
+
+      await shutdown(500);
+
+      expect(emitter.listenerCount('execution:finished')).toBe(0);
+      expect(emitter.listenerCount('execution:failed')).toBe(0);
+    });
+
+    it('does not wait the full timeout when the task finishes right after stop() is requested', async () => {
+      const { task, unblock } = makeBusyTask();
+
+      await waitUntilBusy(task);
+
+      // Unblock as soon as possible - the task settles essentially in the
+      // same window shutdown() reads isBusy()/registers its listeners.
+      queueMicrotask(unblock);
+
+      const start = Date.now();
+      await shutdown(2000);
+      const elapsed = Date.now() - start;
+
+      // Resolved because the execution actually finished, not because the
+      // full 2000ms timeout elapsed.
+      expect(elapsed).toBeLessThan(500);
+      expect(task.getStatus()).toBe('destroyed');
+    });
+  });
 });

--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -338,6 +338,71 @@ describe('BackgroundScheduledTask', function() {
       expect(fakeChildProcess.kill).toHaveBeenCalled();
       expect(task.forkProcess).toBeUndefined();
     });
+
+    // M5: 'task:stopped' fires as soon as the daemon stops scheduling new
+    // runs, not when the current run finishes. Killing the fork right there
+    // would abort the in-flight execution mid-run, and the caller (e.g.
+    // shutdown()) would never see its execution:finished/failed.
+    it('defers killing the daemon until an in-flight execution finishes', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+
+      fakeChildProcess.send.mockImplementation((msg: any) => {
+        if (msg.command === 'task:start') task.emitter.emit('task:started');
+        if (msg.command === 'task:stop') queueMicrotask(() => task.emitter.emit('task:stopped'));
+      });
+
+      await task.start();
+
+      // The daemon reports an execution in progress.
+      task.emitter.emit('execution:started', {} as any);
+
+      const stopPromise = task.stop();
+      await wait(10);
+
+      // stop() itself resolves once the daemon confirms it stopped
+      // scheduling, without waiting for the fork to actually be killed.
+      await stopPromise;
+      expect(fakeChildProcess.kill).not.toHaveBeenCalled();
+      expect(task.forkProcess).toBeDefined();
+
+      // The in-flight execution finishes: only now is the fork killed.
+      task.emitter.emit('execution:finished', { execution: {} } as any);
+
+      expect(fakeChildProcess.kill).toHaveBeenCalledTimes(1);
+      expect(task.forkProcess).toBeUndefined();
+    });
+
+    it('kills immediately when task:stopped arrives and nothing is in flight', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      task.forkProcess = fakeChildProcess as any;
+
+      fakeChildProcess.send.mockImplementation(() => {
+        task.emitter.emit('task:stopped');
+      });
+
+      await task.stop();
+
+      expect(fakeChildProcess.kill).toHaveBeenCalledTimes(1);
+      expect(task.forkProcess).toBeUndefined();
+    });
+
+    it('does not arm the kill wait twice when task:stopped is followed by task:destroyed while busy', function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      task.forkProcess = fakeChildProcess as any;
+
+      // Mirrors what destroy() triggers in the daemon: task:stopped
+      // immediately followed by task:destroyed, both while still busy.
+      task.emitter.emit('execution:started', {} as any);
+      task.emitter.emit('task:stopped');
+      task.emitter.emit('task:destroyed');
+
+      expect(fakeChildProcess.kill).not.toHaveBeenCalled();
+
+      task.emitter.emit('execution:finished', { execution: {} } as any);
+
+      expect(fakeChildProcess.kill).toHaveBeenCalledTimes(1);
+      expect(task.forkProcess).toBeUndefined();
+    });
   });
 
   describe('destroy', function(){

--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -339,7 +339,7 @@ describe('BackgroundScheduledTask', function() {
       expect(task.forkProcess).toBeUndefined();
     });
 
-    // M5: 'task:stopped' fires as soon as the daemon stops scheduling new
+    // 'task:stopped' fires as soon as the daemon stops scheduling new
     // runs, not when the current run finishes. Killing the fork right there
     // would abort the in-flight execution mid-run, and the caller (e.g.
     // shutdown()) would never see its execution:finished/failed.

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -37,6 +37,20 @@ class BackgroundScheduledTask implements ScheduledTask{
   // The last actual execution, mirrored in the parent from the daemon's
   // forwarded finished/failed events.
   private _lastRun: LastRun | null = null;
+  // Whether the daemon last reported an execution in progress. Tracked
+  // independently from stateMachine.state: a 'task:stopped'/'task:destroyed'
+  // message overwrites that state (via context.task.state) before this event
+  // fires, so it cannot be used to tell whether the in-flight run that was
+  // just stopped is still running. See killForkWhenSettled below.
+  private executing = false;
+  // Set while killForkWhenSettled is waiting for an in-flight execution to
+  // finish before killing the daemon, so a stop() immediately followed by a
+  // destroy() (as destroy() does internally) does not arm the wait twice.
+  // Cleared (and the wait's listeners removed) by clearPendingKillWait,
+  // called from killFork so a forced kill (e.g. the stop()/destroy() timeout)
+  // never leaves a stale execution:finished/failed listener behind.
+  private killPending = false;
+  private pendingKillCleanup?: () => void;
 
   constructor(cronExpression: string, taskPath: string, options?: TaskOptions){
     this.cronExpression = cronExpression;
@@ -50,11 +64,11 @@ class BackgroundScheduledTask implements ScheduledTask{
     // events so runsLeft() works across the process boundary.
     this.timeMatcher = new TimeMatcher(cronExpression, options?.timezone);
     this.runCount = 0;
-    this.on('execution:started', () => { this.runCount++; });
+    this.on('execution:started', () => { this.runCount++; this.executing = true; });
     // Mirror the last actual execution from the daemon's events. Both carry the
     // execution's own timestamps, so lastRun reflects the real run time.
-    this.on('execution:finished', (context) => { this.recordLastRun(context.execution); });
-    this.on('execution:failed', (context) => { this.recordLastRun(context.execution); });
+    this.on('execution:finished', (context) => { this.executing = false; this.recordLastRun(context.execution); });
+    this.on('execution:failed', (context) => { this.executing = false; this.recordLastRun(context.execution); });
     // The logger lives in the parent process: it cannot cross the fork
     // boundary. The daemon runs with a no-op logger and forwards events, and
     // this process logs from those events using the configured logger.
@@ -63,14 +77,12 @@ class BackgroundScheduledTask implements ScheduledTask{
     this.runCoordinator = options?.distributed ? resolveRunCoordinator(options?.runCoordinator) : undefined;
 
     this.on('task:stopped', () => {
-      this.forkProcess?.kill();
-      this.forkProcess = undefined;
+      this.killForkWhenSettled();
       this.stateMachine.changeState('stopped');
     });
 
     this.on('task:destroyed', () => {
-      this.forkProcess?.kill();
-      this.forkProcess = undefined;
+      this.killForkWhenSettled();
       this.stateMachine.changeState('destroyed');
     });
   }
@@ -134,6 +146,54 @@ class BackgroundScheduledTask implements ScheduledTask{
     this._lastRun = lastRun;
   }
 
+  // Kills the daemon's fork process, or, if an execution is in flight,
+  // defers the kill until it finishes (execution:finished/failed). Without
+  // this, receiving 'task:stopped' (which fires as soon as the daemon stops
+  // scheduling new runs, not when the current run finishes) would kill the
+  // daemon mid-execution, aborting it and the execution:finished/failed event
+  // it would have reported.
+  //
+  // No extra timeout is needed here: if the execution never settles (a truly
+  // stuck daemon), the caller's own stop()/destroy() timeout still forces a
+  // kill, which is the actual safety net.
+  private killForkWhenSettled(): void {
+    if (!this.forkProcess) return;
+
+    if (!this.executing) {
+      this.killFork();
+      return;
+    }
+
+    if (this.killPending) return;
+    this.killPending = true;
+
+    const onSettled = () => this.killFork();
+
+    this.once('execution:finished', onSettled);
+    this.once('execution:failed', onSettled);
+
+    this.pendingKillCleanup = () => {
+      this.off('execution:finished', onSettled);
+      this.off('execution:failed', onSettled);
+    };
+  }
+
+  // Removes the execution:finished/failed listeners armed by
+  // killForkWhenSettled, if any. Called from killFork so a forced kill (the
+  // stop()/destroy() timeout, or a settled execution) never leaves a stale
+  // listener registered for the event that did not fire.
+  private clearPendingKillWait(): void {
+    this.pendingKillCleanup?.();
+    this.pendingKillCleanup = undefined;
+    this.killPending = false;
+  }
+
+  private killFork(): void {
+    this.clearPendingKillWait();
+    this.forkProcess?.kill();
+    this.forkProcess = undefined;
+  }
+
   start(): Promise<void> {
     return new Promise((resolve, reject) => {
       if (this.forkProcess) {
@@ -147,8 +207,7 @@ class BackgroundScheduledTask implements ScheduledTask{
       // schedule on its own, leading to orphaned/duplicate executions.
       const failStart = (error: Error) => {
         clearTimeout(timeout);
-        this.forkProcess?.kill();
-        this.forkProcess = undefined;
+        this.killFork();
         reject(error);
       };
 
@@ -244,16 +303,18 @@ class BackgroundScheduledTask implements ScheduledTask{
       
       const timeoutId = setTimeout(() => {
         clearTimeout(timeoutId);
-        this.forkProcess?.kill();
-        this.forkProcess = undefined;
+        this.killFork();
         reject(new Error('Stop operation timed out'))
       }, 5000);
       
       const cleanupAndResolve = () => {
         clearTimeout(timeoutId);
         this.off('task:stopped', onStopped);
-        
-        this.forkProcess = undefined;
+
+        // forkProcess is not cleared here: killForkWhenSettled (armed by the
+        // 'task:stopped' handler registered in the constructor, which runs
+        // before this listener) owns clearing it, deferring the actual kill
+        // until an in-flight execution finishes so it is not aborted mid-run.
         resolve(undefined);
       };
 
@@ -293,8 +354,7 @@ class BackgroundScheduledTask implements ScheduledTask{
 
       const timeoutId = setTimeout(() => {
         clearTimeout(timeoutId);
-        this.forkProcess?.kill();
-        this.forkProcess = undefined;
+        this.killFork();
         reject(new Error('Destroy operation timed out'))
       }, 5000);
   

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -37,18 +37,9 @@ class BackgroundScheduledTask implements ScheduledTask{
   // The last actual execution, mirrored in the parent from the daemon's
   // forwarded finished/failed events.
   private _lastRun: LastRun | null = null;
-  // Whether the daemon last reported an execution in progress. Tracked
-  // independently from stateMachine.state: a 'task:stopped'/'task:destroyed'
-  // message overwrites that state (via context.task.state) before this event
-  // fires, so it cannot be used to tell whether the in-flight run that was
-  // just stopped is still running. See killForkWhenSettled below.
+  // Tracked separately from stateMachine.state, which a 'task:stopped' message
+  // overwrites before the kill decision runs, hiding whether a run is still live.
   private executing = false;
-  // Set while killForkWhenSettled is waiting for an in-flight execution to
-  // finish before killing the daemon, so a stop() immediately followed by a
-  // destroy() (as destroy() does internally) does not arm the wait twice.
-  // Cleared (and the wait's listeners removed) by clearPendingKillWait,
-  // called from killFork so a forced kill (e.g. the stop()/destroy() timeout)
-  // never leaves a stale execution:finished/failed listener behind.
   private killPending = false;
   private pendingKillCleanup?: () => void;
 
@@ -146,16 +137,9 @@ class BackgroundScheduledTask implements ScheduledTask{
     this._lastRun = lastRun;
   }
 
-  // Kills the daemon's fork process, or, if an execution is in flight,
-  // defers the kill until it finishes (execution:finished/failed). Without
-  // this, receiving 'task:stopped' (which fires as soon as the daemon stops
-  // scheduling new runs, not when the current run finishes) would kill the
-  // daemon mid-execution, aborting it and the execution:finished/failed event
-  // it would have reported.
-  //
-  // No extra timeout is needed here: if the execution never settles (a truly
-  // stuck daemon), the caller's own stop()/destroy() timeout still forces a
-  // kill, which is the actual safety net.
+  // Defers the kill until an in-flight run settles, so 'task:stopped' does not
+  // abort it mid-execution. A truly stuck daemon is still force-killed by the
+  // caller's stop()/destroy() timeout.
   private killForkWhenSettled(): void {
     if (!this.forkProcess) return;
 
@@ -178,10 +162,6 @@ class BackgroundScheduledTask implements ScheduledTask{
     };
   }
 
-  // Removes the execution:finished/failed listeners armed by
-  // killForkWhenSettled, if any. Called from killFork so a forced kill (the
-  // stop()/destroy() timeout, or a settled execution) never leaves a stale
-  // listener registered for the event that did not fire.
   private clearPendingKillWait(): void {
     this.pendingKillCleanup?.();
     this.pendingKillCleanup = undefined;
@@ -311,10 +291,8 @@ class BackgroundScheduledTask implements ScheduledTask{
         clearTimeout(timeoutId);
         this.off('task:stopped', onStopped);
 
-        // forkProcess is not cleared here: killForkWhenSettled (armed by the
-        // 'task:stopped' handler registered in the constructor, which runs
-        // before this listener) owns clearing it, deferring the actual kill
-        // until an in-flight execution finishes so it is not aborted mid-run.
+        // forkProcess is cleared by killForkWhenSettled, not here, so an
+        // in-flight run is not aborted mid-execution.
         resolve(undefined);
       };
 


### PR DESCRIPTION
Fixes three bugs in the new cron.shutdown() before its first release in 4.6.0:

- A background task rejecting during stop/destroy no longer crashes the process via unhandledRejection (the shutdown promises are now caught and logged).
- shutdown() now waits for an in-progress background execution to finish before killing the daemon, matching its documented contract (the timeout still force-kills a stuck daemon).
- The per-task once listeners are cleaned up and the isBusy() window no longer forces a full-timeout wait.

## Test plan

- [x] npm run build
- [x] npm run lint
- [x] npm test (100% statements/branches/functions/lines coverage)
- [x] npx tsc --noEmit
- [x] Each fix verified to fail before the corresponding change and pass after