### PR TITLE
fix: validate() consistency and multi-asterisk expansion

### DIFF
--- a/src/node-cron.test.ts
+++ b/src/node-cron.test.ts
@@ -278,6 +278,22 @@ describe('node-cron', function() {
         it('should fail with a invalid pattern', function() {
             expect(cron.validate('62 * * * * *')).toBe(false);
         });
+
+        it('rejects an expression with too many fields, matching validateDetailed', function() {
+            expect(cron.validate('* * * * * * *')).toBe(false);
+            expect(cron.validateDetailed('* * * * * * *').valid).toBe(false);
+        });
+
+        it('agrees with validateDetailed on an expression with irregular spacing', function() {
+            const expression = '0  30 9 * * *';
+            expect(cron.validate(expression)).toBe(cron.validateDetailed(expression).valid);
+        });
+
+        it('produces a working schedule for multiple asterisk tokens in a comma list', function() {
+            const fields = cron.validateDetailed('*/2,*/3 * * * *').fields;
+            expect(fields?.minute).toEqual(expect.arrayContaining([0, 2, 4, 3, 6, 9]));
+            expect(cron.validate('*/2,*/3 * * * *')).toBe(true);
+        });
     });
 
     describe('validateDetailed', function() {

--- a/src/pattern/conversion/asterisk-to-range-conversion.test.ts
+++ b/src/pattern/conversion/asterisk-to-range-conversion.test.ts
@@ -12,4 +12,16 @@ describe('asterisk-to-range-conversion', function() {
       const expression = conversion(expressions).join(' ');
       expect(expression).toBe('0-59/2 0-59 0-23 1-31 1-12 0-6');
   });
+
+    it('converts every asterisk token in a comma list, not just the first', function() {
+        const expressions = '*/2,*/3 * * * * *'.split(' ');
+        const expression = conversion(expressions).join(' ');
+        expect(expression).toBe('0-59/2,0-59/3 0-59 0-23 1-31 1-12 0-6');
+    });
+
+    it('converts a comma list mixing a bare asterisk with a stepped one', function() {
+        const expressions = '*,*/15 * * * * *'.split(' ');
+        const expression = conversion(expressions).join(' ');
+        expect(expression).toBe('0-59,0-59/15 0-59 0-23 1-31 1-12 0-6');
+    });
 });

