### PR TITLE
fix: expand inverted ranges with wrap-around instead of silently swapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ All events: `task:started`, `task:stopped`, `task:destroyed`, `execution:started
 
 Supports ranges (`1-5`), steps (`*/2`), lists (`1,15`), named months/weekdays, `L` (last day of month), `L-n` (offset from the last day), `#` (nth weekday), `<weekday>L` (last weekday of month), `W` (nearest weekday), and `?` (alias for `*` in the day fields, for Quartz-style expressions). See the [Cron Syntax guide](https://nodecron.com/cron-syntax).
 
+An inverted range wraps around the field instead of being rejected: `22-2` in the hour field means 22:00 through 02:59 (22,23,0,1,2), and `sat-sun` in the day-of-week field means saturday,sunday.
+
 The `W` modifier in the day-of-month field fires on the nearest weekday (Monday-Friday) to a given day, without crossing the month boundary: `15W` is the nearest weekday to the 15th, `1W` the first weekday of the month, and `LW` the last weekday of the month. Only weekends are adjusted for; **there is no holiday awareness**.
 
 The `L-n` form fires `n` days before the last day of the month (`L-3` is the third-to-last day). In months where the offset reaches before the 1st (e.g. `L-29` in February), it simply does not fire that month.

--- a/src/pattern/conversion/range-conversion.test.ts
+++ b/src/pattern/conversion/range-conversion.test.ts
@@ -19,8 +19,63 @@ describe('range-conversion', function() {
       expect(expression).toBe('0,2,4,6,8,10 11,13,15,17,19,21');
   });
 
