### PR TITLE
fix: make concurrent background start() await the daemon and time out coordinator lookups

### DIFF
--- a/src/coordinator/ipc-run-coordinator.test.ts
+++ b/src/coordinator/ipc-run-coordinator.test.ts
@@ -72,9 +72,36 @@ describe('IpcRunCoordinator', function () {
   });
 
   it('does not throw when the channel has no send (parent gone)', async function () {
-    const coordinator = new IpcRunCoordinator({ on: () => {} });
+    const coordinator = new IpcRunCoordinator({ on: () => {} }, 50);
     await coordinator.onComplete('job:2026');
-    // shouldRun stays pending (no parent to reply); just assert it returns a promise.
-    expect(coordinator.shouldRun('job:2026', 1000)).toBeInstanceOf(Promise);
+    // The parent can never reply, so the bounded timeout is what settles this.
+    const promise = coordinator.shouldRun('job:2026', 1000);
+    expect(promise).toBeInstanceOf(Promise);
+    await expect(promise).rejects.toThrow();
+  });
+
+  it('rejects shouldRun after the timeout when the parent never answers, and clears the pending entry', async function () {
+    const channel = makeChannel();
+    const coordinator = new IpcRunCoordinator(channel, 30);
+
+    let error: Error | undefined;
+    await coordinator.shouldRun('job:2026', 5000).catch((e) => { error = e; });
+
+    expect(error).toBeDefined();
+    expect(error!.message).toMatch(/timed out|timeout/i);
+
+    // A reply that arrives after the timeout must be a no-op: the pending
+    // entry for this reqId is already gone, so nothing should throw.
+    expect(() => channel.reply({ type: 'coordinator:result', reqId: channel.sent[0].reqId, allowed: true })).not.toThrow();
+  });
+
+  it('still resolves normally when the parent answers within the timeout', async function () {
+    const channel = makeChannel();
+    const coordinator = new IpcRunCoordinator(channel, 1000);
+
+    const promise = coordinator.shouldRun('job:2026', 5000);
+    channel.reply({ type: 'coordinator:result', reqId: channel.sent[0].reqId, allowed: true });
+
+    expect(await promise).toBe(true);
   });
 });

