### PR TITLE
refactor: remove CommonJS build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@eslint/js": "^9.26.0",
         "@rollup/plugin-commonjs": "^29.0.3",
         "@rollup/plugin-node-resolve": "^16.0.3",
-        "@rollup/plugin-replace": "^6.0.3",
         "@rollup/plugin-typescript": "^12.3.0",
         "@types/expect": "^1.20.4",
         "@types/node": "^22.15.3",
@@ -29,7 +28,7 @@
         "vitest": "^4.1.9"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -766,28 +765,6 @@
       },
       "peerDependencies": {
         "rollup": "^2.78.0||^3.0.0||^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "rollup": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@rollup/plugin-replace": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
-      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
-        "magic-string": "^0.30.3"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {

--- a/package.json
+++ b/package.json
@@ -6,19 +6,14 @@
   "license": "ISC",
   "homepage": "https://nodecron.com",
   "type": "module",
-  "main": "./dist/node-cron.cjs",
+  "main": "./dist/node-cron.js",
   "module": "./dist/node-cron.js",
   "types": "./dist/node-cron.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/node-cron.d.ts",
-        "default": "./dist/node-cron.js"
-      },
-      "require": {
-        "types": "./dist/node-cron.d.cts",
-        "default": "./dist/node-cron.cjs"
-      }
+      "types": "./dist/node-cron.d.ts",
+      "module-sync": "./dist/node-cron.js",
+      "default": "./dist/node-cron.js"
     }
   },
   "scripts": {
@@ -32,7 +27,7 @@
     "prepack": "npm run build"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=20.19.0"
   },
   "files": [
     "dist/"
@@ -71,7 +66,6 @@
     "@eslint/js": "^9.26.0",
     "@rollup/plugin-commonjs": "^29.0.3",
     "@rollup/plugin-node-resolve": "^16.0.3",
-    "@rollup/plugin-replace": "^6.0.3",
     "@rollup/plugin-typescript": "^12.3.0",
     "@types/expect": "^1.20.4",
     "@types/node": "^22.15.3",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,14 @@
   "types": "./dist/node-cron.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/node-cron.d.ts",
-      "import": "./dist/node-cron.js",
-      "require": "./dist/node-cron.cjs"
+      "import": {
+        "types": "./dist/node-cron.d.ts",
+        "default": "./dist/node-cron.js"
+      },
+      "require": {
+        "types": "./dist/node-cron.d.cts",
+        "default": "./dist/node-cron.cjs"
+      }
     }
   },
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -78,11 +78,19 @@ export default [
     external,
     plugins: [cjsReplace(), ...basePlugins()],
   },
-  // Type declarations: one bundled .d.ts for the public entry.
+  // Type declarations: separate ESM and CJS-flavored entry declarations.
   {
     input: "src/node-cron.ts",
     output: {
       file: "dist/node-cron.d.ts",
+      format: "es",
+    },
+    plugins: [dts()],
+  },
+  {
+    input: "src/node-cron.ts",
+    output: {
+      file: "dist/node-cron.d.cts",
       format: "es",
     },
     plugins: [dts()],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,5 @@
 import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
-import replace from "@rollup/plugin-replace";
 import typescript from "@rollup/plugin-typescript";
 import { rmSync } from "fs";
 import { builtinModules } from "module";
@@ -32,20 +31,7 @@ const basePlugins = () => [
   }),
 ];
 
