### PR TITLE
fix: fix CommonJS type resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,14 @@
   "types": "./dist/node-cron.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/node-cron.d.ts",
-      "import": "./dist/node-cron.js",
-      "require": "./dist/node-cron.cjs"
+      "import": {
+        "types": "./dist/node-cron.d.ts",
+        "default": "./dist/node-cron.js"
+      },
+      "require": {
+        "types": "./dist/node-cron.d.cts",
+        "default": "./dist/node-cron.cjs"
+      }
     }
   },
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -78,11 +78,19 @@ export default [
     external,
     plugins: [cjsReplace(), ...basePlugins()],
   },
-  // Type declarations: one bundled .d.ts for the public entry.
+  // Type declarations: separate ESM and CJS-flavored entry declarations.
   {
     input: "src/node-cron.ts",
     output: {
       file: "dist/node-cron.d.ts",
+      format: "es",
+    },
+    plugins: [dts()],
+  },
+  {
+    input: "src/node-cron.ts",
+    output: {
+      file: "dist/node-cron.d.cts",
       format: "es",
     },
     plugins: [dts()],


### PR DESCRIPTION
The package currently points both ESM and CJS consumers at the same declaration file:

```json
"exports": {
  ".": {
    "types": "./dist/node-cron.d.ts",
    "import": "./dist/node-cron.js",
    "require": "./dist/node-cron.cjs"
  }
}
```

That breaks typed CommonJS consumers using Node16/NodeNext-style resolution. For example, this is a normal way to consume a CommonJS package from a `.cts` file:

```ts
import cron = require("node-cron");

cron.schedule("* * * * *", () => {});
```

With the current package metadata, TypeScript rejects it with:

```text
error TS1471: Module 'node-cron' cannot be imported using this construct.
The specifier only resolves to an ES module, which cannot be imported with 'require'.
Use an ECMAScript import instead.
```

Static imports in a CommonJS TypeScript file fail too:

```ts
import cron from "node-cron";
```

```text
error TS1479: The current file is a CommonJS module whose imports will produce 'require' calls;
however, the referenced file is an ECMAScript module and cannot be imported with 'require'.
Consider writing a dynamic 'import("node-cron")' call instead.
```

The package does have a CommonJS runtime entry (`dist/node-cron.cjs`), so consumers should not need to switch to dynamic `import()` just to satisfy TypeScript. The problem is that TypeScript sees the shared `dist/node-cron.d.ts` file as ESM because this package has `"type": "module"`.

This PR gives the `import` and `require` branches their own type declarations:

```json
"exports": {
  ".": {
    "import": {
      "types": "./dist/node-cron.d.ts",
      "default": "./dist/node-cron.js"
    },
    "require": {
      "types": "./dist/node-cron.d.cts",
      "default": "./dist/node-cron.cjs"
    }
  }
}
```

Rollup now emits `dist/node-cron.d.cts` alongside `dist/node-cron.d.ts`. After that, the `import cron = require("node-cron")` example type-checks correctly.

Previously, `arethetypeswrong` returned:

```text
node10            ok
node16 (from CJS) Masquerading as ESM
node16 (from ESM) ok (ESM)
bundler           ok
```

Now it returns:

```text
No problems found

node10            ok
node16 (from CJS) ok (CJS)
node16 (from ESM) ok (ESM)
bundler           ok
```

Checked with:

```text
npm run build
npm run typecheck
npm test
npm pack --dry-run --json
npx @arethetypeswrong/cli --pack . --format table --no-color
```