--- a/src/pattern/conversion/asterisk-to-range-conversion.ts
+++ b/src/pattern/conversion/asterisk-to-range-conversion.ts
@@ -1,10 +1,13 @@
 
 export default (() => {
     function convertAsterisk(expression, replecement){
-        if(expression.indexOf('*') !== -1){
-            return expression.replace('*', replecement);
-        }
-        return expression;
+        // Convert every comma-separated token, not just the first `*`/`*/n`
+        // found in the whole field, otherwise later tokens (e.g. `*/3` in
+        // `*/2,*/3`) survive as literal text and never match anything.
+        return expression
+            .split(',')
+            .map((token) => token.indexOf('*') !== -1 ? token.replace('*', replecement) : token)
+            .join(',');
     }
 
     function convertAsterisksToRanges(expressions){

--- a/src/pattern/validation/pattern-validation.ts
+++ b/src/pattern/validation/pattern-validation.ts
@@ -9,6 +9,12 @@ const validationRegex = /^(?:\d+|\*|\*\/\d+)$/;
 // day fields; field-level validation rejects either elsewhere.
 const ALLOWED_CHARS_REGEX = /^[a-zA-Z0-9-*/,#? ]+$/;
 
+// Shared by validate() and validateDetailed() so both agree on field count
+// and on how extra/leading spaces are handled before splitting into fields.
+function splitFields(resolved: string): string[] {
+    return resolved.replace(/\s{2,}/g, ' ').trim().split(' ');
+}
+
 /**
  * @param {string} expression The Cron-Job expression.
  * @param {number} min The minimum value.
@@ -235,7 +241,7 @@ export function validateDetailed(pattern: string): DetailedValidation {
     if (!ALLOWED_CHARS_REGEX.test(resolved))
         return { valid: false, errors: [{ field: 'expression', value: pattern, message: 'pattern includes illegal characters' }] };
 
-    const raw = resolved.replace(/\s{2,}/g, ' ').trim().split(' ');
+    const raw = splitFields(resolved);
     if (raw.length !== 5 && raw.length !== 6)
         return { valid: false, errors: [{ field: 'expression', value: pattern, message: `expected 5 or 6 fields but got ${raw.length}` }] };
 
@@ -298,10 +304,12 @@ function validate(pattern) {
     if (!ALLOWED_CHARS_REGEX.test(resolved))
         throw new TypeError('pattern includes illegal characters!');
 
-    const patterns = resolved.split(' ');
-    const executablePatterns = convertExpression(resolved);
+    const raw = splitFields(resolved);
+    if (raw.length !== 5 && raw.length !== 6)
+        throw new Error(`expected 5 or 6 fields but got ${raw.length}`);
 
-    if (patterns.length === 5) patterns.unshift('0');
+    const patterns = raw.length === 5 ? ['0', ...raw] : raw;
+    const executablePatterns = convertExpression(resolved);
 
     validateFields(patterns, executablePatterns);
 }

--- a/src/pattern/validation/validate.test.ts
+++ b/src/pattern/validation/validate.test.ts
@@ -1,4 +1,4 @@
-import validate from './pattern-validation';
+import validate, { validateDetailed } from './pattern-validation';
 
 describe('pattern-validation', function() {
     it('should succeed with a valid expression', function() {
@@ -57,6 +57,22 @@ describe('pattern-validation', function() {
         it('still accepts the valid forms it resembles', function() {
             ['0 0 0 1-5 * *', '0 0 0 */2 * *', '0 0 0 5-3 * *', '0 0 0 1,15,L * *', '0 0 0 1-10/2 * *']
                 .forEach((expr) => expect(() => validate(expr), expr).not.toThrow());
+        });
+    });
+
+    describe('agreement with validateDetailed', function() {
+        it('rejects a 7-field expression, same as validateDetailed', function() {
+            expect(() => validate('* * * * * * *')).toThrow(/5 or 6 fields/);
+            expect(validateDetailed('* * * * * * *').valid).toBe(false);
+        });
+
+        it('rejects a 3-field expression, same as validateDetailed', function() {
+            expect(() => validate('* * *')).toThrow(/5 or 6 fields/);
+            expect(validateDetailed('* * *').valid).toBe(false);
+        });
+
+        it('normalizes double spaces before splitting, so field indexing matches validateDetailed', function() {
+            expect(() => validate('60  9 * * *')).toThrow('60 is a invalid expression for minute');
         });
     });
 


### PR DESCRIPTION
This fixes two bugs found in the pattern validation and conversion code.

## Bug 1: validate() and validateDetailed() disagreed on the same input

validate() never checked the number of fields in an expression, so a 7-field
expression like `* * * * * * *` silently ignored the extra field and returned
true, while validateDetailed() correctly rejected it with "expected 5 or 6
fields but got 7". validate() also split on raw spaces without normalizing
double/leading spaces first, so irregular spacing could misalign which value
an error message blamed.

Fix: validate() now reuses the same field-count check and space
normalization that validateDetailed() already uses, so the two public APIs
agree on the same input.

## Bug 2: multiple asterisks in the same field silently never matched

The asterisk-to-range conversion used `String.replace('*', replacement)`,
which only replaces the first match. In a field like `*/2,*/3`, only the
first token got converted to a range; the second token (`*/3`) survived as
literal text that no time value ever matches, so those minutes silently
never fired.

Fix: the conversion now splits the field on commas and converts every
`*`/`*/n` token individually, so all of them expand into working ranges.

## Test plan
- [x] Added failing tests first, confirmed they failed for the right reason,
      then implemented the fixes (TDD)
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm test` (100% coverage on all V8 metrics)