### PR TITLE
feat: emit task:failed when a background daemon exits unexpectedly

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,10 @@ task.on('execution:finished', (ctx) => console.log('result:', ctx.execution?.res
 task.on('execution:failed', (ctx) => console.error('failed:', ctx.execution?.error));
 task.on('execution:overlap', () => console.warn('skipped: previous run still active'));
 task.on('execution:skipped', (ctx) => console.log('not elected:', ctx.reason));
+task.on('task:failed', () => task.start()); // background task's daemon died unexpectedly (crash, OOM-kill); restart manually
 ```
 
-All events: `task:started`, `task:stopped`, `task:destroyed`, `execution:started`, `execution:finished`, `execution:failed`, `execution:missed`, `execution:overlap`, `execution:maxReached`, `execution:skipped`. See [Events & Observability](https://nodecron.com/event-listening).
+All events: `task:started`, `task:stopped`, `task:destroyed`, `task:failed`, `execution:started`, `execution:finished`, `execution:failed`, `execution:missed`, `execution:overlap`, `execution:maxReached`, `execution:skipped`. See [Events & Observability](https://nodecron.com/event-listening).
 
 ## Cron Syntax
 

--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -297,6 +297,167 @@ describe('BackgroundScheduledTask', function() {
     });
   });
 
+  describe('daemon dies unexpectedly', function(){
+    async function startedTask(options?: any){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', options);
+      fakeChildProcess.send.mockImplementation((msg: any) => {
+        if (msg.command === 'task:start') task.emitter.emit('task:started');
+      });
+      await task.start();
+      return task;
+    }
+
+    it('emits task:failed, moves to stopped and clears the fork on a spontaneous exit', async function(){
+      const task = await startedTask();
+      expect(task.getStatus()).toBe('idle');
+
+      const failedPromise = new Promise<any>(resolve => task.on('task:failed', resolve));
+      fakeChildProcess.emit('exit', null, 'SIGKILL');
+      const ctx: any = await failedPromise;
+
+      expect(ctx.error?.message).toMatch(/daemon exited unexpectedly \(code null, signal SIGKILL\)/);
+      expect(task.getStatus()).toBe('stopped');
+      expect(task.isBusy()).toBe(false);
+      expect(task.forkProcess).toBeUndefined();
+    });
+
+    it('does not fire task:failed on a clean exit (code 0) or SIGTERM', async function(){
+      const task = await startedTask();
+      const failedFn = vi.fn();
+      task.on('task:failed', failedFn);
+
+      fakeChildProcess.emit('exit', 0, null);
+      fakeChildProcess.emit('exit', null, 'SIGTERM');
+      await wait(10);
+
+      expect(failedFn).not.toHaveBeenCalled();
+    });
+
+    it('logs the death as an error via the task logger', async function(){
+      const errorFn = vi.fn();
+      const customLogger = { info() {}, warn() {}, error: errorFn, debug() {} };
+      await startedTask({ logger: customLogger });
+
+      fakeChildProcess.emit('exit', null, 'SIGKILL');
+      await wait(10);
+
+      expect(errorFn).toHaveBeenCalled();
+      expect(errorFn.mock.calls[0][0].message).toMatch(/daemon exited unexpectedly/);
+    });
+
+    it('emits execution:failed for the in-flight run before task:failed, and lastRun reflects it', async function(){
+      const task = await startedTask();
+
+      task.emitter.emit('execution:started', { execution: { id: 'e1', reason: 'scheduled', startedAt: new Date() } } as any);
+
+      const order: string[] = [];
+      task.on('execution:failed', () => { order.push('execution:failed'); });
+      task.on('task:failed', () => { order.push('task:failed'); });
+
+      fakeChildProcess.emit('exit', null, 'SIGKILL');
+      await wait(10);
+
+      expect(order).toEqual(['execution:failed', 'task:failed']);
+      expect(task.isBusy()).toBe(false);
+      expect(task.lastRun()?.error?.message).toMatch(/daemon exited unexpectedly/);
+    });
+
+    it('start() re-forks successfully after a spontaneous death', async function(){
+      const task = await startedTask();
+
+      fakeChildProcess.emit('exit', null, 'SIGKILL');
+      await wait(10);
+      expect(task.getStatus()).toBe('stopped');
+
+      const secondChild = Object.assign(new EventEmitter(), { send: vi.fn(), kill: vi.fn(), killed: false });
+      secondChild.send.mockImplementation((msg: any) => {
+        if (msg.command === 'task:start') task.emitter.emit('task:started');
+      });
+      vi.mocked(fork).mockReturnValue(secondChild as any);
+
+      await task.start();
+      expect(task.getStatus()).toBe('idle');
+      expect(task.forkProcess).toBe(secondChild);
+    });
+
+    it('does not fire task:failed when stop() kills the fork', async function(){
+      const task = await startedTask();
+      fakeChildProcess.send.mockImplementation((msg: any) => {
+        if (msg.command === 'task:stop') task.emitter.emit('task:stopped');
+      });
+
+      const failedFn = vi.fn();
+      task.on('task:failed', failedFn);
+
+      await task.stop();
+      fakeChildProcess.emit('exit', null, 'SIGTERM');
+      await wait(10);
+
+      expect(failedFn).not.toHaveBeenCalled();
+    });
+
+    it('does not fire task:failed when destroy() kills the fork', async function(){
+      const task = await startedTask();
+      fakeChildProcess.send.mockImplementation((msg: any) => {
+        if (msg.command === 'task:destroy') task.emitter.emit('task:destroyed');
+      });
+
+      const failedFn = vi.fn();
+      task.on('task:failed', failedFn);
+
+      await task.destroy();
+      fakeChildProcess.emit('exit', null, 'SIGTERM');
+      await wait(10);
+
+      expect(failedFn).not.toHaveBeenCalled();
+    });
+
+    it('does not fire task:failed when the stop timeout force-kills the fork', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      task.forkProcess = fakeChildProcess as any;
+
+      const failedFn = vi.fn();
+      task.on('task:failed', failedFn);
+
+      try { await task.stop(); } catch { /* expected timeout */ }
+      fakeChildProcess.emit('exit', null, 'SIGTERM');
+      await wait(10);
+
+      expect(failedFn).not.toHaveBeenCalled();
+    });
+
+    it('still emits task:failed and logs the invalid transition when the state is already destroyed', async function(){
+      const errorFn = vi.fn();
+      const customLogger = { info() {}, warn() {}, error: errorFn, debug() {} };
+      const task = await startedTask({ logger: customLogger });
+
+      // A race: the task was destroyed through another path, leaving the state
+      // machine in its terminal state, but this forkProcess is still around.
+      (task as any).stateMachine.state = 'destroyed';
+
+      const failedPromise = new Promise<any>(resolve => task.on('task:failed', resolve));
+      fakeChildProcess.emit('exit', null, 'SIGKILL');
+      await failedPromise;
+
+      expect(task.getStatus()).toBe('destroyed');
+      expect(errorFn.mock.calls.some(call => /invalid transition/.test(call[0]?.message ?? ''))).toBe(true);
+    });
+
+    it('does not fire task:failed on a failed start (fork exits before task:started)', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+      const failedFn = vi.fn();
+      task.on('task:failed', failedFn);
+
+      fakeChildProcess.send.mockImplementation(() => {
+        fakeChildProcess.emit('exit', null, 'SIGKILL');
+      });
+
+      try { await task.start(); } catch { /* expected */ }
+
+      expect(failedFn).not.toHaveBeenCalled();
+    });
+  });
+
   describe('stop', function(){
     it('do not fail if the task is stoped', async function(){
       const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -42,6 +42,12 @@ class BackgroundScheduledTask implements ScheduledTask{
   private executing = false;
   private killPending = false;
   private pendingKillCleanup?: () => void;
+  // The in-flight execution forwarded by 'execution:started', kept around so a
+  // daemon death mid-run can still report it via 'execution:failed'.
+  private currentExecution?: Execution;
+  // Set right before we kill the fork ourselves, so the 'exit' handler can
+  // tell an intentional teardown from the daemon dying on its own.
+  private killRequested = false;
 
   constructor(cronExpression: string, taskPath: string, options?: TaskOptions){
     this.cronExpression = cronExpression;
@@ -55,11 +61,11 @@ class BackgroundScheduledTask implements ScheduledTask{
     // events so runsLeft() works across the process boundary.
     this.timeMatcher = new TimeMatcher(cronExpression, options?.timezone);
     this.runCount = 0;
-    this.on('execution:started', () => { this.runCount++; this.executing = true; });
+    this.on('execution:started', (context) => { this.runCount++; this.executing = true; this.currentExecution = context?.execution; });
     // Mirror the last actual execution from the daemon's events. Both carry the
     // execution's own timestamps, so lastRun reflects the real run time.
-    this.on('execution:finished', (context) => { this.executing = false; this.recordLastRun(context.execution); });
-    this.on('execution:failed', (context) => { this.executing = false; this.recordLastRun(context.execution); });
+    this.on('execution:finished', (context) => { this.executing = false; this.currentExecution = undefined; this.recordLastRun(context.execution); });
+    this.on('execution:failed', (context) => { this.executing = false; this.currentExecution = undefined; this.recordLastRun(context.execution); });
     // The logger lives in the parent process: it cannot cross the fork
     // boundary. The daemon runs with a no-op logger and forwards events, and
     // this process logs from those events using the configured logger.
@@ -170,7 +176,37 @@ class BackgroundScheduledTask implements ScheduledTask{
 
   private killFork(): void {
     this.clearPendingKillWait();
+    this.killRequested = true;
     this.forkProcess?.kill();
+    this.forkProcess = undefined;
+  }
+
+  // The daemon died on its own after a successful start (crash, OOM-kill, an
+  // outside SIGKILL). Nothing else would ever notice: the task would stay
+  // 'running'/'idle' forever with no event and a hung execute(). Correct the
+  // state, fail any in-flight execution, and surface it as 'task:failed'.
+  private handleUnexpectedExit(code: number | null, signal: NodeJS.Signals | null): void {
+    this.clearPendingKillWait();
+    const erro = new Error(`daemon exited unexpectedly (code ${code}, signal ${signal})`);
+    this.logger.error(erro);
+
+    if (this.executing) {
+      const execution: Execution = { id: createID(), reason: 'scheduled', ...this.currentExecution, error: erro, finishedAt: new Date() };
+      this.emitter.emit('execution:failed', this.createContext(new Date(), execution));
+    }
+
+    try {
+      this.stateMachine.changeState('stopped');
+    } catch (err) {
+      // A race (e.g. destroy() already moved us to 'destroyed') can make this
+      // transition invalid; that state is already terminal, so just log it.
+      this.logger.error(err as Error);
+    }
+
+    const context = this.createContext(new Date());
+    context.error = erro;
+    this.emitter.emit('task:failed', context);
+
     this.forkProcess = undefined;
   }
 
@@ -198,6 +234,11 @@ class BackgroundScheduledTask implements ScheduledTask{
         ));
       }, startTimeout);
 
+      // Reset per-fork so a flag left over from a previous daemon cannot
+      // suppress detection of this one dying.
+      this.killRequested = false;
+      let startSucceeded = false;
+
       try {
         this.forkProcess = fork(daemonPath);
 
@@ -206,7 +247,18 @@ class BackgroundScheduledTask implements ScheduledTask{
         });
 
         this.forkProcess.on('exit', (code, signal) => {
+          if (this.killRequested) {
+            this.killRequested = false;
+            return;
+          }
+
+          // A code-0/SIGTERM exit looks like a graceful shutdown, so it is left
+          // alone here too (matches the intentional-kill case above).
           if (code !== 0 && signal !== 'SIGTERM') {
+            if (startSucceeded) {
+              this.handleUnexpectedExit(code, signal);
+              return;
+            }
             const erro = new Error(`node-cron daemon exited with code ${code || signal}`)
             this.logger.error(erro);
             failStart(erro);
@@ -257,6 +309,7 @@ class BackgroundScheduledTask implements ScheduledTask{
         });
         
         this.once('task:started', () => {
+          startSucceeded = true;
           this.stateMachine.changeState('idle');
           clearTimeout(timeout);
           resolve(undefined);

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -18,12 +18,21 @@ export type TaskContext = {
   triggeredAt: Date;
   /** Why the execution was skipped. Present only on `execution:skipped`. */
   reason?: SkipReason;
+  /** The daemon's exit error. Present only on `task:failed`. */
+  error?: Error;
 }
 
 export type TaskEvent =
   | 'task:started'
   | 'task:stopped'
   | 'task:destroyed'
+  /**
+   * A background task's daemon process exited on its own (crash, OOM-kill,
+   * signal from outside), not because stop/destroy asked it to. The task is
+   * left 'stopped'; restart it yourself, e.g.
+   * `task.on('task:failed', () => task.start())`. Inline tasks never emit this.
+   */
+  | 'task:failed'
   | 'execution:started'
   | 'execution:finished'
   | 'execution:failed'

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -26,12 +26,6 @@ export type TaskEvent =
   | 'task:started'
   | 'task:stopped'
   | 'task:destroyed'
-  /**
-   * A background task's daemon process exited on its own (crash, OOM-kill,
-   * signal from outside), not because stop/destroy asked it to. The task is
-   * left 'stopped'; restart it yourself, e.g.
-   * `task.on('task:failed', () => task.start())`. Inline tasks never emit this.
-   */
   | 'task:failed'
   | 'execution:started'
   | 'execution:finished'


### PR DESCRIPTION
## Problem

When a background task's forked daemon process dies without being asked to (OOM-kill, SIGKILL, a crash while running the task file), the parent process never notices. The task stays in whatever state it was last reported in, `isBusy()` can report `true` forever, no event fires, and nothing gets rescheduled. There is no way for the app to know the job died.

## Fix

The parent now tracks whether it requested a fork kill itself (stop/destroy, their timeouts, or a failed start). When the fork exits and that kill was not requested by the parent, and the task had started successfully:

- any in-flight execution is failed via `execution:failed`, so `lastRun()` reflects the failure and a pending `execute()` call rejects instead of hanging forever
- the state machine moves to `stopped`
- a new `task:failed` event fires, carrying the exit error
- the fork reference is cleared so `start()` can be called again

Automatic restart is intentionally left out of scope; that's deferred to a future retry/errorPolicy design. Users can restart manually:

```js
task.on('task:failed', () => task.start());
```

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm test` (100% coverage on all V8 metrics)
- [x] New tests in `background-scheduled-task.test.ts` verified to fail against the pre-fix source (stashed the source change, reran, restored)

BEGIN_COMMIT_OVERRIDE
feat: emit task:failed when a background daemon exits unexpectedly
END_COMMIT_OVERRIDE