### PR TITLE
feat: add isExecuting() to observe manual execute() runs

### DIFF
--- a/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.test.ts
@@ -408,6 +408,17 @@ describe('BackgroundScheduledTask', function() {
       expect(task.lastRun()?.error?.message).toMatch(/daemon exited unexpectedly/);
     });
 
+    it('isExecuting() tracks the in-flight run reported by the daemon', async function(){
+      const task = await startedTask();
+      expect(task.isExecuting()).toBe(false);
+
+      task.emitter.emit('execution:started', { execution: { id: 'e1', reason: 'invoked', startedAt: new Date() } } as any);
+      expect(task.isExecuting()).toBe(true);
+
+      task.emitter.emit('execution:finished', { execution: { id: 'e1', reason: 'invoked', finishedAt: new Date() } } as any);
+      expect(task.isExecuting()).toBe(false);
+    });
+
     it('start() re-forks successfully after a spontaneous death', async function(){
       const task = await startedTask();
 

--- a/src/tasks/background-scheduled-task/background-scheduled-task.ts
+++ b/src/tasks/background-scheduled-task/background-scheduled-task.ts
@@ -127,6 +127,10 @@ class BackgroundScheduledTask implements ScheduledTask{
     return this.getStatus() === 'running';
   }
 
+  isExecuting(): boolean {
+    return this.executing;
+  }
+
   runsLeft(): number | undefined {
     if (this.options?.maxExecutions == null) return undefined;
     return Math.max(0, this.options.maxExecutions - this.runCount);

--- a/src/tasks/inline-scheduled-task.ts
+++ b/src/tasks/inline-scheduled-task.ts
@@ -37,6 +37,10 @@ export class InlineScheduledTask implements ScheduledTask {
   // The last actual execution. Recorded when a run really finishes or fails,
   // keyed off the execution's own timestamps rather than the tick that armed it.
   private _lastRun: LastRun | null = null;
+  // Number of runs currently in flight, scheduled or invoked. Backs
+  // isExecuting(); kept separate from the lifecycle state so a manual
+  // execute() is observable without altering getStatus()/isBusy().
+  private _runsInFlight = 0;
 
   constructor(cronExpression: string, taskFn: TaskFn, options?: TaskOptions){
     this.emitter = new TaskEmitter();
@@ -59,14 +63,22 @@ export class InlineScheduledTask implements ScheduledTask {
       missedExecutionTolerance: options?.missedExecutionTolerance,
       logger: this.logger,
       beforeRun: (date: Date, execution: Execution) => {
-        if(execution.reason === 'scheduled'){
+        // Track every run (scheduled or invoked) so isExecuting() can report
+        // whether work is in flight. The lifecycle state, by contrast, still
+        // flips only for scheduled runs: a manual execute() deliberately stays
+        // outside the state machine (it can run on a stopped task, does not
+        // count toward maxExecutions, etc). changeState is a no-op until the
+        // task is started.
+        this._runsInFlight++;
+        if (execution.reason === 'scheduled') {
           this.changeState('running');
         }
         this.emit('execution:started', this.createContext(date, execution));
         return true;
       },
       onFinished: (date: Date, execution: Execution) => {
-        if(execution.reason === 'scheduled'){
+        this._runsInFlight--;
+        if (execution.reason === 'scheduled') {
           this.changeState('idle');
         }
         this.recordLastRun(execution);
@@ -74,10 +86,13 @@ export class InlineScheduledTask implements ScheduledTask {
         return true;
       },
       onError: (date: Date, error: Error, execution: Execution) => {
+        this._runsInFlight--;
         this.logger.error(error);
         this.recordLastRun(execution);
         this.emit('execution:failed', this.createContext(date, execution));
-        this.changeState('idle');
+        if (execution.reason === 'scheduled') {
+          this.changeState('idle');
+        }
       },
       onOverlap: (date: Date) => {
         this.emit('execution:overlap', this.createContext(date));
@@ -140,6 +155,10 @@ export class InlineScheduledTask implements ScheduledTask {
 
   isBusy(): boolean {
     return this.getStatus() === 'running';
+  }
+
+  isExecuting(): boolean {
+    return this._runsInFlight > 0;
   }
 
   runsLeft(): number | undefined {

--- a/src/tasks/introspection.test.ts
+++ b/src/tasks/introspection.test.ts
@@ -72,6 +72,65 @@ describe('task introspection', function () {
       release();
       task.stop();
     });
+
+    it('stays false for a manually invoked run (execute() is outside the lifecycle)', async function () {
+      // execute() runs with reason 'invoked' and deliberately stays outside the
+      // state machine, so it must NOT flip getStatus()/isBusy(). isExecuting()
+      // is the separate signal that does reflect it (see below).
+      let release!: () => void;
+      const gate = new Promise<void>((r) => { release = r; });
+      const task = new InlineScheduledTask('0 0 12 * * *', async () => { await gate; });
+      const started = new Promise<void>((r) => task.on('execution:started', () => r()));
+
+      task.start();
+      task.execute();
+      await started;
+      expect(task.isBusy()).toBe(false);
+      expect(task.getStatus()).toBe('idle');
+
+      release();
+      task.stop();
+    });
+  });
+
+  describe('isExecuting', function () {
+    it('is true while a manually invoked run is in progress, without touching lifecycle state', async function () {
+      // Gate the handler, fire execute() without awaiting, wait for the run to
+      // start, then assert isExecuting() sees it while isBusy()/getStatus() do
+      // not: the manual run is tracked separately from the lifecycle state.
+      let release!: () => void;
+      const gate = new Promise<void>((r) => { release = r; });
+      const task = new InlineScheduledTask('0 0 12 * * *', async () => { await gate; });
+      const started = new Promise<void>((r) => task.on('execution:started', () => r()));
+
+      task.start();
+      task.execute();
+      await started;
+      expect(task.isExecuting()).toBe(true);
+      expect(task.isBusy()).toBe(false);
+      expect(task.getStatus()).toBe('idle');
+
+      const finished = new Promise<void>((r) => task.on('execution:finished', () => r()));
+      release();
+      await finished;
+      expect(task.isExecuting()).toBe(false);
+      task.stop();
+    });
+
+    it('is true during a scheduled run too', async function () {
+      let release!: () => void;
+      const gate = new Promise<void>((r) => { release = r; });
+      const task = new InlineScheduledTask('* * * * * *', async () => { await gate; });
+      const started = new Promise<void>((r) => task.on('execution:started', () => r()));
+
+      task.start();
+      await started;
+      expect(task.isExecuting()).toBe(true);
+      expect(task.isBusy()).toBe(true);
+
+      release();
+      task.stop();
+    });
   });
 
   describe('runsLeft', function () {

--- a/src/tasks/scheduled-task.ts
+++ b/src/tasks/scheduled-task.ts
@@ -165,6 +165,13 @@ export interface ScheduledTask {
   msToNext(): number | null;
   /** Whether an execution is currently in progress. */
   isBusy(): boolean;
+  /**
+   * Whether any run is currently in progress, including a manual `execute()`.
+   * Unlike `isBusy()` (which reflects the scheduled lifecycle state), this also
+   * reports invoked runs, so it can be polled for "is anything running right
+   * now" (e.g. graceful shutdown that waits for in-flight work).
+   */
+  isExecuting(): boolean;
   /** Remaining scheduled executions when `maxExecutions` is set, otherwise `undefined`. Manual `execute()` calls do not affect this. */
   runsLeft(): number | undefined;
   /** The original cron expression. */


### PR DESCRIPTION
## Problem

`getStatus()` / `isBusy()` only reflect the scheduled lifecycle, so a run started via `execute()` (reason `'invoked'`) is invisible: mid-run `getStatus()` reports `idle` and `isBusy()` returns `false`. There's no way to poll "is any run in progress right now", which the use case in #611 needs (graceful shutdown that waits for in-flight work; not overlapping a manual run with a scheduled one).

## Approach

Following the discussion in #611: `execute()` deliberately runs outside the state machine (it can run on a stopped task, never counts toward `maxExecutions`, etc.), so this **does not touch** `getStatus()` / `isBusy()`. Instead it adds a separate signal, as suggested:

- **`isExecuting(): boolean`** — true while *any* run is actually in flight, scheduled or invoked.

The inline task tracks a small in-flight counter (incremented for every run, so overlapping runs are handled); the background task already keeps an internal `executing` flag synced over IPC, so it just exposes it. The lifecycle state is untouched: it still flips only for scheduled runs.

## Tests

- Inline: a gated manual `execute()` shows `isExecuting() === true` while `isBusy() === false` / `getStatus() === 'idle'` (pins the separation), and clears on finish. A scheduled run also reads `isExecuting() === true`.
- Background: `isExecuting()` tracks the `execution:started` / `execution:finished` the daemon forwards.

Full suite green (757 tests), 100% coverage on the touched files.

Closes #611