-// In the CJS build, ESM-only meta is rewritten to its CommonJS equivalent, and
-// the forked daemon path is pointed at the .cjs artifact.
-const cjsReplace = () =>
-  replace({
-    preventAssignment: true,
-    delimiters: ["", ""],
-    values: {
-      "fileURLToPath(import.meta.url)": "__filename",
-      "'daemon.js'": "'daemon.cjs'",
-    },
-  });
-
 export default [
-  // ESM build: single bundle per entry
   {
     input: {
       "node-cron": "src/node-cron.ts",
@@ -61,36 +47,10 @@ export default [
     external,
     plugins: [cleanDist(), ...basePlugins()],
   },
-  // CJS build: single bundle per entry
-  {
-    input: {
-      "node-cron": "src/node-cron.ts",
-      daemon: "src/tasks/background-scheduled-task/daemon.ts",
-    },
-    output: {
-      dir: "dist",
-      format: "cjs",
-      entryFileNames: "[name].cjs",
-      chunkFileNames: "_shared.cjs",
-      sourcemap: true,
-      exports: "named",
-    },
-    external,
-    plugins: [cjsReplace(), ...basePlugins()],
-  },
-  // Type declarations: separate ESM and CJS-flavored entry declarations.
   {
     input: "src/node-cron.ts",
     output: {
       file: "dist/node-cron.d.ts",
-      format: "es",
-    },
-    plugins: [dts()],
-  },
-  {
-    input: "src/node-cron.ts",
-    output: {
-      file: "dist/node-cron.d.cts",
       format: "es",
     },
     plugins: [dts()],

--- a/src/node-cron.ts
+++ b/src/node-cron.ts
@@ -21,9 +21,7 @@ import { setRunCoordinator } from "./coordinator/run-coordinator";
 import path from "path";
 import { pathToFileURL, fileURLToPath } from "url";
 
-// fileURLToPath(import.meta.url) works on every ESM-capable Node (unlike
-// import.meta.filename, which requires >= 20.11). The CJS build rewrites it to
-// __filename.
+// fileURLToPath(import.meta.url) works on every ESM-capable Node.
 const moduleFilename = fileURLToPath(import.meta.url);
 
 /**

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -11,9 +11,7 @@ import logger, { Logger } from '../../logger';
 import { TimeMatcher } from '../../time/time-matcher';
 import { RunCoordinator, SkipReason, resolveRunCoordinator } from '../../coordinator/run-coordinator';
 
-// fileURLToPath(import.meta.url) works on every ESM-capable Node (unlike
-// import.meta.dirname, which requires >= 20.11). The CJS build rewrites it to
-// __filename.
+// fileURLToPath(import.meta.url) works on every ESM-capable Node.
 const daemonPath = resolvePath(dirname(fileURLToPath(import.meta.url)), 'daemon.js');
 
 class TaskEmitter extends EventEmitter{}

--- a/src/tasks/background-scheduled-task/daemon.ts
+++ b/src/tasks/background-scheduled-task/daemon.ts
@@ -52,13 +52,9 @@ export async function startDaemon(message: any): Promise<InlineScheduledTask> {
  * (missing file, a runtime that cannot run the file, unsupported TS syntax in
  * strip-only mode, etc.). We must surface the real reason rather than crash.
  *
- * HACK: CJS vs ESM combined with Windows vs Linux path/URL rules:
- *   1. On CJS, require should always receive a path
- *   2. On ESM + Windows, import should always receive a file URL
- *   3. On ESM + Linux, import can receive either a URL or a path
- * We cannot reliably tell at runtime which we are in, so we try the path first
- * and fall back to a file URL. If both fail we throw the FIRST error, which is
- * the meaningful one (the fallback usually fails with an unrelated URL error).
+ * Windows and Linux differ in the path/URL shapes import() accepts, so try the
+ * original specifier first and fall back to a file path. If both fail we throw
+ * the first error, which is usually the meaningful task-loading failure.
  */
 async function importTaskModule(path: string) {
   try {


### PR DESCRIPTION
This is stacked on #608, so the diff currently includes that PR until it lands.

node-cron already requires Node 20+, and v5 is the right time to consider whether keeping a separate CommonJS build is still worth it. Node 20.19.0 enabled `require(esm)` by default, so CommonJS consumers on the supported runtime can load the same ESM entry instead of needing a second build artifact.

This removes the CJS build and points the package at the ESM output only:

```json
"exports": {
  ".": {
    "types": "./dist/node-cron.d.ts",
    "module-sync": "./dist/node-cron.js",
    "default": "./dist/node-cron.js"
  }
}
```

To keep that technically accurate, the Node engine floor moves from `>=20` to `>=20.19.0`, which is the Node 20 release where `require(esm)` stopped requiring `--experimental-require-module`. Reference: https://nodejs.org/en/blog/release/v20.19.0

The package-size impact is meaningful. Measured with `npm pack --dry-run --json` on clean temp copies:

```text
#608 base
package size:   62,816 bytes
unpacked size: 327,517 bytes
entries:       17

this PR
package size:   37,396 bytes
unpacked size: 169,332 bytes
entries:       10
```

That is 25,420 fewer packed bytes (40.5% smaller) and 158,185 fewer unpacked bytes (48.3% smaller).

The deleted output is the duplicated CJS surface: `node-cron.cjs`, `daemon.cjs`, `_shared.cjs`, their sourcemaps, and the CJS-only declaration file from #608. It also removes the Rollup replace plugin that only existed to rewrite ESM-specific paths for the CJS build.

Checked with:

```text
npm run build
npm run typecheck
npm run lint
npm test
npm pack --dry-run --json
npx @arethetypeswrong/cli --pack . --profile esm-only --format table --no-color
```

I also smoke-tested the packed package with both import styles on a Node runtime where `process.features.require_module === true`:

```js
import cron, { schedule } from "node-cron";

const cron = require("node-cron");
```

And typed CommonJS consumption in TypeScript `nodenext` mode:

```ts
import cron = require("node-cron");

cron.schedule("* * * * *", () => {});
```