### PR TITLE
fix: make lifecycle calls on a destroyed task safe no-ops

### DIFF
--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -77,6 +77,22 @@ describe('BackgroundScheduledTask', function() {
       expect(result).toBeUndefined();
     });
 
+    it('is a no-op when already destroyed', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      fakeChildProcess.send.mockImplementation((msg: any) => {
+        if (msg.command === 'task:destroy') task.emitter.emit('task:destroyed');
+        else task.emitter.emit('task:started');
+      });
+
+      await task.destroy();
+      vi.mocked(fork).mockClear();
+
+      const result = await task.start();
+      expect(result).toBeUndefined();
+      expect(fork).not.toHaveBeenCalled();
+      expect(task.getStatus()).toBe('destroyed');
+    });
+
     it('fails on fork failure', async function(){
       const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
   
@@ -384,6 +400,30 @@ describe('BackgroundScheduledTask', function() {
 
       expect(fakeChildProcess.kill).toHaveBeenCalledTimes(1);
       expect(task.forkProcess).toBeUndefined();
+    });
+
+    it('is a no-op when already destroyed', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      fakeChildProcess.send.mockImplementation((msg: any) => {
+        if (msg.command === 'task:destroy') task.emitter.emit('task:destroyed');
+        else task.emitter.emit('task:started');
+      });
+
+      await task.destroy();
+
+      const result = await task.stop();
+      expect(result).toBeUndefined();
+      expect(task.getStatus()).toBe('destroyed');
+    });
+
+    it('the task:stopped handler does not attempt a state transition once destroyed', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      await task.destroy();
+
+      // A stray 'task:stopped' arriving after destroy (e.g. a late daemon
+      // message) must not throw or move the task out of 'destroyed'.
+      expect(() => task.emitter.emit('task:stopped')).not.toThrow();
+      expect(task.getStatus()).toBe('destroyed');
     });
 
     it('does not arm the kill wait twice when task:stopped is followed by task:destroyed while busy', function(){

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -69,7 +69,10 @@ class BackgroundScheduledTask implements ScheduledTask{
 
     this.on('task:stopped', () => {
       this.killForkWhenSettled();
-      this.stateMachine.changeState('stopped');
+      // Destroyed is terminal; a stray stop must not attempt to leave it.
+      if (this.stateMachine.state !== 'destroyed') {
+        this.stateMachine.changeState('stopped');
+      }
     });
 
     this.on('task:destroyed', () => {
@@ -176,6 +179,11 @@ class BackgroundScheduledTask implements ScheduledTask{
 
   start(): Promise<void> {
     return new Promise((resolve, reject) => {
+      // A destroyed task has no daemon to (re-)start; treat it as a safe no-op.
+      if (this.stateMachine.state === 'destroyed') {
+        return resolve(undefined);
+      }
+
       if (this.forkProcess) {
         return resolve(undefined);
       }
@@ -276,6 +284,11 @@ class BackgroundScheduledTask implements ScheduledTask{
 
   stop(): Promise<void> {
     return new Promise((resolve, reject) => {
+      // Mirrors the inline task: stopping a destroyed task is a safe no-op.
+      if (this.stateMachine.state === 'destroyed') {
+        return resolve(undefined);
+      }
+
       if (!this.forkProcess) {
         this.emitter.emit('task:stopped');
         return resolve(undefined);

--- a/src/tasks/inline-scheduled-task.test.ts
+++ b/src/tasks/inline-scheduled-task.test.ts
@@ -257,6 +257,24 @@ describe('InlineScheduledTask', function() {
     expect(captured.warnings.some(w => w.includes('missed execution'))).toBe(false);
     task.destroy();
   });
+
+  it('start() after destroy() is a no-op and does not arm the runner', async function(){
+    const captured = makeLogger();
+    const task = new InlineScheduledTask('* * * * * *', async () => {}, { logger: captured });
+    task.destroy();
+    task.start();
+    expect(task.runner.isStopped()).toBe(true);
+    expect(task.getStatus()).toBe('destroyed');
+    await wait(1200);
+    expect(captured.errors.length).toBe(0);
+  });
+
+  it('stop() after destroy() is a no-op', function(){
+    const task = new InlineScheduledTask('* * * * * *', ()=> {});
+    task.destroy();
+    task.stop();
+    expect(task.getStatus()).toBe('destroyed');
+  });
 });
 
 function makeLogger(){

--- a/src/tasks/inline-scheduled-task.ts
+++ b/src/tasks/inline-scheduled-task.ts
@@ -164,6 +164,9 @@ export class InlineScheduledTask implements ScheduledTask {
   }
 
   start(): void {
+    // A destroyed task has no runner to arm; treat it as a safe no-op.
+    if(this.stateMachine.state === 'destroyed') return;
+
     if(this.runner.isStopped()){
       this.runner.start();
       this.stateMachine.changeState('idle');

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -144,6 +144,7 @@ export interface ScheduledTask {
   
   /** Calling this on a destroyed task is a no-op. */
   start(): void | Promise<void>;
+  /** Calling this on a destroyed task is a no-op. */
   stop(): void | Promise<void>;
   getStatus(): string;
   destroy(): void | Promise<void>;

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -142,6 +142,7 @@ export interface ScheduledTask {
   id: string,
   name?: string,
   
+  /** Calling this on a destroyed task is a no-op. */
   start(): void | Promise<void>;
   stop(): void | Promise<void>;
   getStatus(): string;


### PR DESCRIPTION
## Summary

Two related bugs where calling a lifecycle method after `destroy()` did the wrong thing instead of being a safe no-op:

- Inline tasks: `task.destroy(); task.start();` re-armed the runner's heartbeat before the state machine rejected the transition. The timer never died, and every scheduled slot logged an "invalid transition from destroyed to running" error forever. Since the task is already removed from the registry at that point, `cron.shutdown()` cannot reach it either.
- Background tasks: `await task.destroy(); await task.stop();` rejected with "invalid transition from destroyed to stopped", because `stop()` emits `task:stopped` even without a fork process, and the constructor's handler for that event unconditionally tried to move the state machine out of `destroyed`. Since `cron.shutdown()` calls `stop()` on every registered task, a manual `destroy()` followed by `shutdown()` could hit this. Background `start()` after `destroy()` also re-forked a fresh daemon for an already torn-down task.

Both `start()` and `stop()` are now safe no-ops on a destroyed task (inline and background), matching the inline `stop()` behavior that was already correct. `destroy()` itself was already idempotent, so no change was needed there.
