### PR TITLE
fix: correlate execute() by id, isolate event hooks, and stop counting manual runs toward maxExecutions

### DIFF
--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -49,7 +49,7 @@ function makeFakeChild(opts?: { fail?: boolean }) {
         context: { date: now }
       }));
     } else if (msg.command === 'task:execute') {
-      const id = 'exec-' + Math.floor(Math.random() * 1e9);
+      const id = msg.executionId ?? ('exec-' + Math.floor(Math.random() * 1e9));
       queueMicrotask(() => {
         child.emit('message', {
           event: 'execution:started',

--- a/src/scheduler/runner.test.ts
+++ b/src/scheduler/runner.test.ts
@@ -551,6 +551,105 @@ describe('scheduler/runner', function(){
     await new Promise(resolve => setTimeout(resolve, 1200));
     runner.stop();
   });
+
+  it('isolates a throwing onFinished hook from a successful scheduled run (does not call onError)', async function () {
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    let onErrorCalled = false;
+    let onFinishedCalled = false;
+
+    const runner = new Runner(timeMatcher, async () => 'ok', {
+      onFinished() {
+        onFinishedCalled = true;
+        throw new Error('hook boom');
+      },
+      onError() {
+        onErrorCalled = true;
+      },
+    });
+    runner.start();
+
+    await new Promise(resolve => setTimeout(resolve, 1200));
+    runner.stop();
+
+    expect(onFinishedCalled).toBe(true);
+    expect(onErrorCalled).toBe(false);
+  });
+
+  it('does not crash on a rejecting onFinished hook for a scheduled run', async function () {
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    let onErrorCalled = false;
+
+    const runner = new Runner(timeMatcher, async () => 'ok', {
+      onFinished() {
+        return Promise.reject(new Error('async hook boom'));
+      },
+      onError() {
+        onErrorCalled = true;
+      },
+    });
+    runner.start();
+
+    await new Promise(resolve => setTimeout(resolve, 1200));
+    runner.stop();
+
+    expect(onErrorCalled).toBe(false);
+  });
+
+  it('isolates a throwing onFinished hook from a successful manual execute()', async function () {
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    let onErrorCalled = false;
+
+    const runner = new Runner(timeMatcher, async () => 'ok', {
+      onFinished() {
+        throw new Error('hook boom');
+      },
+      onError() {
+        onErrorCalled = true;
+      },
+    });
+
+    await runner.execute();
+
+    expect(onErrorCalled).toBe(false);
+  });
+
+  it('manual execute() does not count toward maxExecutions and is not gated by it', async function () {
+    const timeMatcher = new TimeMatcher('* * * * * *');
+    let onMaxExecutionsCalled = false;
+
+    const runner = new Runner(timeMatcher, async () => 'ok', {
+      maxExecutions: 2,
+      onMaxExecutions() { onMaxExecutionsCalled = true; },
+    });
+
+    await runner.execute();
+    await runner.execute();
+    await runner.execute();
+
+    expect(runner.runCount).toBe(0);
+    expect(onMaxExecutionsCalled).toBe(false);
+  });
+
+  it('manual execute() still runs after the task auto-stopped from maxExecutions', async function () {
+    const timeMatcher = new TimeMatcher('* * * * * *');
+
+    const runner = new Runner(timeMatcher, async () => 'manual after stop', {
+      maxExecutions: 1,
+    });
+
+    runner.start();
+    await new Promise(resolve => setTimeout(resolve, 1200));
+    expect(runner.isStopped()).toBe(true);
+    expect(runner.runCount).toBe(1);
+
+    let manualResult: any;
+    runner.onFinished = (_date, execution) => { manualResult = execution.result; return true; };
+    await runner.execute();
+
+    expect(manualResult).toBe('manual after stop');
+    // Still not counted toward maxExecutions.
+    expect(runner.runCount).toBe(1);
+  });
 });
 
 function blockIO(ms: number) {

--- a/src/scheduler/runner.ts
+++ b/src/scheduler/runner.ts
@@ -194,12 +194,6 @@ export class Runner {
           const result = await this.onMatch(date, execution);
           execution.finishedAt = new Date();
           execution.result = result;
-          this.onFinished(date, execution);
-
-          if (this.maxExecutions && this.runCount >= this.maxExecutions) {
-            this.onMaxExecutions(date);
-            this.stop();
-          }
         } catch (error: any) {
           execution.finishedAt = new Date();
           execution.error = error;
@@ -208,6 +202,20 @@ export class Runner {
           } catch (hookError: any) {
             this.onErrorFallback(date, hookError);
           }
+          return;
+        }
+
+        // A throwing/rejecting onFinished hook must not reclassify this
+        // successful run as failed.
+        try {
+          await this.onFinished(date, execution);
+        } catch (hookError: any) {
+          this.onErrorFallback(date, hookError);
+        }
+
+        if (this.maxExecutions && this.runCount >= this.maxExecutions) {
+          this.onMaxExecutions(date);
+          this.stop();
         }
       };
 
@@ -320,26 +328,34 @@ export class Runner {
     }
   }
 
-  async execute(){
+  // A manual run never counts toward maxExecutions and is never blocked by it;
+  // only scheduled fires do (see runCount++ in runTask above). `executionId`
+  // lets callers that cross a process boundary (background tasks) correlate
+  // the settled event with the run they invoked, rather than any other one.
+  async execute(executionId?: string){
     const date = new Date();
     const execution: Execution = {
-      id: createID(),
+      id: executionId ?? createID(),
       reason: 'invoked'
     }
     try {
       const shouldExecute = await this.beforeRun(date, execution);
-      if(shouldExecute){
-        this.runCount++;
-        execution.startedAt = new Date();
-        const result = await this.onMatch(date, execution);
-        execution.finishedAt = new Date();
-        execution.result = result;
-        this.onFinished(date, execution);
-      }
+      if(!shouldExecute) return;
+      execution.startedAt = new Date();
+      const result = await this.onMatch(date, execution);
+      execution.finishedAt = new Date();
+      execution.result = result;
     } catch (error: any){
       execution.finishedAt = new Date();
       execution.error = error;
       this.onError(date, error, execution);
+      return;
+    }
+
+    try {
+      await this.onFinished(date, execution);
+    } catch (hookError: any) {
+      this.onErrorFallback(date, hookError);
     }
   }
 }

--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -697,7 +697,7 @@ describe('BackgroundScheduledTask', function() {
             context: {
               date: now,
               task: { id: task.id, name: task.name, state: 'running' },
-              execution: { id: 'e1', reason: 'invoked', startedAt: now }
+              execution: { id: msg.executionId, reason: 'invoked', startedAt: now }
             }
           });
         }
@@ -725,7 +725,7 @@ describe('BackgroundScheduledTask', function() {
             context: {
               date: now,
               task: { id: task.id, name: task.name, state: 'running' },
-              execution: { id: 'e1', reason: 'invoked', startedAt: now }
+              execution: { id: msg.executionId, reason: 'invoked', startedAt: now }
             }
           });
           queueMicrotask(() => {
@@ -734,7 +734,7 @@ describe('BackgroundScheduledTask', function() {
               context: {
                 date: now,
                 task: { id: task.id, name: task.name, state: 'idle' },
-                execution: { id: 'e1', reason: 'invoked', startedAt: now, finishedAt: now, result: 'ok' }
+                execution: { id: msg.executionId, reason: 'invoked', startedAt: now, finishedAt: now, result: 'ok' }
               }
             });
           });
@@ -762,14 +762,14 @@ describe('BackgroundScheduledTask', function() {
 
       fakeChildProcess.send.mockImplementation((obj)=>{
         if(obj.command === 'task:execute'){
-          task.emitter.emit('execution:finished', {execution: { result: "task result"}});
+          task.emitter.emit('execution:finished', {execution: { id: obj.executionId, result: "task result"}});
         } else {
           task.emitter.emit('task:started');
         }
       })
 
       await task.start();
-      
+
       const result = await task.execute();
       expect(result).toBe('task result');
     });
@@ -779,7 +779,7 @@ describe('BackgroundScheduledTask', function() {
 
       fakeChildProcess.send.mockImplementation((obj)=>{
         if(obj.command === 'task:execute'){
-          task.emitter.emit('execution:failed', {execution: { error: Error("task error")}});
+          task.emitter.emit('execution:failed', {execution: { id: obj.executionId, error: Error("task error")}});
         } else {
           task.emitter.emit('task:started');
         }
@@ -799,7 +799,7 @@ describe('BackgroundScheduledTask', function() {
 
       fakeChildProcess.send.mockImplementation((obj: any) => {
         if(obj.command === 'task:execute'){
-          task.emitter.emit('execution:failed', { execution: {} });
+          task.emitter.emit('execution:failed', { execution: { id: obj.executionId } });
         } else {
           task.emitter.emit('task:started');
         }
@@ -843,7 +843,7 @@ describe('BackgroundScheduledTask', function() {
       // must wait for it rather than rejecting.
       fakeChildProcess.send.mockImplementation((obj)=>{
         if(obj.command === 'task:execute'){
-          setTimeout(() => task.emitter.emit('execution:finished', {execution: { result: "late result"}}), 50);
+          setTimeout(() => task.emitter.emit('execution:finished', {execution: { id: obj.executionId, result: "late result"}}), 50);
         } else {
           task.emitter.emit('task:started');
         }
@@ -853,6 +853,46 @@ describe('BackgroundScheduledTask', function() {
 
       const result = await task.execute();
       expect(result).toBe('late result');
+    });
+
+    it('resolves with the invoked run\'s result, not a concurrent scheduled run\'s', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+
+      fakeChildProcess.send.mockImplementation((obj: any) => {
+        if (obj.command === 'task:execute') {
+          // A concurrent scheduled fire in the daemon settles first, with a
+          // different execution id.
+          task.emitter.emit('execution:finished', { execution: { id: 'scheduled-1', reason: 'scheduled', result: 'scheduled' } });
+          setTimeout(() => {
+            task.emitter.emit('execution:finished', { execution: { id: obj.executionId, reason: 'invoked', result: 'invoked' } });
+          }, 10);
+        } else {
+          task.emitter.emit('task:started');
+        }
+      });
+
+      await task.start();
+      const result = await task.execute();
+      expect(result).toBe('invoked');
+    });
+
+    it('ignores a concurrent scheduled run\'s failure while the invoked run is still in flight', async function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js');
+
+      fakeChildProcess.send.mockImplementation((obj: any) => {
+        if (obj.command === 'task:execute') {
+          task.emitter.emit('execution:failed', { execution: { id: 'scheduled-1', reason: 'scheduled', error: new Error('scheduled boom') } });
+          setTimeout(() => {
+            task.emitter.emit('execution:finished', { execution: { id: obj.executionId, reason: 'invoked', result: 'invoked' } });
+          }, 10);
+        } else {
+          task.emitter.emit('task:started');
+        }
+      });
+
+      await task.start();
+      const result = await task.execute();
+      expect(result).toBe('invoked');
     });
   });
 
@@ -871,12 +911,19 @@ describe('BackgroundScheduledTask', function() {
       expect(runs[1].getTime()).toBeGreaterThan(runs[0].getTime());
     });
 
-    it('runsLeft tracks executions reported by the daemon', function(){
+    it('runsLeft tracks scheduled executions reported by the daemon', function(){
       const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', { maxExecutions: 3 });
       expect(task.runsLeft()).toBe(3);
-      task.emitter.emit('execution:started', {} as any);
-      task.emitter.emit('execution:started', {} as any);
+      task.emitter.emit('execution:started', { execution: { reason: 'scheduled' } } as any);
+      task.emitter.emit('execution:started', { execution: { reason: 'scheduled' } } as any);
       expect(task.runsLeft()).toBe(1);
+    });
+
+    it('runsLeft is not affected by a manually invoked execution reported by the daemon', function(){
+      const task = new BackgroundScheduledTask('* * * * * *', './test-assets/dummy-task.js', { maxExecutions: 3 });
+      task.emitter.emit('execution:started', { execution: { reason: 'invoked' } } as any);
+      task.emitter.emit('execution:started', { execution: { reason: 'invoked' } } as any);
+      expect(task.runsLeft()).toBe(3);
     });
 
     it('runsLeft is undefined without maxExecutions', function(){

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -61,7 +61,13 @@ class BackgroundScheduledTask implements ScheduledTask{
     // events so runsLeft() works across the process boundary.
     this.timeMatcher = new TimeMatcher(cronExpression, options?.timezone);
     this.runCount = 0;
-    this.on('execution:started', (context) => { this.runCount++; this.executing = true; this.currentExecution = context?.execution; });
+    // Only scheduled fires count toward maxExecutions; a manual execute() must
+    // not (see runner.ts execute()).
+    this.on('execution:started', (context) => {
+      if (context?.execution?.reason === 'scheduled') this.runCount++;
+      this.executing = true;
+      this.currentExecution = context?.execution;
+    });
     // Mirror the last actual execution from the daemon's events. Both carry the
     // execution's own timestamps, so lastRun reflects the real run time.
     this.on('execution:finished', (context) => { this.executing = false; this.currentExecution = undefined; this.recordLastRun(context.execution); });
@@ -422,12 +428,17 @@ class BackgroundScheduledTask implements ScheduledTask{
     });
   }
 
+  // Correlated by an id echoed through the daemon (task:execute -> its
+  // execution -> the forwarded event), so a scheduled fire in the daemon that
+  // settles while this manual run is still in flight cannot resolve it.
   execute(): Promise<any> {
     return new Promise((resolve, reject) => {
       if (!this.forkProcess) {
         return reject(new Error('Cannot execute background task because it hasn\'t been started yet. Please initialize the task using the start() method before attempting to execute it.'));
       }
-      
+
+      const executionId = createID();
+
       // No timeout by default: wait for the task to actually finish or fail.
       // An optional `executeTimeout` (ms) opts into a guard against a daemon
       // that never reports back.
@@ -444,22 +455,25 @@ class BackgroundScheduledTask implements ScheduledTask{
         this.off('execution:finished', onFinished);
         this.off('execution:failed', onFail);
       };
-      
+
       const onFinished = (context: TaskContext) => {
+        if (context.execution?.id !== executionId) return;
         cleanupListeners();
         resolve(context.execution?.result);
       };
-      
+
       const onFail = (context: TaskContext) => {
+        if (context.execution?.id !== executionId) return;
         cleanupListeners();
         reject(context.execution?.error || new Error('Execution failed without specific error'));
       };
 
-      this.once('execution:finished', onFinished);
-      this.once('execution:failed', onFail);
-      
+      this.on('execution:finished', onFinished);
+      this.on('execution:failed', onFail);
+
       this.forkProcess.send({
-        command: 'task:execute'
+        command: 'task:execute',
+        executionId
       });
     });
   }

--- a/src/tasks/background-scheduled-task/daemon.ts
+++ b/src/tasks/background-scheduled-task/daemon.ts
@@ -1,10 +1,10 @@
 import { fileURLToPath } from "url";
 import logger, { noopLogger } from "../../logger";
 import { InlineScheduledTask } from "../inline-scheduled-task";
-import { ScheduledTask, TaskContext, TaskEvent, TaskOptions } from "../scheduled-task";
+import { TaskContext, TaskEvent, TaskOptions } from "../scheduled-task";
 import { IpcRunCoordinator } from "../../coordinator/ipc-run-coordinator";
 
-export async function startDaemon(message: any): Promise<ScheduledTask> {
+export async function startDaemon(message: any): Promise<InlineScheduledTask> {
     const script = await importTaskModule(message.path);
 
     // The inline task in the daemon stays silent; the parent process logs from
@@ -135,7 +135,7 @@ function safelySerializeContext(context: TaskContext): TaskContext {
 
 
 export function bind(){
-  let task: ScheduledTask;
+  let task: InlineScheduledTask;
 
   process.on('message', async (message: any) => {
     switch(message.command){
@@ -157,7 +157,9 @@ export function bind(){
       return task;
     case 'task:execute':
       try {
-        if (task) await task.execute();
+        // Threads the parent's correlation id through so its execute() can
+        // match the forwarded event to this call, not a concurrent scheduled fire.
+        if (task) await task.execute(message.executionId);
       } catch(error: any){
         logger.debug('Daemon task:execute failed:', error);
       }

--- a/src/tasks/inline-scheduled-task.test.ts
+++ b/src/tasks/inline-scheduled-task.test.ts
@@ -275,6 +275,91 @@ describe('InlineScheduledTask', function() {
     task.stop();
     expect(task.getStatus()).toBe('destroyed');
   });
+
+  it('execute() resolves with the invoked run\'s own result, not a concurrent scheduled run\'s', async function(){
+    const task = new InlineScheduledTask('* * * * * *', async (ctx) => {
+      if (ctx.execution?.reason === 'invoked') {
+        await wait(1500);
+        return 'invoked';
+      }
+      return 'scheduled';
+    });
+
+    task.start();
+    const result = await task.execute();
+    task.destroy();
+
+    expect(result).toBe('invoked');
+  });
+
+  it('execute() ignores a concurrent scheduled run\'s failure while the invoked run is still in flight', async function(){
+    const task = new InlineScheduledTask('* * * * * *', async (ctx) => {
+      if (ctx.execution?.reason === 'invoked') {
+        await wait(1500);
+        return 'invoked';
+      }
+      throw new Error('scheduled boom');
+    });
+    task.on('execution:failed', () => {});
+
+    task.start();
+    const result = await task.execute();
+    task.destroy();
+
+    expect(result).toBe('invoked');
+  });
+
+  it('a throwing execution:finished listener does not reclassify the run as failed', async function(){
+    const task = new InlineScheduledTask('* * * * * *', async () => 'ok');
+    let failedFired = false;
+    task.on('execution:failed', () => { failedFired = true; });
+    task.on('execution:finished', () => { throw new Error('listener boom'); });
+
+    const result = await task.execute();
+
+    expect(result).toBe('ok');
+    expect(failedFired).toBe(false);
+    expect(task.lastRun()?.result).toBe('ok');
+    expect(task.lastRun()?.error).toBeUndefined();
+  });
+
+  it('an async execution:finished listener that rejects does not crash the process', async function(){
+    const captured = makeLogger();
+    const task = new InlineScheduledTask('* * * * * *', async () => 'ok', { logger: captured });
+    task.on('execution:finished', async () => { throw new Error('async listener boom'); });
+
+    const result = await task.execute();
+    await wait(20);
+
+    expect(result).toBe('ok');
+    expect(captured.errors.length).toBeGreaterThan(0);
+  });
+
+  it('manual execute() does not count toward maxExecutions or get blocked by it', async function(){
+    const task = new InlineScheduledTask('* * * * * *', async () => 'ok', { maxExecutions: 2 });
+
+    await task.execute();
+    await task.execute();
+    await task.execute();
+
+    expect(task.runsLeft()).toBe(2);
+    expect(task.getStatus()).not.toBe('destroyed');
+  });
+
+  it('two scheduled fires still stop the task at maxExecutions, and execute() still runs after', async function(){
+    const task = new InlineScheduledTask('* * * * * *', async () => 'ok', { maxExecutions: 2 });
+    const maxReached = new Promise<void>(resolve => task.on('execution:maxReached', () => resolve()));
+
+    task.start();
+    await maxReached;
+
+    expect(task.getStatus()).toBe('destroyed');
+    expect(task.runsLeft()).toBe(0);
+
+    const result = await task.execute();
+    expect(result).toBe('ok');
+    expect(task.runsLeft()).toBe(0);
+  });
 });
 
 function makeLogger(){

--- a/src/tasks/inline-scheduled-task.ts
+++ b/src/tasks/inline-scheduled-task.ts
@@ -10,6 +10,19 @@ import { resolveRunCoordinator, SkipReason } from "../coordinator/run-coordinato
 
 class TaskEmitter extends EventEmitter{}
 
+// Isolates user listeners from the task's own control flow: a listener that
+// throws synchronously or returns a rejecting promise must not affect the
+// execution it was notified about (see InlineScheduledTask event emission).
+function safeEmit(emitter: TaskEmitter, event: TaskEvent, context: TaskContext, onError: (error: Error) => void): void {
+  for (const listener of emitter.listeners(event)) {
+    try {
+      Promise.resolve((listener as (context: TaskContext) => any)(context)).catch(onError);
+    } catch (error: any) {
+      onError(error);
+    }
+  }
+}
+
 export class InlineScheduledTask implements ScheduledTask {
   emitter: TaskEmitter;
   cronExpression: string;
@@ -49,7 +62,7 @@ export class InlineScheduledTask implements ScheduledTask {
         if(execution.reason === 'scheduled'){
           this.changeState('running');
         }
-        this.emitter.emit('execution:started', this.createContext(date, execution));
+        this.emit('execution:started', this.createContext(date, execution));
         return true;
       },
       onFinished: (date: Date, execution: Execution) => {
@@ -57,17 +70,17 @@ export class InlineScheduledTask implements ScheduledTask {
           this.changeState('idle');
         }
         this.recordLastRun(execution);
-        this.emitter.emit('execution:finished', this.createContext(date, execution));
+        this.emit('execution:finished', this.createContext(date, execution));
         return true;
       },
       onError: (date: Date, error: Error, execution: Execution) => {
         this.logger.error(error);
         this.recordLastRun(execution);
-        this.emitter.emit('execution:failed', this.createContext(date, execution));
+        this.emit('execution:failed', this.createContext(date, execution));
         this.changeState('idle');
       },
       onOverlap: (date: Date) => {
-        this.emitter.emit('execution:overlap', this.createContext(date));
+        this.emit('execution:overlap', this.createContext(date));
       },
       onMissedExecution: (date: Date) => {
         // Warn only when the caller is not handling the missed execution
@@ -76,10 +89,10 @@ export class InlineScheduledTask implements ScheduledTask {
         if(!this.suppressMissedWarning && !handled){
           this.logger.warn(`missed execution at ${date}! Possible blocking IO or high CPU user at the same process used by node-cron.`);
         }
-        this.emitter.emit('execution:missed', this.createContext(date));
+        this.emit('execution:missed', this.createContext(date));
       },
       onMaxExecutions: (date: Date) => {
-        this.emitter.emit('execution:maxReached', this.createContext(date));
+        this.emit('execution:maxReached', this.createContext(date));
         this.destroy();
       },
       // Distributed coordination: only wired when this task opted in
@@ -89,7 +102,7 @@ export class InlineScheduledTask implements ScheduledTask {
       coordinatorKeyPrefix: this.name,
       coordinatorTtl: options?.distributedLease,
       onSkipped: (date: Date, reason: SkipReason) => {
-        this.emitter.emit('execution:skipped', this.createContext(date, undefined, reason));
+        this.emit('execution:skipped', this.createContext(date, undefined, reason));
       },
       unref: options?.unref
     }
@@ -157,6 +170,11 @@ export class InlineScheduledTask implements ScheduledTask {
     this._lastRun = lastRun;
   }
 
+  // Isolates user listeners from the task's own control flow (see safeEmit).
+  private emit(event: TaskEvent, context: TaskContext): void {
+    safeEmit(this.emitter, event, context, (error) => this.logger.error(error));
+  }
+
   private changeState(state){
     if(this.runner.isStarted()){
       this.stateMachine.changeState(state);
@@ -170,7 +188,7 @@ export class InlineScheduledTask implements ScheduledTask {
     if(this.runner.isStopped()){
       this.runner.start();
       this.stateMachine.changeState('idle');
-      this.emitter.emit('task:started', this.createContext(new Date()));
+      this.emit('task:started', this.createContext(new Date()));
     } 
   }
   
@@ -178,7 +196,7 @@ export class InlineScheduledTask implements ScheduledTask {
     if(this.runner.isStarted()) { 
       this.runner.stop();
       this.stateMachine.changeState('stopped');
-      this.emitter.emit('task:stopped', this.createContext(new Date()));
+      this.emit('task:stopped', this.createContext(new Date()));
     }
   }
 
@@ -199,25 +217,32 @@ export class InlineScheduledTask implements ScheduledTask {
 
     this.stop();
     this.stateMachine.changeState('destroyed');
-    this.emitter.emit('task:destroyed', this.createContext(new Date()));
+    this.emit('task:destroyed', this.createContext(new Date()));
   }
   
-  execute() {
+  // Correlated by the execution id the runner invokes: a scheduled fire that
+  // settles while this manual run is still in flight must not resolve it.
+  execute(executionId?: string) {
+    const id = executionId ?? createID();
     return new Promise<any>((resolve, reject) => {
       const onFail = (context: TaskContext) => {
+        if (context.execution?.id !== id) return;
         this.off('execution:finished', onFinished);
+        this.off('execution:failed', onFail);
         reject(context.execution?.error)
       };
 
       const onFinished = (context: TaskContext) => {
+        if (context.execution?.id !== id) return;
+        this.off('execution:finished', onFinished);
         this.off('execution:failed', onFail);
         resolve(context.execution?.result)
       }
 
-      this.once('execution:finished', onFinished);
-      this.once('execution:failed', onFail);
+      this.on('execution:finished', onFinished);
+      this.on('execution:failed', onFail);
 
-      this.runner.execute();
+      this.runner.execute(id);
     })
   }
 

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -62,11 +62,14 @@ export type TaskOptions = {
    */
   distributedLease?: number,
   /**
-   * Stop the task after this many executions. Counted per instance: combined
-   * with `distributed` and a per-fire coordinator (e.g. a Redis lock), each
-   * instance counts only the fires it won, so the total across the fleet can
-   * exceed this number. With the default single-runner coordinator it behaves
-   * as expected (only the designated instance runs and counts).
+   * Stop the task after this many scheduled executions. Only scheduled fires
+   * count; manual `execute()` calls never count toward it and are never
+   * blocked by it, even after the task has auto-stopped. Counted per
+   * instance: combined with `distributed` and a per-fire coordinator (e.g. a
+   * Redis lock), each instance counts only the fires it won, so the total
+   * across the fleet can exceed this number. With the default single-runner
+   * coordinator it behaves as expected (only the designated instance runs and
+   * counts).
    */
   maxExecutions?: number,
   maxRandomDelay?: number,
@@ -162,7 +165,7 @@ export interface ScheduledTask {
   msToNext(): number | null;
   /** Whether an execution is currently in progress. */
   isBusy(): boolean;
-  /** Remaining executions when `maxExecutions` is set, otherwise `undefined`. */
+  /** Remaining scheduled executions when `maxExecutions` is set, otherwise `undefined`. Manual `execute()` calls do not affect this. */
   runsLeft(): number | undefined;
   /** The original cron expression. */
   getPattern(): string;


### PR DESCRIPTION
## Summary

Three related bugs in the runner/task execution path:

- **execute() could resolve with the wrong run's result.** It matched on the generic `execution:finished`/`execution:failed` events without checking which execution actually settled, so a scheduled fire completing while a manual `execute()` call was still in flight could resolve the manual call with the scheduled run's result. Both `InlineScheduledTask.execute()` and `BackgroundScheduledTask.execute()` now correlate by the execution id they invoked. For background tasks, the id is generated in the parent, sent through the `task:execute` IPC command, threaded into the daemon's `InlineScheduledTask.execute(id)` call, and echoed back on the forwarded events.

- **A throwing/rejecting user hook could reclassify a successful run as failed.** `onFinished` was called inside the task's own try block, so a synchronously-throwing `execution:finished` listener made the runner treat a successful execution as failed (emitting `execution:failed` after `execution:finished`, and overwriting `lastRun()`). An async listener that rejected became an unhandled rejection. The runner now calls `onFinished` outside the task's try block, in its own try/catch routed to the internal error fallback logger, and the inline task's event emission catches both a throwing and a rejecting listener without affecting the task's own outcome.

- **Manual execute() silently drifted toward maxExecutions.** It incremented `runCount` on every call but never checked `maxExecutions`, so repeated manual calls could push the count past the limit. Per decision: `maxExecutions` (and `runsLeft()`) now only counts scheduled fires. Manual `execute()` never counts toward it and is never blocked by it, even after the task has auto-stopped from `maxExecutions`.

## Test plan
- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test` (741 tests, 100% statements/branches/functions/lines)
- [x] TDD: each new test observed failing for the right reason before the fix (race resolves with the wrong result, hook throw reclassifies success as failure, unhandled rejection from async hook, runCount incrementing/gating on manual execute()), then passing after