-    it('should expand a reversed range', function() {
-        expect(conversion(['5-3']).join(' ')).toBe('3,4,5');
+    it('should wrap an inverted range through the field boundary instead of swapping it', function() {
+        // Index 0 is the second/minute-shaped field (bounds 0-59): 5-3 wraps
+        // 5..59 then 0..3, it does not become the swapped 3,4,5.
+        const wrapped = conversion(['5-3'])[0].split(',').map(Number);
+        expect(wrapped[0]).toBe(5);
+        expect(wrapped[wrapped.length - 1]).toBe(3);
+        expect(wrapped).not.toEqual([3, 4, 5]);
+        expect(wrapped).toHaveLength(59);
+    });
+
+    it('should wrap inverted hours through midnight (22-2 does not contain noon)', function() {
+        const expressions = ['0', '0', '22-2', '1', '1', '0'];
+        const hours = conversion(expressions)[2].split(',').map(Number);
+        expect(hours).toEqual([22, 23, 0, 1, 2]);
+        expect(hours).not.toContain(12);
+    });
+
+    it('should step over a wrapped hour range in order (22-2/2)', function() {
+        const expressions = ['0', '0', '22-2/2', '1', '1', '0'];
+        const hours = conversion(expressions)[2].split(',').map(Number);
+        expect(hours).toEqual([22, 0, 2]);
+    });
+
+    it('should wrap inverted minutes through the top of the hour (50-10)', function() {
+        const expressions = ['0', '50-10', '0', '1', '1', '0'];
+        const minutes = conversion(expressions)[1].split(',').map(Number);
+        expect(minutes).toEqual([50,51,52,53,54,55,56,57,58,59,0,1,2,3,4,5,6,7,8,9,10]);
+    });
+
+    it('should wrap an inverted day-of-month range through the end of the month (28-2)', function() {
+        const expressions = ['0', '0', '0', '28-2', '1', '0'];
+        const days = conversion(expressions)[3].split(',').map(Number);
+        expect(days).toEqual([28,29,30,31,1,2]);
+    });
+
+    it('should wrap an inverted month range through December (11-2)', function() {
+        const expressions = ['0', '0', '0', '1', '11-2', '0'];
+        const months = conversion(expressions)[4].split(',').map(Number);
+        expect(months).toEqual([11,12,1,2]);
+    });
+
+    it('should wrap an inverted weekday range through the end of the week (5-1, Fri-Mon)', function() {
+        const expressions = ['0', '0', '0', '1', '1', '5-1'];
+        const weekdays = conversion(expressions)[5].split(',').map(Number);
+        expect(weekdays).toEqual([5, 6, 0, 1]);
+    });
+
+    it('should wrap an inverted weekday range (6-0, Sat-Sun)', function() {
+        const expressions = ['0', '0', '0', '1', '1', '6-0'];
+        const weekdays = conversion(expressions)[5].split(',').map(Number);
+        expect(weekdays).toEqual([6, 0]);
+    });
+
+    it('should leave an ascending weekday range 6-7 unwrapped (still Sat,Sun once 7 normalizes to 0)', function() {
+        const expressions = ['0', '0', '0', '1', '1', '6-7'];
+        const weekdays = conversion(expressions)[5].split(',').map(Number);
+        expect(weekdays).toEqual([6, 7]);
     });
 
     it('should leave malformed multi-dash forms untouched', function() {

--- a/src/pattern/conversion/range-conversion.ts
+++ b/src/pattern/conversion/range-conversion.ts
@@ -7,40 +7,61 @@ export default ( () => {
     // every legitimate range is numeric.
     const rangeRegEx = /^(\d+)-(\d+)(?:\/(\d+))?$/;
 
-    function expandRange(initTxt, endTxt, stepTxt) {
+    // Bounds per expression index (second, minute, hour, day-of-month, month,
+    // day-of-week), used to wrap an inverted range through the field's edge
+    // instead of swapping it.
+    const FIELD_BOUNDS = [
+        { min: 0, max: 59 },
+        { min: 0, max: 59 },
+        { min: 0, max: 23 },
+        { min: 1, max: 31 },
+        { min: 1, max: 12 },
+        { min: 0, max: 6 },
+    ];
+
+    function expandRange(initTxt, endTxt, stepTxt, bounds) {
         const step = parseInt(stepTxt, 10);
         // A non-positive step would never terminate; leave the token for
         // validation to reject.
         if (!(step >= 1)) return `${initTxt}-${endTxt}/${stepTxt}`;
 
-        let first = parseInt(initTxt, 10);
-        let last = parseInt(endTxt, 10);
-        if (first > last) {
-            const swap = first;
-            first = last;
-            last = swap;
-        }
+        const first = parseInt(initTxt, 10);
+        const last = parseInt(endTxt, 10);
 
         const numbers: number[] = [];
-        for (let i = first; i <= last; i += step) {
-            numbers.push(i);
+        if (first <= last) {
+            for (let i = first; i <= last; i += step) {
+                numbers.push(i);
+            }
+            return numbers.join();
+        }
+
+        // Inverted range: wrap through the field's upper bound back to its
+        // lower bound instead of swapping (e.g. hours `22-2` -> 22,23,0,1,2).
+        const { min, max } = bounds;
+        const size = max - min + 1;
+        const span = ((last - first) % size + size) % size;
+        for (let offset = 0; offset <= span; offset += step) {
+            let value = first + offset;
+            if (value > max) value -= size;
+            numbers.push(value);
         }
         return numbers.join();
     }
 
-    function convertRange(expression){
+    function convertRange(expression, bounds){
         return expression
             .split(',')
             .map((token) => {
                 const match = rangeRegEx.exec(token.trim());
-                return match ? expandRange(match[1], match[2], match[3] || '1') : token;
+                return match ? expandRange(match[1], match[2], match[3] || '1', bounds) : token;
             })
             .join();
     }
 
     function convertAllRanges(expressions){
         for(let i = 0; i < expressions.length; i++){
-            expressions[i] = convertRange(expressions[i]);
+            expressions[i] = convertRange(expressions[i], FIELD_BOUNDS[i]);
         }
         return expressions;
     }

--- a/src/pattern/validation/validate-detailed.test.ts
+++ b/src/pattern/validation/validate-detailed.test.ts
@@ -105,6 +105,58 @@ describe('validateDetailed', function () {
   });
 });
 
+describe('inverted ranges wrap around instead of swapping', function () {
+  it('accepts and wraps an inverted hour range (22-2), does not contain noon', function () {
+    const result = validateDetailed('0 0 22-2 * * *');
+    expect(result.valid).toBe(true);
+    expect(result.fields?.hour).toEqual([22, 23, 0, 1, 2]);
+    expect(result.fields?.hour).not.toContain(12);
+  });
+
+  it('steps over a wrapped hour range in order (22-2/2)', function () {
+    const result = validateDetailed('0 0 22-2/2 * * *');
+    expect(result.valid).toBe(true);
+    expect(result.fields?.hour).toEqual([22, 0, 2]);
+  });
+
+  it('wraps a named weekday range through the week boundary (sat-sun)', function () {
+    const result = validateDetailed('0 0 0 * * sat-sun');
+    expect(result.valid).toBe(true);
+    expect(result.fields?.dayOfWeek).toEqual([6, 0]);
+  });
+
+  it('wraps a named weekday range spanning Friday to Monday (fri-mon)', function () {
+    const result = validateDetailed('0 0 0 * * fri-mon');
+    expect(result.valid).toBe(true);
+    expect(result.fields?.dayOfWeek).toEqual([5, 6, 0, 1]);
+  });
+
+  it('leaves the ascending numeric weekday range 6-7 as Sat,Sun (no full-week wrap)', function () {
+    const result = validateDetailed('0 0 0 * * 6-7');
+    expect(result.valid).toBe(true);
+    expect(result.fields?.dayOfWeek).toEqual([6, 0]);
+  });
+
+  it('wraps a named month range through the year boundary (nov-feb)', function () {
+    const result = validateDetailed('0 0 0 1 nov-feb *');
+    expect(result.valid).toBe(true);
+    expect(result.fields?.month).toEqual([11, 12, 1, 2]);
+  });
+
+  it('wraps an inverted day-of-month range through the end of the month (28-2)', function () {
+    const result = validateDetailed('0 0 0 28-2 * *');
+    expect(result.valid).toBe(true);
+    expect(result.fields?.dayOfMonth).toEqual([28, 29, 30, 31, 1, 2]);
+  });
+
+  it('leaves the L, W and # tokens unaffected in the day fields', function () {
+    const result = validateDetailed('0 0 12 L,15W * 5L,2#3');
+    expect(result.valid).toBe(true);
+    expect(result.fields?.dayOfMonth).toEqual(['L', '15W']);
+    expect(result.fields?.dayOfWeek).toEqual(['5L', '2#3']);
+  });
+});
+
 describe('parse', function () {
   it('returns the decomposed fields for a valid expression', function () {
     const fields = parse('0 30 9 * * *');


### PR DESCRIPTION
Inverted ranges were silently swapped into ascending ones, changing the schedule meaning: `0 22-2 * * *` ran at hours 2 through 22 (21 executions at the wrong times) and `0 0 * * sat-sun` expanded to every day of the week, with no error or warning.

Ranges now wrap through the field boundary: `22-2` means 22,23,0,1,2 and `sat-sun` means Saturday and Sunday. Steps apply over the wrapped sequence in order (`22-2/2` runs at 22,0,2). Ascending ranges, the weekday 7 alias, named ranges, and the L/W/# tokens are unaffected.

Behavior change note: anyone who wrote an inverted range and was silently getting the swapped meaning will see their schedule change to what the expression actually says.