### PR TITLE
fix: validate the cron expression when scheduling a task

### DIFF
--- a/src/node-cron.test.ts
+++ b/src/node-cron.test.ts
@@ -188,7 +188,88 @@ describe('node-cron', function() {
             await task.destroy();
         });
     });
-    
+
+    describe('schedule validation', function() {
+        // Previously an out-of-range field was only caught deep inside the
+        // matcher scan (MAX_DAYS candidates), blocking the event loop for
+        // seconds before a misleading timeout error. It must now be rejected
+        // synchronously, before the task is even constructed.
+        it('rejects an out-of-range minute synchronously and fast', { timeout: 2000 }, function() {
+            const start = Date.now();
+            expect(() => cron.schedule('61 * * * *', () => {})).toThrow('61 is a invalid expression for minute');
+            expect(Date.now() - start).toBeLessThan(1000);
+        });
+
+        it('rejects an out-of-range hour', function() {
+            expect(() => cron.schedule('0 24 * * *', () => {})).toThrow('24 is a invalid expression for hour');
+        });
+
+        it('rejects an out-of-range month', function() {
+            expect(() => cron.schedule('0 0 1 13 *', () => {})).toThrow('13 is a invalid expression for month');
+        });
+
+        it('rejects a wrong field count (4 fields) with a clear error instead of a TypeError', function() {
+            let error: any;
+            try {
+                cron.schedule('* * * *', () => {});
+            } catch (e) {
+                error = e;
+            }
+            expect(error).toBeDefined();
+            expect(error).not.toBeInstanceOf(TypeError);
+            expect(error.message).toMatch(/5 or 6 fields/);
+        });
+
+        it('rejects a wrong field count (7 fields) with a clear error instead of a TypeError', function() {
+            let error: any;
+            try {
+                cron.schedule('0 0 0 * * * *', () => {});
+            } catch (e) {
+                error = e;
+            }
+            expect(error).toBeDefined();
+            expect(error).not.toBeInstanceOf(TypeError);
+            expect(error.message).toMatch(/5 or 6 fields/);
+        });
+
+        it('does not register the task when schedule() rejects the expression', function() {
+            const before = cron.getTasks().size;
+            expect(() => cron.schedule('61 * * * *', () => {})).toThrow();
+            expect(cron.getTasks().size).toBe(before);
+        });
+
+        it('does not register the task when createTask() rejects the expression', function() {
+            const before = cron.getTasks().size;
+            expect(() => cron.createTask('61 * * * *', () => {})).toThrow();
+            expect(cron.getTasks().size).toBe(before);
+        });
+
+        it('cleans up the registry when task.start() itself throws', function() {
+            const before = cron.getTasks().size;
+            expect(() => cron.schedule('* * * * *', () => {}, { timezone: 'Not/AZone' })).toThrow();
+            expect(cron.getTasks().size).toBe(before);
+        });
+
+        it('still schedules valid expressions (regression)', function() {
+            const cases: [string, object?][] = [
+                ['* * * * * *', undefined],
+                ['* * * * *', undefined],
+                ['@daily', undefined],
+                ['@hourly', undefined],
+                ['*/5 * * * *', undefined],
+                ['0 0 12 15W * *', undefined],
+                ['0 0 12 L * *', undefined],
+                ['0 0 12 * * 2#3', undefined],
+            ];
+
+            cases.forEach(([expression]) => {
+                const task = cron.schedule(expression, () => {});
+                expect(task).toBeDefined();
+                task.stop();
+            });
+        });
+    });
+
     describe('validate', function() {
         it('should validate a pattern', function() {
             expect(cron.validate('* * * * * *')).toBe(true);

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -51,10 +51,19 @@ const registry = new TaskRegistry();
  */
 export function schedule(expression:string, func: TaskFn | string, options?: TaskOptions): ScheduledTask {
     const task = createTask(expression, func, options);
+
+    let started: void | Promise<void>;
+    try {
+      started = task.start();
+    } catch (error) {
+      // A synchronous start() failure (e.g. an unresolvable timezone) leaves
+      // no running task behind; do not leave it registered either.
+      registry.remove(task);
+      throw error;
+    }
     // Background tasks start asynchronously and can fail (e.g. the task file
     // cannot be loaded). Route that failure to the logger instead of leaving it
     // as an unhandled rejection.
-    const started = task.start();
     if (started && typeof (started as Promise<void>).catch === 'function') {
       (started as Promise<void>).catch((error: any) => {
         /* v8 ignore next */
@@ -74,6 +83,11 @@ export function schedule(expression:string, func: TaskFn | string, options?: Tas
  * @private
  */
 export function createTask(expression: string, func: TaskFn | string, options?: TaskOptions): ScheduledTask {
+    // Fail fast with the same field-specific error validate()/parse() produce,
+    // instead of letting a bad expression reach the matcher (which can scan
+    // for seconds before giving up with a misleading timeout error).
+    parseExpression(expression);
+
     if (options?.distributed && !options.name) {
       throw new Error('`distributed` requires a `name` (it forms the coordination key shared across instances).');
     }

--- a/src/pattern/validation/pattern-validation.ts
+++ b/src/pattern/validation/pattern-validation.ts
@@ -134,6 +134,28 @@ function isInvalidWeekDay(expression) {
     return !isValidExpression(days, 0, 7);
 }
 
+// The last calendar day (28-31) each month can ever reach, Feb counted as 29
+// (leap years) so a leap-only date like Feb 29 is still accepted.
+const MAX_DAYS_IN_MONTH: Record<number, number> = {
+    1: 31, 2: 29, 3: 31, 4: 30, 5: 31, 6: 30,
+    7: 31, 8: 31, 9: 30, 10: 31, 11: 30, 12: 31,
+};
+
+/**
+ * Whether every listed day-of-month exceeds the max day of every listed
+ * month, i.e. the combination can never occur in any year (e.g. day 30 with
+ * month February). Skipped when a day-of-month entry is a date-dependent
+ * token (`L`, `nW`, `LW`, `L-n`) since those always resolve to a real day.
+ *
+ * @param {(number|string)[]} days The executable day-of-month expression.
+ * @param {number[]} months The executable month expression.
+ * @returns {boolean}
+ */
+function isImpossibleDayOfMonth(days, months) {
+    if (days.some((day) => typeof day !== 'number')) return false;
+    return !months.some((month) => days.some((day) => day <= MAX_DAYS_IN_MONTH[month]));
+}
+
 /**
  * @param {string[]} patterns The Cron-Job expression patterns.
  * @param {string[]} executablePatterns The executable Cron-Job expression
@@ -160,6 +182,9 @@ function validateFields(patterns, executablePatterns) {
 
     if (isInvalidWeekDay(executablePatterns[5]))
         throw new Error(`${patterns[5]} is a invalid expression for week day`);
+
+    if (isImpossibleDayOfMonth(executablePatterns[3], executablePatterns[4]))
+        throw new Error(`${patterns[3]} ${patterns[4]} is an impossible day of month for the given month`);
 }
 
 // Field metadata reused by the detailed (non-throwing) API below. Order matches
@@ -223,6 +248,14 @@ export function validateDetailed(pattern: string): DetailedValidation {
         if (f.invalid(executable[i]) || rawWMisuse)
             errors.push({ field: f.key, value: patterns[i], message: `${patterns[i]} is a invalid expression for ${f.label}` });
     });
+
+    if (!errors.length && isImpossibleDayOfMonth(executable[3], executable[4])) {
+        errors.push({
+            field: 'dayOfMonth',
+            value: patterns[3],
+            message: `${patterns[3]} ${patterns[4]} is an impossible day of month for the given month`,
+        });
+    }
 
     if (errors.length) return { valid: false, errors };
 

--- a/src/pattern/validation/validate-day.test.ts
+++ b/src/pattern/validation/validate-day.test.ts
@@ -162,6 +162,50 @@ describe('pattern-validation', function() {
         });
     });
 
+    describe('validate impossible day-of-month/month combinations', function() {
+        it('should fail when the day never occurs in the given month (Feb 30)', function() {
+            expect(() => {
+                validate('0 0 30 2 *');
+            }).toThrow(/30 2 is an impossible day of month for the given month/);
+        });
+
+        it('should not fail with Feb 29 (occurs in leap years)', function() {
+            expect(() => {
+                validate('0 0 29 2 *');
+            }).not.toThrow();
+        });
+
+        it('should not fail when at least one listed month has the day (Jan/Mar 31)', function() {
+            expect(() => {
+                validate('0 0 31 1,3 *');
+            }).not.toThrow();
+        });
+
+        it('should fail when none of several months has the day (Apr/Jun 31)', function() {
+            expect(() => {
+                validate('0 0 31 4,6 *');
+            }).toThrow(/31 4,6 is an impossible day of month for the given month/);
+        });
+
+        it('should not check the combination when day-of-month uses a date-dependent token', function() {
+            expect(() => {
+                validate('0 0 L 2 *');
+            }).not.toThrow();
+            expect(() => {
+                validate('0 0 30W 2 *');
+            }).not.toThrow();
+        });
+
+        it('should not check the combination when day-of-month or month is a wildcard', function() {
+            expect(() => {
+                validate('0 0 30 * *');
+            }).not.toThrow();
+            expect(() => {
+                validate('0 0 * 2 *');
+            }).not.toThrow();
+        });
+    });
+
     describe('validate ? (no-specific-value alias)', function() {
         it('should accept ? in the day-of-month field', function() {
             expect(() => {

--- a/src/pattern/validation/validate-detailed.test.ts
+++ b/src/pattern/validation/validate-detailed.test.ts
@@ -103,6 +103,18 @@ describe('validateDetailed', function () {
     expect(result.valid).toBe(false);
     expect(result.errors[0].field).toBe('expression');
   });
+
+  it('reports an impossible day-of-month/month combination', function () {
+    const result = validateDetailed('0 0 30 2 *');
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe('dayOfMonth');
+    expect(result.errors[0].message).toMatch(/impossible day of month/);
+  });
+
+  it('accepts Feb 29 as a possible day-of-month/month combination', function () {
+    const result = validateDetailed('0 0 29 2 *');
+    expect(result.valid).toBe(true);
+  });
 });
 
 describe('parse', function () {


### PR DESCRIPTION
schedule()/createTask() accepted any expression and only failed once the runner tried to compute the next match: an out-of-range field (e.g. minute 61) triggered a scan of up to MAX_DAYS candidate dates before throwing a misleading timeout error (about 16 seconds, blocking the event loop the whole time), and a wrong field count (4 or 7 fields) crashed with a raw TypeError deep inside range conversion. Either way, the task was left in the registry with the runner never actually started.

Fix: validate the expression at the start of createTask() (which schedule() goes through), reusing the same field-specific errors parse()/validate() already produce, before the task is constructed or registered. Also cover the case where task.start() itself throws synchronously (e.g. an unresolvable timezone): the task is now removed from the registry before the error is rethrown, so a failed schedule() never leaves an orphan.

Also added a small validation rule for day-of-month/month combinations that can never occur in any year (e.g. day 30 in February), since that hit the same slow scan. It only fires when every listed day is a plain number (skipped for L/W/# tokens, which always resolve to a real day) and leap years are accounted for, so Feb 29 is still accepted.

## Test plan
- [x] New tests for schedule()/createTask() rejecting invalid expressions synchronously and fast, including field-count and impossible-date cases
- [x] Regression tests confirming valid expressions (nicknames, steps, L/W/#, 6-field) still schedule
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm test` (696 tests passing, 100% coverage on all four V8 metrics)