--- a/src/coordinator/ipc-run-coordinator.ts
+++ b/src/coordinator/ipc-run-coordinator.ts
@@ -12,6 +12,11 @@ export type IpcChannel = {
 
 type CoordinatorResult = { type: 'coordinator:result'; reqId: string; allowed: boolean; error?: string };
 
+// Bounds how long a shouldRun ask waits for the parent's reply. Without this a
+// lost message or a blocked parent event loop leaves the promise pending
+// forever, which (with noOverlap) blocks every future fire.
+const DEFAULT_REPLY_TIMEOUT_MS = 5000;
+
 /**
  * A `RunCoordinator` used inside a background task's daemon (child process). The
  * real coordinator lives in the parent (resolved from setRunCoordinator / the
@@ -23,7 +28,7 @@ type CoordinatorResult = { type: 'coordinator:result'; reqId: string; allowed: b
 export class IpcRunCoordinator implements RunCoordinator {
   private pending = new Map<string, (result: CoordinatorResult) => void>();
 
-  constructor(private channel: IpcChannel) {
+  constructor(private channel: IpcChannel, private replyTimeoutMs: number = DEFAULT_REPLY_TIMEOUT_MS) {
     this.channel.on('message', (message: any) => {
       if (message?.type !== 'coordinator:result') return;
       const resolve = this.pending.get(message.reqId);
@@ -37,7 +42,13 @@ export class IpcRunCoordinator implements RunCoordinator {
   shouldRun(key: string, ttlMs: number): Promise<boolean> {
     const reqId = createID();
     return new Promise<boolean>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        this.pending.delete(reqId);
+        reject(new Error(`Run coordinator reply timed out after ${this.replyTimeoutMs}ms`));
+      }, this.replyTimeoutMs);
+
       this.pending.set(reqId, (result) => {
+        clearTimeout(timeoutId);
         // The parent reports a coordinator error by replying with `error`; reject
         // so the runner fails closed (skips the run), mirroring the inline path.
         if (result.error) reject(new Error(result.error));

--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -77,6 +77,36 @@ describe('BackgroundScheduledTask', function() {
       expect(result).toBeUndefined();
     });
 
+    it('memoizes concurrent start() calls until the daemon handshake completes', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+
+      // 'task:started' is only emitted once send() below is manually triggered,
+      // so both calls are in flight together before either can resolve.
+      fakeChildProcess.send.mockImplementation(() => {});
+
+      const first = task.start();
+      const second = task.start();
+
+      expect(fork).toHaveBeenCalledTimes(1);
+
+      let firstSettled = false;
+      let secondSettled = false;
+      first.then(() => { firstSettled = true; });
+      second.then(() => { secondSettled = true; });
+
+      // Neither resolves yet: the daemon has not signalled readiness.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(firstSettled).toBe(false);
+      expect(secondSettled).toBe(false);
+
+      task.emitter.emit('task:started');
+
+      await expect(first).resolves.toBeUndefined();
+      await expect(second).resolves.toBeUndefined();
+      expect(fork).toHaveBeenCalledTimes(1);
+    });
+
     it('is a no-op when already destroyed', async function(){
       const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
       fakeChildProcess.send.mockImplementation((msg: any) => {

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -48,6 +48,10 @@ class BackgroundScheduledTask implements ScheduledTask{
   // Set right before we kill the fork ourselves, so the 'exit' handler can
   // tell an intentional teardown from the daemon dying on its own.
   private killRequested = false;
+  // Memoizes an in-flight start() so a concurrent caller awaits the same
+  // handshake instead of seeing forkProcess set and resolving early, before
+  // the daemon has actually loaded the task.
+  private startPromise?: Promise<void>;
 
   constructor(cronExpression: string, taskPath: string, options?: TaskOptions){
     this.cronExpression = cronExpression;
@@ -214,16 +218,30 @@ class BackgroundScheduledTask implements ScheduledTask{
   }
 
   start(): Promise<void> {
+    // A destroyed task has no daemon to (re-)start; treat it as a safe no-op.
+    if (this.stateMachine.state === 'destroyed') {
+      return Promise.resolve();
+    }
+
+    // A concurrent caller must await the same handshake, not resolve early:
+    // forkProcess is assigned synchronously below, before the daemon has
+    // actually loaded the task.
+    if (this.startPromise) {
+      return this.startPromise;
+    }
+
+    if (this.forkProcess) {
+      return Promise.resolve();
+    }
+
+    this.startPromise = this.forkAndStart().finally(() => {
+      this.startPromise = undefined;
+    });
+    return this.startPromise;
+  }
+
+  private forkAndStart(): Promise<void> {
     return new Promise((resolve, reject) => {
-      // A destroyed task has no daemon to (re-)start; treat it as a safe no-op.
-      if (this.stateMachine.state === 'destroyed') {
-        return resolve(undefined);
-      }
-
-      if (this.forkProcess) {
-        return resolve(undefined);
-      }
-
       const startTimeout = this.options?.startTimeout ?? 5000;
 
       // Any failure to start must also tear down the daemon. Otherwise a daemon

--- a/src/tasks/background-scheduled-task/daemon.test.ts
+++ b/src/tasks/background-scheduled-task/daemon.test.ts
@@ -337,10 +337,27 @@ describe('daemon - register', function () {
   });
 
   it('task:execute is safe when no task has been started', async function () {
+    messages = [];
     bind();
     const onMessage = listeners.filter(l => l.event === 'message').pop();
     const result = await onMessage.fn({ command: 'task:execute' });
     expect(result).toBeUndefined();
+  });
+
+  // The daemon must not silently drop a task:execute that arrives before
+  // task:start has finished loading the task: the parent's execute() waits
+  // for a matching event forever otherwise.
+  it('reports an error instead of hanging when task:execute arrives with no task loaded', async function () {
+    messages = [];
+    bind();
+    const onMessage = listeners.filter(l => l.event === 'message').pop();
+    const result = await onMessage.fn({ command: 'task:execute' });
+
+    expect(result).toBeUndefined();
+    const failedEvent = messages.find(m => m.event === 'execution:failed');
+    expect(failedEvent).toBeDefined();
+    expect(failedEvent.jsonError).toBeDefined();
+    expect(JSON.parse(failedEvent.jsonError).message).toMatch(/no task loaded|not loaded/i);
   });
 
   it('starts a daemon without options', async function () {

--- a/src/tasks/background-scheduled-task/daemon.ts
+++ b/src/tasks/background-scheduled-task/daemon.ts
@@ -3,6 +3,7 @@ import logger, { noopLogger } from "../../logger";
 import { InlineScheduledTask } from "../inline-scheduled-task";
 import { ScheduledTask, TaskContext, TaskEvent, TaskOptions } from "../scheduled-task";
 import { IpcRunCoordinator } from "../../coordinator/ipc-run-coordinator";
+import { createID } from "../../create-id";
 
 export async function startDaemon(message: any): Promise<ScheduledTask> {
     const script = await importTaskModule(message.path);
@@ -156,8 +157,19 @@ export function bind(){
       if(task) task.destroy();
       return task;
     case 'task:execute':
+      if (!task) {
+        // No task loaded yet: report it instead of dropping the message, or
+        // the parent's execute() waits for an event that never arrives.
+        sendEvent('execution:failed', {
+          date: new Date(),
+          dateLocalIso: new Date().toISOString(),
+          triggeredAt: new Date(),
+          execution: { id: createID(), reason: 'invoked', error: new Error('Cannot execute: no task loaded') }
+        });
+        return task;
+      }
       try {
-        if (task) await task.execute();
+        await task.execute();
       } catch(error: any){
         logger.debug('Daemon task:execute failed:', error);
       }


### PR DESCRIPTION
## Summary

Two related bugs in the background (forked) task path:

**1. Concurrent start() resolved before the daemon was ready.** A second `start()` call saw `forkProcess` already assigned (it is set synchronously when forking) and resolved immediately, without waiting for the daemon to actually load the task file and send `task:started`. A following `execute()` could then reach a daemon whose internal task was still undefined, get silently dropped, and hang forever.

Fix: `start()` now memoizes the in-flight promise and returns it to any concurrent caller, so it only resolves once the daemon signals readiness. The daemon also now replies with an error (instead of silently doing nothing) when a `task:execute` arrives before a task has been loaded, so a caller in that state fails fast instead of hanging.

**2. IpcRunCoordinator.shouldRun had no timeout.** The daemon asks the parent `coordinator:shouldRun` over IPC; if the parent never replies (a blocked event loop, a lost message), the returned promise stayed pending forever. Combined with `noOverlap`, that blocks every future fire, and the pending request map entry was never cleaned up.

Fix: `shouldRun` now rejects after a bounded timeout (defaults to 5s, configurable via the constructor), which the runner already treats as a coordinator error (fails closed, skips the run). The pending map entry is deleted on settle or timeout either way, so it cannot leak.

## Test plan
- [x] New test: two near-simultaneous `start()` calls resolve only after `task:started`, and `fork()` is called once
- [x] New test: a `task:execute` reaching the daemon with no task loaded reports `execution:failed` instead of hanging
- [x] New test: `shouldRun` rejects after the timeout when the parent never answers, and the pending entry is cleared
- [x] New test: `shouldRun` still resolves normally when the parent answers within the timeout
- [x] `npm run build`, `npm run lint`, `npx tsc --noEmit`, `npm test` all green, 100% coverage on all four V8 metrics